### PR TITLE
Feature: Add display option for enabling or disabling target tracking dots

### DIFF
--- a/everything-presence-mmwave-configurator/frontend/src/hooks/useDisplaySettings.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/hooks/useDisplaySettings.ts
@@ -7,6 +7,7 @@ export interface DisplaySettings {
   showZones: boolean;
   showDeviceIcon: boolean;
   showDeviceRadar: boolean;
+  showTargets: boolean;
   showAlignedDirection: boolean;
   clipRadarToWalls: boolean;
   // Heatmap settings
@@ -24,6 +25,7 @@ const defaultSettings: DisplaySettings = {
   showZones: true,
   showDeviceIcon: true,
   showDeviceRadar: false,
+  showTargets: true,
   showAlignedDirection: false,
   clipRadarToWalls: true,
   // Heatmap defaults
@@ -87,6 +89,10 @@ export const useDisplaySettings = () => {
     setSettings((prev) => ({ ...prev, showDeviceRadar: value }));
   }, []);
 
+  const setShowTargets = useCallback((value: boolean) => {
+    setSettings((prev) => ({ ...prev, showTargets: value }));
+  }, []);
+
   const setShowAlignedDirection = useCallback((value: boolean) => {
     setSettings((prev) => ({ ...prev, showAlignedDirection: value }));
   }, []);
@@ -115,6 +121,7 @@ export const useDisplaySettings = () => {
     showZones: settings.showZones,
     showDeviceIcon: settings.showDeviceIcon,
     showDeviceRadar: settings.showDeviceRadar,
+    showTargets: settings.showTargets,
     showAlignedDirection: settings.showAlignedDirection,
     clipRadarToWalls: settings.clipRadarToWalls,
     heatmapEnabled: settings.heatmapEnabled,
@@ -127,6 +134,7 @@ export const useDisplaySettings = () => {
     setShowZones,
     setShowDeviceIcon,
     setShowDeviceRadar,
+    setShowTargets,
     setShowAlignedDirection,
     setClipRadarToWalls,
     setHeatmapEnabled,

--- a/everything-presence-mmwave-configurator/frontend/src/pages/LiveTrackingPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/LiveTrackingPage.tsx
@@ -98,6 +98,7 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
     showZones, setShowZones,
     showDeviceIcon, setShowDeviceIcon,
     showDeviceRadar, setShowDeviceRadar,
+    showTargets, setShowTargets,
     showAlignedDirection, setShowAlignedDirection,
     clipRadarToWalls, setClipRadarToWalls,
     heatmapEnabled, setHeatmapEnabled,
@@ -927,7 +928,7 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
               ) : null;
 
               // Render live target positions (EP Lite with tracking)
-              const targetElements = displayTargetPositions.length > 0 ? (
+              const targetElements = showTargets && displayTargetPositions.length > 0 ? (
                 <g>
                   {/* Render trails first (so they appear behind targets) */}
                   {showTrails && displayTargetPositions.map((target) => {
@@ -1924,6 +1925,18 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
                         <span className="flex items-center gap-1.5">
                           <span className="w-3 h-3 rounded-full bg-green-500"></span>
                           Device Icon
+                        </span>
+                      </label>
+                      <label className="flex items-center gap-2 cursor-pointer text-sm text-slate-200 hover:text-white transition-colors">
+                        <input
+                          type="checkbox"
+                          checked={showTargets}
+                          onChange={(e) => setShowTargets(e.target.checked)}
+                          className="w-4 h-4 rounded border-slate-600 bg-slate-800 text-cyan-500 focus:ring-cyan-500 focus:ring-offset-0"
+                        />
+                        <span className="flex items-center gap-1.5">
+                          <span className="w-3 h-3 rounded-full bg-cyan-500"></span>
+                          Targets
                         </span>
                       </label>
                     </div>

--- a/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
@@ -80,6 +80,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
     showDoors, setShowDoors,
     showZones, setShowZones,
     showDeviceIcon, setShowDeviceIcon,
+    showTargets, setShowTargets,
     clipRadarToWalls,
   } = useDisplaySettings();
   const liveState = propLiveState;
@@ -1115,7 +1116,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
               ];
 
               // Render live target positions
-              if (targetPositions.length > 0) {
+              if (showTargets && targetPositions.length > 0) {
                 return (
                   <g>
                     {targetPositions.map((target) => {
@@ -1338,6 +1339,18 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
                     <span className="flex items-center gap-1.5">
                       <span className="w-3 h-3 rounded-full bg-green-500"></span>
                       Device Icon
+                    </span>
+                  </label>
+                  <label className="flex items-center gap-2 cursor-pointer text-sm text-slate-200 hover:text-white transition-colors">
+                    <input
+                      type="checkbox"
+                      checked={showTargets}
+                      onChange={(e) => setShowTargets(e.target.checked)}
+                      className="w-4 h-4 rounded border-slate-600 bg-slate-800 text-cyan-500 focus:ring-cyan-500 focus:ring-offset-0"
+                    />
+                    <span className="flex items-center gap-1.5">
+                      <span className="w-3 h-3 rounded-full bg-cyan-500"></span>
+                      Targets
                     </span>
                   </label>
                 </div>


### PR DESCRIPTION
Adds a feature to be able to toggle displaying target tracking dots on or off in the display options on live dashboard and zone editor

Helps as a workaround for: https://github.com/EverythingSmartHome/everything-presence-addons/issues/204