### PR TITLE
Improve using entiity mappings over hardcoded entity names

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/domain/entityDiscovery.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/entityDiscovery.ts
@@ -828,7 +828,7 @@ export class EntityDiscoveryService {
       'humidityEntity', 'illuminanceEntity', 'co2Entity', 'distanceEntity',
       'speedEntity', 'energyEntity', 'targetCountEntity', 'modeEntity',
       'maxDistanceEntity', 'installationAngleEntity', 'polygonZonesEnabledEntity',
-      'trackingTargetCountEntity',
+      'trackingTargetCountEntity', 'assumedPresentEntity', 'assumedPresentRemainingEntity',
     ];
 
     for (const key of flatKeys) {
@@ -1040,6 +1040,10 @@ export class EntityDiscoveryService {
     if (em.installationAngleEntity) mappings['installationAngle'] = em.installationAngleEntity;
     if (em.polygonZonesEnabledEntity) mappings['polygonZonesEnabled'] = em.polygonZonesEnabledEntity;
     if (em.trackingTargetCountEntity) mappings['trackingTargetCount'] = em.trackingTargetCountEntity;
+
+    // Entry/Exit feature entities
+    if (em.assumedPresentEntity) mappings['assumedPresent'] = em.assumedPresentEntity;
+    if (em.assumedPresentRemainingEntity) mappings['assumedPresentRemaining'] = em.assumedPresentRemainingEntity;
 
     // Zone config entities (rectangular)
     this.flattenZoneEntitiesToFlat(mappings, em.zoneConfigEntities, 'zone');

--- a/everything-presence-mmwave-configurator/backend/src/domain/types.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/types.ts
@@ -182,6 +182,10 @@ export interface EntityMappings {
     target3?: TargetEntitySet;
   };
 
+  // Entry/Exit feature entities (EPL)
+  assumedPresentEntity?: string;
+  assumedPresentRemainingEntity?: string;
+
   // Settings entities (device configuration controls)
   settingsEntities?: Record<string, string>;
 

--- a/everything-presence-mmwave-configurator/config/device-profiles/everything_presence_lite.json
+++ b/everything-presence-mmwave-configurator/config/device-profiles/everything_presence_lite.json
@@ -138,6 +138,20 @@
       "unit": "s",
       "required": false
     },
+    "assumedPresent": {
+      "template": "binary_sensor.${name}_assumed_present",
+      "category": "sensor",
+      "subcategory": "entryExit",
+      "label": "Assumed Present",
+      "required": false
+    },
+    "assumedPresentRemaining": {
+      "template": "sensor.${name}_assumed_present_remaining",
+      "category": "sensor",
+      "subcategory": "entryExit",
+      "label": "Assumed Present Remaining",
+      "required": false
+    },
     "staleTargetReset": {
       "template": "switch.${name}_stale_target_reset",
       "category": "setting",

--- a/everything-presence-mmwave-configurator/frontend/src/api/types.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/api/types.ts
@@ -236,6 +236,10 @@ export interface EntityMappings {
     target3?: TargetEntitySet;
   };
 
+  // Entry/Exit feature entities (EPL)
+  assumedPresentEntity?: string;
+  assumedPresentRemainingEntity?: string;
+
   // Settings entities (device configuration controls)
   settingsEntities?: Record<string, string>;
 

--- a/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
@@ -9,7 +9,6 @@ import { FurnitureEditor } from '../components/FurnitureEditor';
 import { DoorEditor } from '../components/DoorEditor';
 import { FLOOR_MATERIALS } from '../components/FloorMaterials';
 import { useDisplaySettings } from '../hooks/useDisplaySettings';
-import { getEffectiveEntityPrefix } from '../utils/entityUtils';
 import { getInstallationAngleSuggestion } from '../utils/rotationSuggestion';
 import { useDeviceMappings } from '../contexts/DeviceMappingsContext';
 
@@ -147,12 +146,9 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     const mappingEntity = selectedRoom.entityMappings?.installationAngleEntity;
     if (mappingEntity) return mappingEntity;
 
-    // Last resort: hardcoded pattern (EPL only)
-    const devicePrefix = selectedRoom.entityNamePrefix ?? selectedDevice?.entityNamePrefix;
-    const prefix = getEffectiveEntityPrefix(selectedRoom.entityMappings, devicePrefix);
-    if (!prefix) return null;
-    return `number.${prefix}_installation_angle`;
-  }, [selectedRoom, selectedDevice, getEntityId]);
+    // No mapping found - return null (user should run entity discovery)
+    return null;
+  }, [selectedRoom, getEntityId]);
 
   const handleRotationSuggestion = useCallback(
     (rotationDeg: number) => {

--- a/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
@@ -13,7 +13,6 @@ import { useWallDrawing } from '../hooks/useWallDrawing';
 import { pushZonesToDevice, fetchZonesFromDevice, fetchPolygonModeStatus, setPolygonMode, fetchPolygonZonesFromDevice, pushPolygonZonesToDevice, PolygonModeStatus } from '../api/zones';
 import { fetchZoneAvailability, ingressAware } from '../api/client';
 import { useDeviceMappings } from '../contexts/DeviceMappingsContext';
-import { getEffectiveEntityPrefix } from '../utils/entityUtils';
 import { getInstallationAngleSuggestion } from '../utils/rotationSuggestion';
 import { useDisplaySettings } from '../hooks/useDisplaySettings';
 
@@ -213,12 +212,9 @@ export const WizardPage: React.FC<WizardPageProps> = ({
     const mappingEntity = selectedRoom.entityMappings?.installationAngleEntity;
     if (mappingEntity) return mappingEntity;
 
-    // Last resort: hardcoded pattern (EPL only)
-    const devicePrefix = selectedRoom.entityNamePrefix ?? selectedDevice?.entityNamePrefix;
-    const prefix = getEffectiveEntityPrefix(selectedRoom.entityMappings, devicePrefix);
-    if (!prefix) return null;
-    return `number.${prefix}_installation_angle`;
-  }, [selectedRoom, selectedDevice, getEntityId]);
+    // No mapping found - return null (user should run entity discovery)
+    return null;
+  }, [selectedRoom, getEntityId]);
 
   const handleRotationSuggestion = useCallback(
     (rotationDeg: number) => {


### PR DESCRIPTION
Improve using device profiles and entity mappings rather than hardcoded entity names. This makes it rely on the entity map captured during setup or by going to settings > re-sync entites over older hardcoded entity names which is not good if users have renamed them.