### PR TITLE
Add short title to config.yaml

### DIFF
--- a/everything-presence-mmwave-configurator/config.yaml
+++ b/everything-presence-mmwave-configurator/config.yaml
@@ -11,6 +11,7 @@ arch:
   - i386
 startup: services
 boot: auto
+panel_title: EP Zones
 ingress: true
 ingress_port: 8099
 ingress_entry: index.html


### PR DESCRIPTION
Uses "EP Zones" as an placeholder.

See: 

![jjj-2024-11-08-at-19-30-20-UTC@2x](https://github.com/user-attachments/assets/cc849000-ae48-4685-9795-95c8525741af)

See #11.