### PR TITLE
Display sensor name selected by user

### DIFF
--- a/everything-presence-mmwave-configurator/www/script.js
+++ b/everything-presence-mmwave-configurator/www/script.js
@@ -770,7 +770,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 {% set manufacturer = device_attr(device, 'manufacturer') %}
                 {% if manufacturer == 'EverythingSmartTechnology' %}
                     {% if model == 'Everything_Presence_Lite' or model == 'Everything Presence Lite' %}
-                        {% set devices.list = devices.list + [{'id': device, 'name': device_attr(device, 'name')}] %}
+                        {% set devices.list = devices.list + [{'id': device, 'name': device_attr(device, 'name_by_user')}] %}
                     {% endif %}
                 {% endif %}
             {% endfor %}

--- a/everything-presence-mmwave-configurator/www/script.js
+++ b/everything-presence-mmwave-configurator/www/script.js
@@ -770,7 +770,8 @@ document.addEventListener("DOMContentLoaded", () => {
                 {% set manufacturer = device_attr(device, 'manufacturer') %}
                 {% if manufacturer == 'EverythingSmartTechnology' %}
                     {% if model == 'Everything_Presence_Lite' or model == 'Everything Presence Lite' %}
-                        {% set devices.list = devices.list + [{'id': device, 'name': device_attr(device, 'name_by_user')}] %}
+                        {% set device_name = device_attr(device, 'name_by_user') or device_attr(device, 'name') %}
+                        {% set devices.list = devices.list + [{'id': device, 'name': device_name}] %}
                     {% endif %}
                 {% endif %}
             {% endfor %}


### PR DESCRIPTION
Closes #47 

This PR switches from the name attribute to the name_by_user attribute which should result in showing the sensor names the users have set in Home Assistant instead of something like "Everything Presence Lite 2fbc58"