### PR TITLE
Bug: Fix EP Pro installation angle not working

### DIFF
--- a/everything-presence-mmwave-configurator/frontend/src/App.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/App.tsx
@@ -281,7 +281,12 @@ function App() {
                   if (!updated.config) updated.config = {} as any;
                   setAvailability('thresholdFactor');
                   updated.config.thresholdFactor = parseIntValue();
-                } else if (message.entityId.includes('installation_angle')) {
+                } else if (
+                  // Check against the mapped entity ID first (from room entityMappings)
+                  (selectedRoom.entityMappings?.installationAngleEntity && message.entityId === selectedRoom.entityMappings.installationAngleEntity) ||
+                  // Fallback to pattern matching for legacy rooms without explicit mapping
+                  (!selectedRoom.entityMappings?.installationAngleEntity && (message.entityId.includes('installation_angle') || message.entityId.includes('tracking_sensor_angle')))
+                ) {
                   if (!updated.config) updated.config = {} as any;
                   setAvailability('installationAngle');
                   updated.config.installationAngle = parseNumberValue();

--- a/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
@@ -11,6 +11,7 @@ import { FLOOR_MATERIALS } from '../components/FloorMaterials';
 import { useDisplaySettings } from '../hooks/useDisplaySettings';
 import { getEffectiveEntityPrefix } from '../utils/entityUtils';
 import { getInstallationAngleSuggestion } from '../utils/rotationSuggestion';
+import { useDeviceMappings } from '../contexts/DeviceMappingsContext';
 
 interface RoomBuilderPageProps {
   onBack?: () => void;
@@ -130,16 +131,28 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     return Boolean(caps?.tracking) && !caps?.distanceOnlyTracking;
   }, [selectedProfile]);
 
+  // Device mappings context for entity resolution
+  const { getEntityId } = useDeviceMappings();
+
   const resolveInstallationAngleEntityId = useCallback(() => {
     if (!selectedRoom) return null;
+
+    // First try device mappings (new system - supports EPP and EPL)
+    if (selectedRoom.deviceId) {
+      const entityFromMapping = getEntityId(selectedRoom.deviceId, 'installationAngle');
+      if (entityFromMapping) return entityFromMapping;
+    }
+
+    // Fall back to legacy room-level mapping
     const mappingEntity = selectedRoom.entityMappings?.installationAngleEntity;
     if (mappingEntity) return mappingEntity;
 
+    // Last resort: hardcoded pattern (EPL only)
     const devicePrefix = selectedRoom.entityNamePrefix ?? selectedDevice?.entityNamePrefix;
     const prefix = getEffectiveEntityPrefix(selectedRoom.entityMappings, devicePrefix);
     if (!prefix) return null;
     return `number.${prefix}_installation_angle`;
-  }, [selectedRoom, selectedDevice]);
+  }, [selectedRoom, selectedDevice, getEntityId]);
 
   const handleRotationSuggestion = useCallback(
     (rotationDeg: number) => {


### PR DESCRIPTION
Fix an issue where changing the installation angle in room builder settings, would change the UI, but would not set it in the Home Assistant entity. This would cause a mismatch.