### PR TITLE
Implement zone edit mode, fix zones being longer than max supported size, fix zones saving, fix exclusion zones not being deletable, fix zones being deleted if outside max width

### DIFF
--- a/everything-presence-mmwave-configurator/www/index.html
+++ b/everything-presence-mmwave-configurator/www/index.html
@@ -215,12 +215,15 @@
       </div>
 
       <div id="save-controls">
+      <div id="editing-status" style="margin-bottom: 10px; padding: 8px; border-radius: 4px; font-weight: 500; display: none;">
+        <span id="editing-status-text"></span>
+      </div>
       <div id="save-control-group">
+        <button id="editZonesButton">Edit Zones</button>
+        <button id="saveZonesButton" disabled>Save Zones</button>
+        <button id="resetZonesButton" disabled>Reset Changes</button>
         <button id="importZonesButton">Import Zones</button>
-        <button id="exportZonesButton" style="margin-left: 10px;">Export Zones</button>
-        <button id="saveZonesButton" style="margin-left: 10px;">Save Zones</button>
-        <button id="haUserZonesButton" style="margin-left: 10px;">HA -> User Zones</button>
-        <button id="resetZonesButton" style="margin-left: 10px;">Reset User Zones</button>
+        <button id="exportZonesButton">Export Zones</button>
       </div>
       </div>
 

--- a/everything-presence-mmwave-configurator/www/styles.css
+++ b/everything-presence-mmwave-configurator/www/styles.css
@@ -356,6 +356,13 @@ button:disabled {
   min-width: 140px;
 }
 
+#save-control-group {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
 /* ==============================================
    COMPONENT-SPECIFIC STYLES
    ============================================== */
@@ -470,6 +477,18 @@ button:disabled {
   box-shadow: var(--shadow-md);
 }
 
+.zone-tile.edit-disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.zone-tile.edit-disabled:hover {
+  background-color: var(--gray-50);
+  border-color: var(--border-light);
+  transform: none;
+  box-shadow: none;
+}
+
 .zone-tile-header {
   display: flex;
   align-items: center;
@@ -514,6 +533,32 @@ button:disabled {
 .zone-color-indicator.exclusion-zone { 
   background: linear-gradient(to bottom, #f87171, #ef4444); 
   opacity: 1; /* Show when colored */
+}
+
+/* Editing Status Indicator */
+#editing-status {
+  background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+  color: white;
+  text-align: center;
+  box-shadow: var(--shadow-sm);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+}
+
+#editing-status.has-changes {
+  background: linear-gradient(135deg, #f59e0b, #d97706);
+  border-color: rgba(245, 158, 11, 0.3);
+}
+
+@media (prefers-color-scheme: dark) {
+  #editing-status {
+    background: linear-gradient(135deg, #1e40af, #1e3a8a);
+    border-color: rgba(30, 64, 175, 0.3);
+  }
+  
+  #editing-status.has-changes {
+    background: linear-gradient(135deg, #d97706, #b45309);
+    border-color: rgba(217, 119, 6, 0.3);
+  }
 }
 
 .zone-title {


### PR DESCRIPTION
This adds a big new feature that should make adding and editing zones much more intuitive - edit mode. 

Previously you could draw 2 zones and save them. Then when you came back into add a 3rd zones, you'd draw 1 more zone to make 3, but then you'd save it and the original ones would be removed. This is due to the way that pressing save would overwrite all zones if they weren't drawn again each time. Further, there was no way to edit previously drawn zones.

This feature adds an "Edit Zones" button which does exactly that, allows you to edit, resize, move and delete zones that were drawn previously. Also let's you add another zone to an existing set of zones.

Also fixes an issue where if zones were drawn outside of the max supported dimensions, it would either delete them completely or put them in the complete wrong position.

Also makes exclusion zones deletable now same as regular zones.