### PR TITLE
Fix room import to use proper API client (fixes #209)

### DIFF
--- a/everything-presence-mmwave-configurator/frontend/src/pages/SettingsPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { fetchRooms, deleteRoom, updateRoom } from '../api/rooms';
+import { fetchRooms, deleteRoom, updateRoom, createRoom } from '../api/rooms';
 import { fetchSettings, updateSettings } from '../api/client';
 import {
   fetchCustomFloors,
@@ -298,14 +298,8 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onBack, onRoomDelete
 
           // Add the imported room via API
           importPromises.push(
-            fetch('/api/rooms', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify(newRoom),
-            }).then((response) => {
-              if (!response.ok) {
-                throw new Error(`Failed to import room: ${newRoom.name}`);
-              }
+            createRoom(newRoom).then(() => {}).catch(() => {
+              throw new Error(`Failed to import room: ${newRoom.name}`);
             })
           );
         }


### PR DESCRIPTION
## Description
Fixes the room import functionality that was failing with a 404 error when trying to import backup files.

## Problem
The room import feature was using a hardcoded `/api/rooms` path instead of the proper API client, causing issues when the application is accessed through different ingress paths (e.g., behind a reverse proxy or in Home Assistant ingress).

## Changes
- Added `createRoom` import from the rooms API module
- Replaced hardcoded `fetch('/api/rooms', ...)` with `createRoom(newRoom)` 
- This ensures the API path is properly handled through the `ingressAware()` helper function

## Testing
Confirmed the export from main addon is being imported in a container-hosted version: 

<img width="891" height="378" alt="image" src="https://github.com/user-attachments/assets/875e204c-7065-4a03-bb5e-f3fee667314f" />


Closes #209