### PR TITLE
Fix issue with re-appearing re-sync entities message constantly

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/config/deviceMappingStorage.ts
+++ b/everything-presence-mmwave-configurator/backend/src/config/deviceMappingStorage.ts
@@ -35,6 +35,8 @@ export interface DeviceMapping {
   esphomeVersion?: string;
   /** Raw sw_version string from Home Assistant (e.g., "1.4.1 (ESPHome 2025.11.2)") */
   rawSwVersion?: string;
+  /** Schema version from device profile at time of last sync (e.g., "1.0") */
+  profileSchemaVersion?: string;
 }
 
 /**

--- a/everything-presence-mmwave-configurator/backend/src/domain/deviceProfiles.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/deviceProfiles.ts
@@ -79,6 +79,8 @@ export interface EntityDefinition {
 
 export interface DeviceProfile {
   id: string;
+  /** Schema version - bump when entities/features change to trigger resync prompts */
+  schemaVersion?: string;
   label: string;
   manufacturer: string;
   capabilities: unknown;

--- a/everything-presence-mmwave-configurator/backend/src/domain/entityDiscovery.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/entityDiscovery.ts
@@ -896,6 +896,10 @@ export class EntityDiscoveryService {
     // Run discovery
     const discovery = await this.discoverEntities(deviceId, profileId);
 
+    // Get profile schema version for resync detection
+    const profile = this.profileLoader.getProfileById(profileId);
+    const profileSchemaVersion = profile?.schemaVersion;
+
     // Convert suggestedMappings (nested EntityMappings) to flat format
     const flatMappings = normalizeMappingKeys(this.convertToFlatMappings(discovery.suggestedMappings));
 
@@ -938,6 +942,7 @@ export class EntityDiscoveryService {
       firmwareVersion,
       esphomeVersion,
       rawSwVersion,
+      profileSchemaVersion,
     };
 
     // Save to device storage

--- a/everything-presence-mmwave-configurator/backend/src/server.ts
+++ b/everything-presence-mmwave-configurator/backend/src/server.ts
@@ -51,7 +51,7 @@ export const createServer = (config: AppConfig, deps?: ServerDependencies): expr
   app.use('/api/zones', createZonesRouter());
   app.use('/api/settings', createSettingsRouter());
   app.use('/api/custom-assets', createCustomAssetsRouter());
-  app.use('/api/device-mappings', createDeviceMappingsRouter({ readTransport: deps?.readTransport }));
+  app.use('/api/device-mappings', createDeviceMappingsRouter({ readTransport: deps?.readTransport, profileLoader: deps?.profileLoader }));
 
   // Routes that require HA dependencies
   if (deps) {

--- a/everything-presence-mmwave-configurator/config/device-profiles/everything_presence_lite.json
+++ b/everything-presence-mmwave-configurator/config/device-profiles/everything_presence_lite.json
@@ -1,5 +1,6 @@
 {
   "id": "everything_presence_lite",
+  "schemaVersion": "1.0",
   "label": "Everything Presence Lite",
   "model": "Everything Presence Lite",
   "manufacturer": "EverythingSmartTechnology",

--- a/everything-presence-mmwave-configurator/config/device-profiles/everything_presence_one.json
+++ b/everything-presence-mmwave-configurator/config/device-profiles/everything_presence_one.json
@@ -1,5 +1,6 @@
 {
   "id": "everything_presence_one",
+  "schemaVersion": "1.0",
   "label": "Everything Presence One",
   "model": "Everything Presence One",
   "manufacturer": "EverythingSmartTechnology",

--- a/everything-presence-mmwave-configurator/frontend/src/api/deviceMappings.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/api/deviceMappings.ts
@@ -61,6 +61,8 @@ export interface DeviceMapping {
   esphomeVersion?: string;
   /** Raw sw_version string from Home Assistant (e.g., "1.4.1 (ESPHome 2025.11.2)") */
   rawSwVersion?: string;
+  /** Schema version from device profile at time of last sync (e.g., "1.0") */
+  profileSchemaVersion?: string;
 }
 
 /**
@@ -301,13 +303,11 @@ export const getMigrationPreview = async (): Promise<MigrationResponse | null> =
 };
 
 /**
- * Check if a device has valid mappings.
+ * Check if a device has mappings stored.
+ * Note: Callers should compare profileSchemaVersion with profile.schemaVersion
+ * to determine if resync is needed.
  */
 export const hasValidMappings = async (deviceId: string): Promise<boolean> => {
   const mapping = await getDeviceMapping(deviceId);
-  if (!mapping) {
-    return false;
-  }
-  // Must have at least the presence entity
-  return !!(mapping.mappings.presence || mapping.mappings.presenceEntity);
+  return mapping !== null;
 };

--- a/everything-presence-mmwave-configurator/frontend/src/api/types.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/api/types.ts
@@ -58,6 +58,8 @@ export interface EntityDefinition {
 
 export interface DeviceProfile {
   id: string;
+  /** Schema version - bump when entities/features change to trigger resync prompts */
+  schemaVersion?: string;
   label: string;
   manufacturer: string;
   capabilities: unknown;

--- a/everything-presence-mmwave-configurator/frontend/src/pages/SettingsPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/SettingsPage.tsx
@@ -10,6 +10,7 @@ import {
 } from '../api/client';
 import { RoomConfig, CustomFloorMaterial, CustomFurnitureType, EntityMappings } from '../api/types';
 import { EntityDiscovery } from '../components/EntityDiscovery';
+import { useDeviceMappings } from '../contexts/DeviceMappingsContext';
 
 interface SettingsPageProps {
   onBack?: () => void;
@@ -24,6 +25,9 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onBack, onRoomDelete
   const [deletingRoomId, setDeletingRoomId] = useState<string | null>(null);
   const [syncingRoom, setSyncingRoom] = useState<RoomConfig | null>(null);
   const [isSyncing, setIsSyncing] = useState(false);
+
+  // Device mappings context - used to refresh cache after resync
+  const { refreshMapping } = useDeviceMappings();
 
   // Custom assets state
   const [customFloors, setCustomFloors] = useState<CustomFloorMaterial[]>([]);
@@ -104,6 +108,12 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onBack, onRoomDelete
       setRooms((prev) =>
         prev.map((r) => (r.id === syncingRoom.id ? { ...r, entityMappings: mappings } : r))
       );
+
+      // Refresh device mapping cache so other pages see the new mappings
+      if (syncingRoom.deviceId) {
+        await refreshMapping(syncingRoom.deviceId);
+      }
+
       setSuccess(`Entity mappings updated for "${syncingRoom.name}"`);
       setTimeout(() => setSuccess(null), 3000);
     } catch (err) {


### PR DESCRIPTION
Add a schema version to device profile so that anytime a change is that requires a user to resync, we can bump the schema version and compare to that. This should resolve the issue where the "resync entities" message would keep re-appearing even when just done