### PR TITLE
Bug: Fix issue where when in zone editor, you can't change rooms

### DIFF
--- a/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
@@ -246,7 +246,8 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
       }
     };
     load();
-  }, [initialProfileId, initialRoomId, selectedProfileId, selectedRoomId]);
+    // Note: selectedRoomId and selectedProfileId intentionally excluded - this is initialization only.
+  }, [initialProfileId, initialRoomId]);
 
   useEffect(() => {
     // Only run when room ID actually changes (not on every render)


### PR DESCRIPTION
Fix an issue where when you navigate to zone editor, then try to change rooms, the selected room would briefly show before being reverted.

Fixes: https://github.com/EverythingSmartHome/everything-presence-addons/issues/206