### PR TITLE
Fix issue where no devices would show up to be added

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/domain/deviceDiscovery.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/deviceDiscovery.ts
@@ -11,6 +11,19 @@ export interface DiscoveredDevice {
   areaName?: string; // Home Assistant area name (e.g., "Living Room")
 }
 
+const normalizeManufacturer = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  if (Array.isArray(value)) {
+    return value.map(item => String(item ?? '')).join(', ').trim();
+  }
+  if (value == null) {
+    return '';
+  }
+  return String(value).trim();
+};
+
 export class DeviceDiscoveryService {
   private readonly readTransport: IHaReadTransport;
   private readonly manufacturerFilters = [
@@ -173,13 +186,13 @@ export class DeviceDiscoveryService {
       .map((d: any) => ({
         id: d.id as string,
         name: (d.name_by_user as string) || (d.name as string) || 'Unnamed device',
-        manufacturer: (d.manufacturer as string | undefined)?.trim(),
+        manufacturer: normalizeManufacturer(d.manufacturer) || undefined,
         model: d.model as string | undefined,
         firmwareVersion: d.sw_version as string | undefined,
         areaId: d.area_id as string | undefined,
       }))
       .filter((d) => {
-        const manufacturer = (d.manufacturer ?? '').toLowerCase();
+        const manufacturer = normalizeManufacturer(d.manufacturer).toLowerCase();
         return this.manufacturerFilters.some(filter => manufacturer === filter.toLowerCase());
       });
 


### PR DESCRIPTION
Fix issue where no devices would show up to be added, if the Home Assistant install had devices that had a null manufacturer in it.

Fixes https://github.com/EverythingSmartHome/everything-presence-addons/issues/113 and https://github.com/EverythingSmartHome/everything-presence-addons/issues/186