### PR TITLE
Improve re-connecting of WS

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/ha/wsReadTransport.ts
+++ b/everything-presence-mmwave-configurator/backend/src/ha/wsReadTransport.ts
@@ -118,6 +118,9 @@ export class WsReadTransport implements IHaReadTransport {
           this._isConnected = true;
           this.setReady();
           resolve();
+          if (this.subscriptions.size > 0) {
+            void this.activateStateSubscription();
+          }
           return;
         }
 


### PR DESCRIPTION
Re-subscribes to HA state change events after websocket reconnect so live tracking recovers automatically instead of freezing