### PR TITLE
Improve displaying of units of measurement

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/domain/deviceEntityService.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/deviceEntityService.ts
@@ -373,6 +373,8 @@ class DeviceEntityServiceImpl {
           if (!groups[group]) {
             groups[group] = [];
           }
+          // Use entityUnits from device mapping if available, otherwise fall back to profile unit
+          const unit = mapping.entityUnits?.[key] || def.unit;
           groups[group].push({
             key,
             entityId: mapping.mappings[key],
@@ -381,7 +383,7 @@ class DeviceEntityServiceImpl {
             min: def.min,
             max: def.max,
             step: def.step,
-            unit: def.unit,
+            unit,
             options: def.options,
             description: def.description,
           });

--- a/everything-presence-mmwave-configurator/frontend/src/components/EP1Dashboard.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/EP1Dashboard.tsx
@@ -16,9 +16,10 @@ interface EP1DashboardProps {
   roomId: string;
   room: RoomConfig;
   liveState: LiveState | null;
+  entityUnits?: Record<string, string>;
 }
 
-export const EP1Dashboard: React.FC<EP1DashboardProps> = ({ roomId, room, liveState }) => {
+export const EP1Dashboard: React.FC<EP1DashboardProps> = ({ roomId, room, liveState, entityUnits }) => {
   if (!liveState) {
     return (
       <div className="min-h-screen bg-slate-950 flex items-center justify-center">
@@ -58,7 +59,7 @@ export const EP1Dashboard: React.FC<EP1DashboardProps> = ({ roomId, room, liveSt
           {/* Main Content - Left Column (spans 2) */}
           <div className="lg:col-span-2 space-y-6">
             {/* Environmental Sensors (with CO2 and Light Context) */}
-            <EP1EnvironmentalPanel environmental={environmental} co2={liveState.co2} />
+            <EP1EnvironmentalPanel environmental={environmental} co2={liveState.co2} entityUnits={entityUnits} />
 
             {/* Canvas with Distance Arc */}
             <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
@@ -168,6 +169,7 @@ export const EP1Dashboard: React.FC<EP1DashboardProps> = ({ roomId, room, liveSt
             <EP1ComfortPanel
               temperature={liveState.temperature ?? null}
               humidity={liveState.humidity ?? null}
+              entityUnits={entityUnits}
             />
 
             {/* Sensor Comparison */}

--- a/everything-presence-mmwave-configurator/frontend/src/components/EP1EnvironmentalPanel.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/EP1EnvironmentalPanel.tsx
@@ -5,15 +5,21 @@ import { getLightLevel } from './ep1/ep1Utils';
 interface EP1EnvironmentalPanelProps {
   environmental: EP1EnvironmentalData;
   co2?: number | null;
+  entityUnits?: Record<string, string>;
 }
 
-export const EP1EnvironmentalPanel: React.FC<EP1EnvironmentalPanelProps> = ({ environmental, co2 }) => {
+export const EP1EnvironmentalPanel: React.FC<EP1EnvironmentalPanelProps> = ({ environmental, co2, entityUnits }) => {
   const { temperature, humidity, illuminance } = environmental;
 
-  // Format values with fallback for null
-  const tempDisplay = temperature !== null ? `${temperature.toFixed(1)}°C` : '--';
-  const humidityDisplay = humidity !== null ? `${humidity.toFixed(1)}%` : '--';
-  const illuminanceDisplay = illuminance !== null ? `${Math.round(illuminance)} lx` : '--';
+  // Format values with fallback for null, using entityUnits for correct unit display
+  const tempUnit = entityUnits?.temperature || '°C';
+  const humidityUnit = entityUnits?.humidity || '%';
+  const illuminanceUnit = entityUnits?.illuminance || 'lx';
+  const co2Unit = entityUnits?.co2 || 'ppm';
+
+  const tempDisplay = temperature !== null ? `${temperature.toFixed(1)}${tempUnit}` : '--';
+  const humidityDisplay = humidity !== null ? `${humidity.toFixed(1)}${humidityUnit}` : '--';
+  const illuminanceDisplay = illuminance !== null ? `${Math.round(illuminance)} ${illuminanceUnit}` : '--';
 
   // Get light level context
   const lightLevel = illuminance !== null ? getLightLevel(illuminance) : null;
@@ -64,7 +70,7 @@ export const EP1EnvironmentalPanel: React.FC<EP1EnvironmentalPanelProps> = ({ en
             <div className="text-2xl">🌬️</div>
             <div className="text-xs font-semibold text-emerald-200/70 uppercase tracking-wide">CO2</div>
           </div>
-          <div className="text-3xl font-bold text-emerald-100">{Math.round(co2!)} <span className="text-lg">ppm</span></div>
+          <div className="text-3xl font-bold text-emerald-100">{Math.round(co2!)} <span className="text-lg">{co2Unit}</span></div>
         </div>
       )}
     </div>

--- a/everything-presence-mmwave-configurator/frontend/src/components/ep1/EP1CO2Panel.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/ep1/EP1CO2Panel.tsx
@@ -3,14 +3,16 @@ import { getCO2Level } from './ep1Utils';
 
 interface EP1CO2PanelProps {
   co2: number | null;
+  entityUnits?: Record<string, string>;
 }
 
-export const EP1CO2Panel: React.FC<EP1CO2PanelProps> = ({ co2 }) => {
+export const EP1CO2Panel: React.FC<EP1CO2PanelProps> = ({ co2, entityUnits }) => {
   if (co2 === null) {
     return null; // Don't render if CO2 sensor not available
   }
 
   const level = getCO2Level(co2);
+  const co2Unit = entityUnits?.co2 || 'ppm';
 
   // Calculate gauge percentage (0-3000 ppm range)
   const gaugePercent = Math.min(100, (co2 / 3000) * 100);
@@ -25,7 +27,7 @@ export const EP1CO2Panel: React.FC<EP1CO2PanelProps> = ({ co2 }) => {
       {/* Value and Label */}
       <div className="flex items-baseline gap-2 mb-3">
         <span className="text-3xl font-bold text-slate-100">{Math.round(co2)}</span>
-        <span className="text-sm text-slate-400">ppm</span>
+        <span className="text-sm text-slate-400">{co2Unit}</span>
       </div>
 
       {/* Gauge Bar */}
@@ -43,9 +45,9 @@ export const EP1CO2Panel: React.FC<EP1CO2PanelProps> = ({ co2 }) => {
           style={{ width: `${gaugePercent}%` }}
         />
         {/* Threshold markers */}
-        <div className="absolute top-0 h-full w-px bg-slate-600" style={{ left: '26.7%' }} title="800 ppm" />
-        <div className="absolute top-0 h-full w-px bg-slate-600" style={{ left: '33.3%' }} title="1000 ppm" />
-        <div className="absolute top-0 h-full w-px bg-slate-600" style={{ left: '66.7%' }} title="2000 ppm" />
+        <div className="absolute top-0 h-full w-px bg-slate-600" style={{ left: '26.7%' }} title={`800 ${co2Unit}`} />
+        <div className="absolute top-0 h-full w-px bg-slate-600" style={{ left: '33.3%' }} title={`1000 ${co2Unit}`} />
+        <div className="absolute top-0 h-full w-px bg-slate-600" style={{ left: '66.7%' }} title={`2000 ${co2Unit}`} />
       </div>
 
       {/* Status Label */}

--- a/everything-presence-mmwave-configurator/frontend/src/components/ep1/EP1ComfortPanel.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/ep1/EP1ComfortPanel.tsx
@@ -4,9 +4,11 @@ import { calculateDewPoint, calculateHeatIndex, getComfortLevel } from './ep1Uti
 interface EP1ComfortPanelProps {
   temperature: number | null;
   humidity: number | null;
+  entityUnits?: Record<string, string>;
 }
 
-export const EP1ComfortPanel: React.FC<EP1ComfortPanelProps> = ({ temperature, humidity }) => {
+export const EP1ComfortPanel: React.FC<EP1ComfortPanelProps> = ({ temperature, humidity, entityUnits }) => {
+  const tempUnit = entityUnits?.temperature || '°C';
   if (temperature === null || humidity === null) {
     return (
       <div className="rounded-xl border border-slate-700/50 bg-slate-800/30 p-4">
@@ -35,14 +37,14 @@ export const EP1ComfortPanel: React.FC<EP1ComfortPanelProps> = ({ temperature, h
         {/* Dew Point */}
         <div className="bg-slate-800/40 rounded-lg p-2">
           <div className="text-xs text-slate-500 mb-0.5">Dew Point</div>
-          <div className="text-slate-200 font-medium">{dewPoint}°C</div>
+          <div className="text-slate-200 font-medium">{dewPoint}{tempUnit}</div>
         </div>
 
         {/* Feels Like (Heat Index) */}
         <div className="bg-slate-800/40 rounded-lg p-2">
           <div className="text-xs text-slate-500 mb-0.5">Feels Like</div>
           <div className="text-slate-200 font-medium">
-            {heatIndex !== null ? `${heatIndex}°C` : `${temperature}°C`}
+            {heatIndex !== null ? `${heatIndex}${tempUnit}` : `${temperature}${tempUnit}`}
           </div>
         </div>
       </div>
@@ -55,11 +57,11 @@ export const EP1ComfortPanel: React.FC<EP1ComfortPanelProps> = ({ temperature, h
         <div className="relative h-3 bg-slate-700/50 rounded-full overflow-hidden">
           {/* Gradient background showing zones */}
           <div className="absolute inset-0 flex">
-            <div className="flex-1 bg-cyan-500/40" title="Cold (<18°C)" />
-            <div className="flex-1 bg-blue-500/40" title="Cool (18-20°C)" />
-            <div className="flex-1 bg-emerald-500/40" title="Optimal (20-24°C)" />
-            <div className="flex-1 bg-amber-500/40" title="Warm (24-26°C)" />
-            <div className="flex-1 bg-red-500/40" title="Hot (>26°C)" />
+            <div className="flex-1 bg-cyan-500/40" title={tempUnit === '°F' ? 'Cold (<64°F)' : 'Cold (<18°C)'} />
+            <div className="flex-1 bg-blue-500/40" title={tempUnit === '°F' ? 'Cool (64-68°F)' : 'Cool (18-20°C)'} />
+            <div className="flex-1 bg-emerald-500/40" title={tempUnit === '°F' ? 'Optimal (68-75°F)' : 'Optimal (20-24°C)'} />
+            <div className="flex-1 bg-amber-500/40" title={tempUnit === '°F' ? 'Warm (75-79°F)' : 'Warm (24-26°C)'} />
+            <div className="flex-1 bg-red-500/40" title={tempUnit === '°F' ? 'Hot (>79°F)' : 'Hot (>26°C)'} />
           </div>
           {/* Current position marker */}
           <div
@@ -70,8 +72,8 @@ export const EP1ComfortPanel: React.FC<EP1ComfortPanelProps> = ({ temperature, h
           />
         </div>
         <div className="flex justify-between text-[10px] text-slate-500 mt-1">
-          <span>14°C</span>
-          <span>30°C</span>
+          <span>{tempUnit === '°F' ? '57°F' : '14°C'}</span>
+          <span>{tempUnit === '°F' ? '86°F' : '30°C'}</span>
         </div>
       </div>
 

--- a/everything-presence-mmwave-configurator/frontend/src/components/ep1/EP1MiniCharts.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/ep1/EP1MiniCharts.tsx
@@ -10,6 +10,7 @@ interface EP1MiniChartsProps {
   presence: boolean;
   distance: number | null;
   maxPoints?: number;
+  entityUnits?: Record<string, string>;
 }
 
 // Simple sparkline SVG component
@@ -96,8 +97,10 @@ export const EP1MiniCharts: React.FC<EP1MiniChartsProps> = ({
   presence,
   distance,
   maxPoints = 60,
+  entityUnits,
 }) => {
   const [collapsed, setCollapsed] = React.useState(false);
+  const tempUnit = entityUnits?.temperature || '°C';
 
   // Store history in refs to persist across renders
   const tempHistory = useRef<DataPoint[]>([]);
@@ -174,7 +177,7 @@ export const EP1MiniCharts: React.FC<EP1MiniChartsProps> = ({
               <span className="text-xs text-slate-400">Temperature</span>
             </div>
             <div className="text-[10px] text-slate-500">
-              {tempMin}° - {tempMax}°C
+              {tempMin}° - {tempMax}{tempUnit}
             </div>
           </div>
           <div className="bg-slate-800/50 rounded-lg p-2">

--- a/everything-presence-mmwave-configurator/frontend/src/components/ep1/EP1StatsPanel.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/ep1/EP1StatsPanel.tsx
@@ -5,14 +5,17 @@ interface EP1StatsPanelProps {
   deviceId: string;
   presence: boolean;
   temperature: number | null;
+  entityUnits?: Record<string, string>;
 }
 
 export const EP1StatsPanel: React.FC<EP1StatsPanelProps> = ({
   deviceId,
   presence,
   temperature,
+  entityUnits,
 }) => {
   const [collapsed, setCollapsed] = useState(false);
+  const tempUnit = entityUnits?.temperature || '°C';
   const [stats, setStats] = useState<DailyStats | null>(null);
   const lastUpdateTime = useRef<number>(Date.now());
   const wasPresent = useRef<boolean>(presence);
@@ -190,11 +193,11 @@ export const EP1StatsPanel: React.FC<EP1StatsPanelProps> = ({
           <div className="text-[10px] text-slate-500 mb-1">Avg Temperature</div>
           <div className="flex items-baseline gap-1">
             <span className="text-2xl font-bold text-orange-400">{avgTemp}</span>
-            <span className="text-sm text-slate-500">°C</span>
+            <span className="text-sm text-slate-500">{tempUnit}</span>
           </div>
           <div className="text-[10px] text-slate-500 mt-2">
             {stats.tempMin !== null && stats.tempMax !== null
-              ? `${stats.tempMin.toFixed(1)}° - ${stats.tempMax.toFixed(1)}°`
+              ? `${stats.tempMin.toFixed(1)}° - ${stats.tempMax.toFixed(1)}${tempUnit}`
               : 'Min - Max'}
           </div>
         </div>

--- a/everything-presence-mmwave-configurator/frontend/src/pages/LiveTrackingPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/LiveTrackingPage.tsx
@@ -1166,14 +1166,14 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
                 {liveState.illuminance !== null && liveState.illuminance !== undefined && (
                   <div className="flex justify-between py-1 border-b border-slate-700/50">
                     <span className="text-slate-400">Light:</span>
-                    <span className="text-slate-200">{liveState.illuminance.toFixed(1)} lx</span>
+                    <span className="text-slate-200">{liveState.illuminance.toFixed(1)} {deviceMapping?.entityUnits?.illuminance || 'lx'}</span>
                   </div>
                 )}
 
                 {liveState.temperature !== null && liveState.temperature !== undefined && (
                   <div className="flex justify-between py-1 border-b border-slate-700/50">
                     <span className="text-slate-400">Temperature:</span>
-                    <span className="text-slate-200">{liveState.temperature.toFixed(1)}°C</span>
+                    <span className="text-slate-200">{liveState.temperature.toFixed(1)}{deviceMapping?.entityUnits?.temperature || '°C'}</span>
                   </div>
                 )}
 
@@ -1187,7 +1187,7 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
                       liveState.co2 < 2000 ? 'text-orange-400' :
                       'text-rose-400'
                     }>
-                      {Math.round(liveState.co2)} ppm
+                      {Math.round(liveState.co2)} {deviceMapping?.entityUnits?.co2 || 'ppm'}
                     </span>
                   </div>
                 )}
@@ -1461,7 +1461,7 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
                       'text-rose-400'
                     }`}>
                       {Math.round(liveState.co2)}
-                      <span className="text-base font-normal text-slate-400 ml-1">ppm</span>
+                      <span className="text-base font-normal text-slate-400 ml-1">{deviceMapping?.entityUnits?.co2 || 'ppm'}</span>
                     </div>
                     <div className={`text-xs font-medium mt-1 ${
                       liveState.co2 < 800 ? 'text-emerald-300' :
@@ -1526,6 +1526,7 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
                 temperature={liveState.temperature ?? null}
                 presence={liveState.presence ?? false}
                 distance={liveState.distance ?? null}
+                entityUnits={deviceMapping?.entityUnits}
               />
             )}
 
@@ -1544,6 +1545,7 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
                 deviceId={selectedRoom.deviceId || selectedRoomId || 'unknown'}
                 presence={liveState.presence ?? false}
                 temperature={liveState.temperature ?? null}
+                entityUnits={deviceMapping?.entityUnits}
               />
             )}
 


### PR DESCRIPTION
Improve units of  measurement displaying throughout the UI. Store unit of measurement in device profile during discovery or  re-sync of entities  then use that to display in the  UI.