### PR TITLE
Feature: Add firmware update option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,21 @@ services:
     restart: unless-stopped
     ports:
       - "3000:3000"
+      - "38080:38080"
     environment:
       HA_BASE_URL: "http://homeassistant.local:8123"
       HA_LONG_LIVED_TOKEN: "REPLACE_WITH_LONG_LIVED_TOKEN"
+      FIRMWARE_LAN_PORT: "38080"
     volumes:
       - ./config:/config
 ```
+
+### LAN Firmware Port
+
+Firmware updates are served over a local HTTP port for ESP devices. By default this uses port `38080`.
+
+- Home Assistant add-on: configure `firmware_lan_port` in the add-on Configuration tab.
+- Standalone Docker: set `FIRMWARE_LAN_PORT` and map the same host port.
 
 ### Documentation
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,8 +5,10 @@ services:
     restart: unless-stopped
     ports:
       - "3000:3000"
+      - "38080:38080"
     environment:
       HA_BASE_URL: "http://homeassistant.local:8123"
       HA_LONG_LIVED_TOKEN: "REPLACE_WITH_LONG_LIVED_TOKEN"
+      FIRMWARE_LAN_PORT: "38080"
     volumes:
       - ./config:/config

--- a/everything-presence-mmwave-configurator/Dockerfile
+++ b/everything-presence-mmwave-configurator/Dockerfile
@@ -20,6 +20,7 @@ FROM ${BUILD_FROM} AS addon
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV NODE_ENV=production \
     PORT=3000 \
+    FIRMWARE_LAN_PORT=38080 \
     FRONTEND_DIST=/app/frontend/dist
 WORKDIR /app
 
@@ -37,12 +38,13 @@ COPY rootfs/ /
 RUN rm -rf /etc/services.d/zone-configurator && \
     chmod +x /etc/s6-overlay/s6-rc.d/zone-configurator/run
 
-EXPOSE 3000/tcp
+EXPOSE 3000/tcp 38080/tcp
 
 FROM node:20-alpine AS standalone
 WORKDIR /app
 ENV NODE_ENV=production \
     PORT=3000 \
+    FIRMWARE_LAN_PORT=38080 \
     FRONTEND_DIST=/app/frontend/dist
 
 COPY --from=build /app/package.json /app/package-lock.json ./
@@ -53,7 +55,7 @@ COPY --from=build /app/backend/dist ./backend/dist
 COPY --from=build /app/frontend/dist ./frontend/dist
 COPY config ./config
 
-EXPOSE 3000/tcp
+EXPOSE 3000/tcp 38080/tcp
 CMD ["node", "backend/dist/index.js"]
 
 # Default build target for Home Assistant add-on builds.

--- a/everything-presence-mmwave-configurator/backend/src/config.ts
+++ b/everything-presence-mmwave-configurator/backend/src/config.ts
@@ -12,14 +12,26 @@ export interface HaConfig {
   supervisorApiUrl?: string;
 }
 
+export interface FirmwareConfig {
+  lanPort: number;
+  lanIpOverride?: string;
+  cacheDir: string;
+  maxVersionsPerDevice: number;
+}
+
 export interface AppConfig {
   port: number;
   ha: HaConfig;
   frontendDist: string | null;
+  firmware: FirmwareConfig;
 }
 
 const DEFAULT_PORT = 3000;
+const DEFAULT_FIRMWARE_LAN_PORT = 38080;
+const DEFAULT_MAX_VERSIONS_PER_DEVICE = 3;
 const DEFAULT_FRONTEND_DIST = path.resolve(__dirname, '../../frontend/dist');
+const DEFAULT_DATA_DIR = '/config/everything-presence-zone-configurator';
+const DEFAULT_FIRMWARE_CACHE_DIR = path.join(process.env.DATA_DIR ?? DEFAULT_DATA_DIR, 'fw_cache');
 
 const trimTrailingSlash = (value: string): string => value.replace(/\/+$/, '');
 
@@ -76,6 +88,15 @@ const detectHaConfig = (): HaConfig => {
   );
 };
 
+const loadFirmwareConfig = (): FirmwareConfig => {
+  return {
+    lanPort: parsePort(process.env.FIRMWARE_LAN_PORT) || DEFAULT_FIRMWARE_LAN_PORT,
+    lanIpOverride: process.env.FIRMWARE_LAN_IP || undefined,
+    cacheDir: process.env.FIRMWARE_CACHE_DIR ?? DEFAULT_FIRMWARE_CACHE_DIR,
+    maxVersionsPerDevice: Number(process.env.FIRMWARE_MAX_VERSIONS) || DEFAULT_MAX_VERSIONS_PER_DEVICE,
+  };
+};
+
 export const loadConfig = (): AppConfig => {
   const ha = detectHaConfig();
 
@@ -85,6 +106,7 @@ export const loadConfig = (): AppConfig => {
     frontendDist: process.env.FRONTEND_DIST
       ? path.resolve(process.env.FRONTEND_DIST)
       : DEFAULT_FRONTEND_DIST,
+    firmware: loadFirmwareConfig(),
   };
 };
 

--- a/everything-presence-mmwave-configurator/backend/src/config/firmwareStorage.ts
+++ b/everything-presence-mmwave-configurator/backend/src/config/firmwareStorage.ts
@@ -1,0 +1,269 @@
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import { logger } from '../logger';
+
+// Use the same base directory as other storage, with a fw_cache subdirectory
+const DATA_DIR = process.env.DATA_DIR ?? '/config/everything-presence-zone-configurator';
+const FIRMWARE_CACHE_DIR = process.env.FIRMWARE_CACHE_DIR ?? path.join(DATA_DIR, 'fw_cache');
+const CACHE_INDEX_FILE = path.join(FIRMWARE_CACHE_DIR, 'cache-index.json');
+const SETTINGS_FILE = path.join(FIRMWARE_CACHE_DIR, 'firmware-settings.json');
+
+export interface CachedFirmwareEntry {
+  deviceId: string;
+  token: string;
+  version: string;
+  manifestPath: string;
+  binaryPaths: string[];
+  originalManifestUrl: string;
+  cachedAt: number;
+}
+
+export interface FirmwareCacheIndex {
+  entries: CachedFirmwareEntry[];
+}
+
+export interface FirmwareSettings {
+  lanIpOverride?: string;
+  firmwareBaseUrl?: string;
+  firmwareIndexUrls?: string[];
+  cacheKeepCount?: number;
+}
+
+const ensureCacheDir = (subDir?: string): string => {
+  const dir = subDir ? path.join(FIRMWARE_CACHE_DIR, subDir) : FIRMWARE_CACHE_DIR;
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  return dir;
+};
+
+const readCacheIndex = (): FirmwareCacheIndex => {
+  ensureCacheDir();
+  if (!fs.existsSync(CACHE_INDEX_FILE)) {
+    return { entries: [] };
+  }
+  try {
+    const raw = fs.readFileSync(CACHE_INDEX_FILE, 'utf-8');
+    const parsed = JSON.parse(raw);
+    return {
+      entries: Array.isArray(parsed?.entries) ? parsed.entries : [],
+    };
+  } catch (error) {
+    logger.warn({ error }, 'Failed to read firmware cache index; returning empty');
+    return { entries: [] };
+  }
+};
+
+const writeCacheIndex = (index: FirmwareCacheIndex): void => {
+  ensureCacheDir();
+  fs.writeFileSync(CACHE_INDEX_FILE, JSON.stringify(index, null, 2));
+};
+
+const readSettings = (): FirmwareSettings => {
+  ensureCacheDir();
+  if (!fs.existsSync(SETTINGS_FILE)) {
+    return {};
+  }
+  try {
+    const raw = fs.readFileSync(SETTINGS_FILE, 'utf-8');
+    return JSON.parse(raw) as FirmwareSettings;
+  } catch (error) {
+    logger.warn({ error }, 'Failed to read firmware settings; returning empty');
+    return {};
+  }
+};
+
+const writeSettings = (settings: FirmwareSettings): void => {
+  ensureCacheDir();
+  fs.writeFileSync(SETTINGS_FILE, JSON.stringify(settings, null, 2));
+};
+
+/**
+ * Recursively delete a directory and its contents
+ */
+const deleteDirectory = (dirPath: string): void => {
+  if (fs.existsSync(dirPath)) {
+    fs.rmSync(dirPath, { recursive: true, force: true });
+  }
+};
+
+export const firmwareStorage = {
+  /**
+   * Generate a unique token for URL security
+   */
+  generateToken: (): string => crypto.randomBytes(16).toString('hex'),
+
+  /**
+   * Get the cache directory path for a device/token combination
+   */
+  getCacheDir: (deviceId: string, token: string): string => {
+    return path.join(FIRMWARE_CACHE_DIR, deviceId, token);
+  },
+
+  /**
+   * Ensure the cache directory exists for a device/token
+   */
+  ensureDeviceCacheDir: (deviceId: string, token: string): string => {
+    const dir = path.join(FIRMWARE_CACHE_DIR, deviceId, token);
+    ensureCacheDir(path.join(deviceId, token));
+    return dir;
+  },
+
+  /**
+   * Save a cache entry to the index
+   */
+  saveCacheEntry: (entry: CachedFirmwareEntry): void => {
+    const index = readCacheIndex();
+    const duplicateEntries = index.entries.filter(
+      (e) => e.deviceId === entry.deviceId && e.version === entry.version && e.token !== entry.token
+    );
+    const tokensToDelete = new Set(duplicateEntries.map((e) => e.token));
+
+    for (const duplicate of duplicateEntries) {
+      const cacheDir = path.join(FIRMWARE_CACHE_DIR, duplicate.deviceId, duplicate.token);
+      try {
+        deleteDirectory(cacheDir);
+        logger.info(
+          { deviceId: duplicate.deviceId, token: duplicate.token, version: duplicate.version },
+          'Deleted duplicate firmware cache entry'
+        );
+      } catch (error) {
+        logger.warn({ error, cacheDir }, 'Failed to delete duplicate firmware cache directory');
+      }
+    }
+
+    // Remove any existing entry with same device/token or duplicate version
+    index.entries = index.entries.filter(
+      (e) =>
+        !(e.deviceId === entry.deviceId && e.token === entry.token) &&
+        !(e.deviceId === entry.deviceId && tokensToDelete.has(e.token))
+    );
+    index.entries.push(entry);
+    writeCacheIndex(index);
+  },
+
+  /**
+   * Get a cache entry by device ID and token
+   */
+  getCacheEntry: (deviceId: string, token: string): CachedFirmwareEntry | null => {
+    const index = readCacheIndex();
+    return index.entries.find((e) => e.deviceId === deviceId && e.token === token) ?? null;
+  },
+
+  /**
+   * Get all cache entries for a device
+   */
+  getDeviceEntries: (deviceId: string): CachedFirmwareEntry[] => {
+    const index = readCacheIndex();
+    return index.entries
+      .filter((e) => e.deviceId === deviceId)
+      .sort((a, b) => b.cachedAt - a.cachedAt); // Most recent first
+  },
+
+  /**
+   * Get all cache entries
+   */
+  getAllEntries: (): CachedFirmwareEntry[] => {
+    const index = readCacheIndex();
+    return index.entries.sort((a, b) => b.cachedAt - a.cachedAt);
+  },
+
+  /**
+   * Clean up old versions for a device, keeping only the most recent N versions
+   */
+  cleanupOldVersions: (deviceId: string, keepCount: number = 3): void => {
+    const index = readCacheIndex();
+    const effectiveKeepCount = Number.isFinite(keepCount) && keepCount > 0 ? Math.floor(keepCount) : 1;
+    const deviceEntries = index.entries
+      .filter((e) => e.deviceId === deviceId)
+      .sort((a, b) => b.cachedAt - a.cachedAt); // Most recent first
+
+    const entriesToDelete: CachedFirmwareEntry[] = [];
+    const uniqueEntries: CachedFirmwareEntry[] = [];
+    const seenVersions = new Set<string>();
+
+    for (const entry of deviceEntries) {
+      if (seenVersions.has(entry.version)) {
+        entriesToDelete.push(entry);
+        continue;
+      }
+      seenVersions.add(entry.version);
+      uniqueEntries.push(entry);
+    }
+
+    if (uniqueEntries.length > effectiveKeepCount) {
+      entriesToDelete.push(...uniqueEntries.slice(effectiveKeepCount));
+    }
+
+    if (entriesToDelete.length === 0) {
+      return;
+    }
+
+    const tokensToDelete = new Set(entriesToDelete.map((e) => e.token));
+
+    // Delete the directories for old entries
+    for (const entry of entriesToDelete) {
+      const cacheDir = path.join(FIRMWARE_CACHE_DIR, entry.deviceId, entry.token);
+      try {
+        deleteDirectory(cacheDir);
+        logger.info({ deviceId: entry.deviceId, token: entry.token, version: entry.version }, 'Deleted old firmware cache entry');
+      } catch (error) {
+        logger.warn({ error, cacheDir }, 'Failed to delete firmware cache directory');
+      }
+    }
+
+    // Update the index to remove deleted entries
+    index.entries = index.entries.filter(
+      (e) => !(e.deviceId === deviceId && tokensToDelete.has(e.token))
+    );
+    writeCacheIndex(index);
+  },
+
+  /**
+   * Delete a specific cache entry
+   */
+  deleteCacheEntry: (deviceId: string, token: string): boolean => {
+    const index = readCacheIndex();
+    const entry = index.entries.find((e) => e.deviceId === deviceId && e.token === token);
+
+    if (!entry) {
+      return false;
+    }
+
+    // Delete the directory
+    const cacheDir = path.join(FIRMWARE_CACHE_DIR, deviceId, token);
+    try {
+      deleteDirectory(cacheDir);
+    } catch (error) {
+      logger.warn({ error, cacheDir }, 'Failed to delete firmware cache directory');
+    }
+
+    // Update the index
+    index.entries = index.entries.filter(
+      (e) => !(e.deviceId === deviceId && e.token === token)
+    );
+    writeCacheIndex(index);
+    return true;
+  },
+
+  /**
+   * Get firmware settings
+   */
+  getSettings: (): FirmwareSettings => readSettings(),
+
+  /**
+   * Save firmware settings (merge with existing)
+   */
+  saveSettings: (settings: Partial<FirmwareSettings>): FirmwareSettings => {
+    const current = readSettings();
+    const merged = { ...current, ...settings };
+    writeSettings(merged);
+    return merged;
+  },
+
+  /**
+   * Get the base cache directory path
+   */
+  getBaseCacheDir: (): string => FIRMWARE_CACHE_DIR,
+};

--- a/everything-presence-mmwave-configurator/backend/src/domain/deviceProfiles.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/deviceProfiles.ts
@@ -26,6 +26,11 @@ export type ZoneType = 'regular' | 'exclusion' | 'entry' | 'polygon' | 'polygonE
  */
 export type ControlType = 'number' | 'switch' | 'select' | 'light' | 'text';
 
+export interface ServiceDefinition {
+  domain: string;
+  template: string;
+}
+
 /**
  * Entity definition in the device profile.
  * Provides full metadata for each entity type.
@@ -87,6 +92,8 @@ export interface DeviceProfile {
   limits: DeviceProfileLimits;
   /** New categorized entity definitions */
   entities?: Record<string, EntityDefinition>;
+  /** Service definitions for device actions */
+  services?: Record<string, ServiceDefinition>;
   /** Legacy entity map (for backward compatibility) */
   entityMap: Record<string, unknown>;
   iconUrl?: string;

--- a/everything-presence-mmwave-configurator/backend/src/domain/entityDiscovery.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/entityDiscovery.ts
@@ -828,7 +828,7 @@ export class EntityDiscoveryService {
       'humidityEntity', 'illuminanceEntity', 'co2Entity', 'distanceEntity',
       'speedEntity', 'energyEntity', 'targetCountEntity', 'modeEntity',
       'maxDistanceEntity', 'installationAngleEntity', 'polygonZonesEnabledEntity',
-      'trackingTargetCountEntity', 'assumedPresentEntity', 'assumedPresentRemainingEntity',
+      'trackingTargetCountEntity', 'firmwareUpdateEntity', 'assumedPresentEntity', 'assumedPresentRemainingEntity',
     ];
 
     for (const key of flatKeys) {
@@ -1040,6 +1040,7 @@ export class EntityDiscoveryService {
     if (em.installationAngleEntity) mappings['installationAngle'] = em.installationAngleEntity;
     if (em.polygonZonesEnabledEntity) mappings['polygonZonesEnabled'] = em.polygonZonesEnabledEntity;
     if (em.trackingTargetCountEntity) mappings['trackingTargetCount'] = em.trackingTargetCountEntity;
+    if (em.firmwareUpdateEntity) mappings['firmwareUpdate'] = em.firmwareUpdateEntity;
 
     // Entry/Exit feature entities
     if (em.assumedPresentEntity) mappings['assumedPresent'] = em.assumedPresentEntity;

--- a/everything-presence-mmwave-configurator/backend/src/domain/firmwareService.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/firmwareService.ts
@@ -1,0 +1,888 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { logger } from '../logger';
+import { firmwareStorage, CachedFirmwareEntry } from '../config/firmwareStorage';
+import { FirmwareConfig } from '../config';
+import type { IHaWriteClient } from '../ha/writeClient';
+import type { IHaReadTransport, EntityState } from '../ha/readTransport';
+import { deviceEntityService } from './deviceEntityService';
+import {
+  DeviceConfig,
+  FirmwareIndex,
+  FirmwareVariant,
+  FirmwareValidation,
+  ValidationIssue,
+  AvailableUpdate,
+  DEFAULT_FIRMWARE_INDEX_URLS,
+} from '../types/firmware';
+
+/**
+ * ESPHome HTTP Request Update manifest format
+ * See: https://esphome.io/components/update/http_request.html
+ */
+export interface ESPHomeManifest {
+  name: string;
+  version: string;
+  home_assistant_domain?: string;
+  new_install_skip_erase?: boolean;
+  builds: Array<{
+    chipFamily: string;
+    ota?: {
+      path: string;
+      md5?: string;
+    };
+    parts: Array<{
+      path: string;
+      offset: number;
+    }>;
+  }>;
+  // Optional fields for changelog/release notes
+  releaseUrl?: string;
+  releaseSummary?: string;
+}
+
+export interface PreparedFirmware {
+  deviceId: string;
+  token: string;
+  version: string;
+  localManifestUrl: string;
+  releaseSummary?: string;
+  releaseUrl?: string;
+}
+
+export interface FirmwareServiceDependencies {
+  config: FirmwareConfig;
+  writeClient?: IHaWriteClient;
+  readTransport?: IHaReadTransport;
+}
+
+/**
+ * Cached firmware index entry
+ */
+interface CachedIndex {
+  data: FirmwareIndex;
+  fetchedAt: number;
+}
+
+// Cache TTL for firmware indexes (1 hour)
+const INDEX_CACHE_TTL = 60 * 60 * 1000;
+
+/**
+ * Get the local network IP address
+ * Attempts to find a non-loopback IPv4 address
+ */
+const isDockerEnv = (): boolean => {
+  try {
+    return fs.existsSync('/.dockerenv') || fs.existsSync('/.dockerinit');
+  } catch {
+    return false;
+  }
+};
+
+const isLikelyDockerInterface = (name: string): boolean =>
+  name === 'lo' ||
+  name.startsWith('docker') ||
+  name.startsWith('br-') ||
+  name.startsWith('veth') ||
+  name.startsWith('tun') ||
+  name.startsWith('wg');
+
+const getLocalIpAddress = (): string | null => {
+  const interfaces = os.networkInterfaces();
+  const preferred: string[] = [];
+  const fallback: string[] = [];
+
+  for (const name of Object.keys(interfaces)) {
+    const netInterface = interfaces[name];
+    if (!netInterface) continue;
+
+    for (const info of netInterface) {
+      // Skip loopback and non-IPv4
+      if (info.family === 'IPv4' && !info.internal) {
+        if (isLikelyDockerInterface(name)) {
+          fallback.push(info.address);
+        } else {
+          preferred.push(info.address);
+        }
+      }
+    }
+  }
+
+  return preferred[0] ?? fallback[0] ?? null;
+};
+
+export class FirmwareService {
+  private readonly config: FirmwareConfig;
+  private readonly writeClient?: IHaWriteClient;
+  private readonly readTransport?: IHaReadTransport;
+  private indexCache: Map<string, CachedIndex> = new Map();
+
+  constructor(deps: FirmwareServiceDependencies) {
+    this.config = deps.config;
+    this.writeClient = deps.writeClient;
+    this.readTransport = deps.readTransport;
+  }
+
+  /**
+   * Get the LAN IP address to use for firmware URLs
+   * Uses override if set, otherwise auto-detects
+   */
+  getLanIp(): string {
+    // Check for override in config (from env var)
+    if (this.config.lanIpOverride) {
+      return this.config.lanIpOverride;
+    }
+
+    // Check for override in settings (user-configured)
+    const settings = firmwareStorage.getSettings();
+    if (settings.lanIpOverride) {
+      return settings.lanIpOverride;
+    }
+
+    // Auto-detect
+    const detected = getLocalIpAddress();
+    if (detected) {
+      if (isDockerEnv()) {
+        logger.warn(
+          { detectedIp: detected },
+          'Detected Docker environment; auto-detected LAN IP may be container address. Set LAN IP override or FIRMWARE_LAN_IP if devices cannot reach this IP.'
+        );
+      }
+      return detected;
+    }
+
+    // Fallback to localhost (won't work for devices, but better than nothing)
+    logger.warn('Could not auto-detect LAN IP address, using localhost');
+    return '127.0.0.1';
+  }
+
+  /**
+   * Fetch the remote manifest from HTTPS
+   */
+  async fetchRemoteManifest(manifestUrl: string): Promise<ESPHomeManifest> {
+    logger.info({ url: manifestUrl }, 'Fetching remote manifest');
+
+    const response = await fetch(manifestUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch manifest: ${response.status} ${response.statusText}`);
+    }
+
+    const manifest = await response.json() as ESPHomeManifest;
+
+    if (!manifest.name || !manifest.version || !manifest.builds) {
+      throw new Error('Invalid manifest format: missing required fields');
+    }
+
+    logger.info({ name: manifest.name, version: manifest.version }, 'Fetched manifest');
+    return manifest;
+  }
+
+  /**
+   * Download a binary file to the specified path
+   */
+  async downloadBinary(url: string, destPath: string): Promise<void> {
+    logger.info({ url, destPath }, 'Downloading binary');
+
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to download binary: ${response.status} ${response.statusText}`);
+    }
+
+    const buffer = await response.arrayBuffer();
+    fs.writeFileSync(destPath, Buffer.from(buffer));
+
+    const stats = fs.statSync(destPath);
+    logger.info({ destPath, size: stats.size }, 'Downloaded binary');
+  }
+
+  /**
+   * Rewrite manifest paths to use relative filenames
+   * Since manifest and binaries are served from the same directory,
+   * relative paths work and avoid IP detection issues
+   */
+  rewriteManifest(manifest: ESPHomeManifest): ESPHomeManifest {
+    const rewritten: ESPHomeManifest = {
+      ...manifest,
+      builds: manifest.builds.map((build) => ({
+        ...build,
+        // Rewrite OTA path if present
+        ota: build.ota
+          ? {
+              ...build.ota,
+              path: path.basename(build.ota.path),
+            }
+          : undefined,
+        // Rewrite parts paths
+        parts: build.parts.map((part) => ({
+          ...part,
+          // Use just the filename - relative to the manifest location
+          path: path.basename(part.path),
+        })),
+      })),
+    };
+
+    return rewritten;
+  }
+
+  /**
+   * Prepare firmware for a device by downloading and caching it locally
+   */
+  async prepareFirmwareForDevice(
+    deviceId: string,
+    manifestUrl: string
+  ): Promise<PreparedFirmware> {
+    const token = firmwareStorage.generateToken();
+    const cacheDir = firmwareStorage.ensureDeviceCacheDir(deviceId, token);
+    const lanIp = this.getLanIp();
+    const localBaseUrl = `http://${lanIp}:${this.config.lanPort}/fw/${deviceId}/${token}`;
+
+    logger.info({ deviceId, token, manifestUrl, localBaseUrl }, 'Preparing firmware');
+
+    try {
+      // 1. Fetch the remote manifest
+      const manifest = await this.fetchRemoteManifest(manifestUrl);
+
+      // 2. Determine the base URL for binary downloads
+      const manifestUrlObj = new URL(manifestUrl);
+      const manifestDir = manifestUrlObj.href.substring(0, manifestUrlObj.href.lastIndexOf('/'));
+
+      // 3. Download all binary files (parts and OTA)
+      const binaryPaths: string[] = [];
+      for (const build of manifest.builds) {
+        // Download OTA binary if present
+        if (build.ota) {
+          const otaUrl = build.ota.path.startsWith('http')
+            ? build.ota.path
+            : `${manifestDir}/${build.ota.path}`;
+
+          const otaFilename = path.basename(build.ota.path);
+          const localOtaPath = path.join(cacheDir, otaFilename);
+
+          await this.downloadBinary(otaUrl, localOtaPath);
+          binaryPaths.push(localOtaPath);
+        }
+
+        // Download parts binaries
+        for (const part of build.parts) {
+          // Resolve the binary URL (could be relative or absolute)
+          const binaryUrl = part.path.startsWith('http')
+            ? part.path
+            : `${manifestDir}/${part.path}`;
+
+          const binaryFilename = path.basename(part.path);
+          const localBinaryPath = path.join(cacheDir, binaryFilename);
+
+          await this.downloadBinary(binaryUrl, localBinaryPath);
+          binaryPaths.push(localBinaryPath);
+        }
+      }
+
+      // 4. Rewrite manifest to use relative paths
+      const rewrittenManifest = this.rewriteManifest(manifest);
+
+      // 5. Save the rewritten manifest
+      const manifestPath = path.join(cacheDir, 'manifest.json');
+      fs.writeFileSync(manifestPath, JSON.stringify(rewrittenManifest, null, 2));
+
+      // 6. Save cache entry
+      const entry: CachedFirmwareEntry = {
+        deviceId,
+        token,
+        version: manifest.version,
+        manifestPath,
+        binaryPaths,
+        originalManifestUrl: manifestUrl,
+        cachedAt: Date.now(),
+      };
+      firmwareStorage.saveCacheEntry(entry);
+
+      // 7. Cleanup old versions (keep last N distinct versions)
+      const settings = firmwareStorage.getSettings();
+      const keepCount = typeof settings.cacheKeepCount === 'number' && settings.cacheKeepCount > 0
+        ? Math.floor(settings.cacheKeepCount)
+        : this.config.maxVersionsPerDevice;
+      firmwareStorage.cleanupOldVersions(deviceId, keepCount);
+
+      const localManifestUrl = `${localBaseUrl}/manifest.json`;
+
+      logger.info(
+        { deviceId, token, version: manifest.version, localManifestUrl },
+        'Firmware prepared successfully'
+      );
+
+      return {
+        deviceId,
+        token,
+        version: manifest.version,
+        localManifestUrl,
+        releaseSummary: manifest.releaseSummary,
+        releaseUrl: manifest.releaseUrl,
+      };
+    } catch (error) {
+      // Clean up on failure
+      try {
+        firmwareStorage.deleteCacheEntry(deviceId, token);
+      } catch {
+        // Ignore cleanup errors
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Trigger a device to update using the ESPHome set_update_manifest service
+   * This calls the custom ESPHome service that sets the URL and triggers the update
+   */
+  async triggerDeviceUpdate(
+    deviceId: string,
+    localManifestUrl: string
+  ): Promise<void> {
+    if (!this.writeClient) {
+      throw new Error('Write client not available');
+    }
+
+    const service = deviceEntityService.getService(deviceId, 'setUpdateManifest');
+    if (!service) {
+      throw new Error('Update manifest service not mapped');
+    }
+
+    logger.info({ deviceId, localManifestUrl, service: service.service }, 'Triggering device update via ESPHome service');
+
+    try {
+      // Call the ESPHome service: esphome.<device_name>_set_update_manifest
+      // This service sets the manifest URL and triggers the update
+      await this.writeClient.callService(service.domain, service.service, {
+        url: localManifestUrl,
+      });
+
+      logger.info({ deviceId, service: service.service }, 'Update triggered successfully');
+    } catch (error) {
+      logger.error({ error, deviceId, service: service.service }, 'Failed to trigger update');
+      throw error;
+    }
+  }
+
+  /**
+   * Set the update manifest URL on a device via a text entity
+   * This is used when the device has a configurable manifest URL
+   */
+  async setDeviceManifestUrl(
+    textEntityId: string,
+    manifestUrl: string
+  ): Promise<void> {
+    if (!this.writeClient) {
+      throw new Error('Write client not available');
+    }
+
+    logger.info({ textEntityId, manifestUrl }, 'Setting device manifest URL');
+
+    await this.writeClient.setTextEntity(textEntityId, manifestUrl);
+
+    logger.info({ textEntityId }, 'Manifest URL set successfully');
+  }
+
+  /**
+   * Press a button entity to trigger firmware update
+   */
+  async pressUpdateButton(buttonEntityId: string): Promise<void> {
+    if (!this.writeClient) {
+      throw new Error('Write client not available');
+    }
+
+    logger.info({ buttonEntityId }, 'Pressing update button');
+
+    await this.writeClient.callService('button', 'press', {
+      entity_id: buttonEntityId,
+    });
+
+    logger.info({ buttonEntityId }, 'Update button pressed');
+  }
+
+  /**
+   * Get all cached firmware entries
+   */
+  getCachedFirmware(): CachedFirmwareEntry[] {
+    return firmwareStorage.getAllEntries();
+  }
+
+  /**
+   * Get cached firmware for a specific device
+   */
+  getDeviceCachedFirmware(deviceId: string): CachedFirmwareEntry[] {
+    return firmwareStorage.getDeviceEntries(deviceId);
+  }
+
+  /**
+   * Delete a cached firmware entry
+   */
+  deleteCachedFirmware(deviceId: string, token: string): boolean {
+    return firmwareStorage.deleteCacheEntry(deviceId, token);
+  }
+
+  // ─────────────────────────────────────────────────────────────────
+  // Auto-Update System Methods
+  // ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Get device configuration by calling the get_build_flags ESPHome service.
+   * This service returns the device's build configuration directly.
+   *
+   * Returns configSource='inferred' if the service doesn't exist (device needs firmware update first)
+   */
+  async getDeviceConfig(
+    deviceModel: string,
+    firmwareVersion: string,
+    deviceId: string
+  ): Promise<DeviceConfig> {
+    if (!this.writeClient) {
+      throw new Error('Write client not available');
+    }
+
+    const service = deviceEntityService.getService(deviceId, 'getBuildFlags');
+    const namePrefix = deviceEntityService.getDeviceNamePrefix(deviceId) ?? '';
+    logger.info({ deviceId, deviceModel }, 'Getting device config via get_build_flags service');
+
+    // Determine model from device info (fallback)
+    const inferredModel = this.inferModelFromDeviceInfo(deviceModel);
+
+    try {
+      if (!service) {
+        throw new Error('Build flags service not mapped');
+      }
+
+      const response = await this.writeClient.callService(
+        service.domain,
+        service.service,
+        {},
+        { returnResponse: true }
+      );
+
+      logger.info({ response, responseType: typeof response }, 'get_build_flags service response');
+
+      // Parse the response - it could be in different formats depending on HA version
+      let configData: Record<string, unknown> | null = null;
+
+      if (response && typeof response === 'object') {
+        // Check if response is an array (HA returns array of state changes for some services)
+        if (Array.isArray(response)) {
+          // If it's an array with service_response, extract it
+          // Some HA versions nest the response
+          if (response.length > 0 && typeof response[0] === 'object') {
+            configData = response[0] as Record<string, unknown>;
+          }
+        } else {
+          // Direct object response - check for nested service_response or use directly
+          const respObj = response as Record<string, unknown>;
+          if (respObj.service_response && typeof respObj.service_response === 'object') {
+            configData = respObj.service_response as Record<string, unknown>;
+          } else if (respObj.response && typeof respObj.response === 'object') {
+            configData = respObj.response as Record<string, unknown>;
+          } else if ('ethernet_enabled' in respObj || 'model' in respObj) {
+            // Direct response with config fields
+            configData = respObj;
+          }
+        }
+      }
+
+      if (configData && ('ethernet_enabled' in configData || 'model' in configData || 'co2_enabled' in configData)) {
+        const config: DeviceConfig = {
+          model: (configData.model as DeviceConfig['model']) || inferredModel,
+          ethernet_enabled: Boolean(configData.ethernet_enabled),
+          co2_enabled: Boolean(configData.co2_enabled),
+          bluetooth_enabled: Boolean(configData.bluetooth_enabled),
+          board_revision: String(configData.board_revision || ''),
+          sensor_variant: String(configData.sensor_variant || ''),
+          firmware_channel: (configData.firmware_channel as DeviceConfig['firmware_channel']) || 'stable',
+          configSource: 'entities',
+        };
+
+        logger.info({ config }, 'Device config retrieved from get_build_flags service');
+        return config;
+      }
+
+      logger.warn({ response }, 'get_build_flags returned unexpected format, falling back to inference');
+    } catch (error) {
+      // Service call failed - device likely has old firmware without this service
+      logger.info(
+        { deviceId, error: error instanceof Error ? error.message : 'Unknown error' },
+        'get_build_flags service not available, falling back to inference'
+      );
+    }
+
+    // Fallback to inferred config for devices without the service
+    const config: DeviceConfig = {
+      model: inferredModel,
+      ethernet_enabled: false,
+      co2_enabled: false,
+      bluetooth_enabled: false,
+      board_revision: this.inferBoardRevision(inferredModel, firmwareVersion),
+      sensor_variant: this.inferSensorVariant(inferredModel, namePrefix),
+      firmware_channel: this.inferFirmwareChannel(firmwareVersion),
+      configSource: 'inferred',
+    };
+
+    logger.info({ config }, 'Device config inferred (service not available or returned unexpected format)');
+    return config;
+  }
+
+  /**
+   * Infer model from Home Assistant device model string
+   */
+  private inferModelFromDeviceInfo(deviceModel: string): DeviceConfig['model'] {
+    const lower = deviceModel.toLowerCase();
+    if (lower.includes('pro')) {
+      return 'everything-presence-pro';
+    }
+    if (lower.includes('lite')) {
+      return 'everything-presence-lite';
+    }
+    // Default to EP1 for "Everything Presence One" or similar
+    return 'everything-presence-one';
+  }
+
+  /**
+   * Infer board revision from model and firmware version
+   * This is a best-effort guess - ideally firmware should expose this
+   */
+  private inferBoardRevision(model: DeviceConfig['model'], firmwareVersion: string): string {
+    // Default revisions by model
+    switch (model) {
+      case 'everything-presence-lite':
+        return '1.2';
+      case 'everything-presence-pro':
+        return '1.8';
+      case 'everything-presence-one':
+        // EP1 has multiple revisions, default to 1.5
+        return '1.5';
+      default:
+        return '1.0';
+    }
+  }
+
+  /**
+   * Infer sensor variant from model and entity patterns
+   */
+  private inferSensorVariant(model: DeviceConfig['model'], entityPrefix: string): string {
+    switch (model) {
+      case 'everything-presence-lite':
+        // Default LD2450, check entity prefix for alternatives
+        if (entityPrefix.includes('sen0609')) return 'sen0609';
+        if (entityPrefix.includes('sen0395')) return 'sen0395';
+        if (entityPrefix.includes('ld2410')) return 'ld2410';
+        if (entityPrefix.includes('mr24hpc1')) return 'mr24hpc1';
+        return ''; // Default LD2450
+      case 'everything-presence-pro':
+        return 'ld2450+sen0609';
+      case 'everything-presence-one':
+        // Check for SEN0609 vs legacy SEN0395
+        if (entityPrefix.includes('sen0609')) return 'sen0609';
+        return 'sen0395'; // Legacy default
+      default:
+        return '';
+    }
+  }
+
+  /**
+   * Infer firmware channel from version string
+   */
+  private inferFirmwareChannel(version: string): DeviceConfig['firmware_channel'] {
+    if (version.toLowerCase().includes('beta')) {
+      return 'beta';
+    }
+    return 'stable';
+  }
+
+  /**
+   * Fetch a firmware index from a URL with caching
+   */
+  async fetchFirmwareIndex(url: string): Promise<FirmwareIndex | null> {
+    // Check cache first
+    const cached = this.indexCache.get(url);
+    if (cached && Date.now() - cached.fetchedAt < INDEX_CACHE_TTL) {
+      logger.debug({ url }, 'Using cached firmware index');
+      return cached.data;
+    }
+
+    try {
+      logger.info({ url }, 'Fetching firmware index');
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        logger.warn({ url, status: response.status }, 'Failed to fetch firmware index');
+        return null;
+      }
+
+      const index = await response.json() as FirmwareIndex;
+
+      // Validate basic structure
+      if (!index.schemaVersion || !index.product || !index.firmwares) {
+        logger.warn({ url }, 'Invalid firmware index format');
+        return null;
+      }
+
+      // Cache the result
+      this.indexCache.set(url, {
+        data: index,
+        fetchedAt: Date.now(),
+      });
+
+      logger.info({ url, product: index.product.id, version: index.product.latestVersion }, 'Fetched firmware index');
+      return index;
+    } catch (error) {
+      logger.error({ error, url }, 'Error fetching firmware index');
+      return null;
+    }
+  }
+
+  /**
+   * Fetch all firmware indexes from configured URLs
+   */
+  async fetchAllFirmwareIndexes(): Promise<FirmwareIndex[]> {
+    // Get custom URLs from settings, or use defaults
+    const settings = firmwareStorage.getSettings();
+    const urls = settings.firmwareIndexUrls || Object.values(DEFAULT_FIRMWARE_INDEX_URLS);
+
+    const results = await Promise.all(
+      urls.map((url) => this.fetchFirmwareIndex(url))
+    );
+
+    return results.filter((index): index is FirmwareIndex => index !== null);
+  }
+
+  /**
+   * Find matching firmware variant for a device config
+   */
+  findMatchingFirmware(
+    deviceConfig: DeviceConfig,
+    indexes: FirmwareIndex[]
+  ): FirmwareVariant | null {
+    // Find the product index matching device model
+    const productIndex = indexes.find(
+      (idx) => idx.product.id === deviceConfig.model
+    );
+
+    if (!productIndex) {
+      logger.warn({ model: deviceConfig.model }, 'No firmware index found for model');
+      return null;
+    }
+
+    // Find firmware matching device's channel
+    const channelFirmwares = productIndex.firmwares.filter(
+      (fw) => fw.channel === deviceConfig.firmware_channel
+    );
+
+    if (channelFirmwares.length === 0) {
+      logger.warn({ model: deviceConfig.model, channel: deviceConfig.firmware_channel }, 'No firmware found for channel');
+      return null;
+    }
+
+    // Get latest version for this channel
+    const latestFirmware = channelFirmwares.sort((a, b) =>
+      this.compareVersions(b.version, a.version)
+    )[0];
+
+    // Find variant matching ALL device config fields
+    const matchingVariant = latestFirmware.variants.find((variant) => {
+      const req = variant.requirements;
+      return (
+        req.model === deviceConfig.model &&
+        req.ethernet_enabled === deviceConfig.ethernet_enabled &&
+        req.co2_enabled === deviceConfig.co2_enabled &&
+        req.bluetooth_enabled === deviceConfig.bluetooth_enabled &&
+        req.board_revision === deviceConfig.board_revision &&
+        req.sensor_variant === deviceConfig.sensor_variant &&
+        req.firmware_channel === deviceConfig.firmware_channel
+      );
+    });
+
+    if (!matchingVariant) {
+      logger.warn({ deviceConfig }, 'No matching firmware variant found');
+    }
+
+    return matchingVariant || null;
+  }
+
+  /**
+   * Compare semantic version strings
+   * Returns: negative if a < b, positive if a > b, 0 if equal
+   */
+  private compareVersions(a: string, b: string): number {
+    const parseVersion = (v: string) => {
+      const parts = v.replace(/^v/, '').split(/[-+]/)[0].split('.');
+      return parts.map((p) => parseInt(p, 10) || 0);
+    };
+
+    const aParts = parseVersion(a);
+    const bParts = parseVersion(b);
+    const len = Math.max(aParts.length, bParts.length);
+
+    for (let i = 0; i < len; i++) {
+      const aVal = aParts[i] || 0;
+      const bVal = bParts[i] || 0;
+      if (aVal !== bVal) {
+        return aVal - bVal;
+      }
+    }
+
+    return 0;
+  }
+
+  /**
+   * Validate firmware compatibility with device config
+   */
+  validateFirmwareCompatibility(
+    deviceConfig: DeviceConfig,
+    firmwareVariant: FirmwareVariant
+  ): FirmwareValidation {
+    const hardBlocks: ValidationIssue[] = [];
+    const warnings: ValidationIssue[] = [];
+    const req = firmwareVariant.requirements;
+
+    // Hard blocks - will break the device
+    if (req.model !== deviceConfig.model) {
+      hardBlocks.push({
+        field: 'model',
+        deviceValue: deviceConfig.model,
+        firmwareValue: req.model,
+        message: `Cannot install ${req.model} firmware on ${deviceConfig.model} device`,
+        severity: 'hard_block',
+      });
+    }
+
+    if (req.ethernet_enabled !== deviceConfig.ethernet_enabled) {
+      hardBlocks.push({
+        field: 'ethernet_enabled',
+        deviceValue: deviceConfig.ethernet_enabled,
+        firmwareValue: req.ethernet_enabled,
+        message: `Network type mismatch: device is ${deviceConfig.ethernet_enabled ? 'Ethernet' : 'WiFi'}, firmware is for ${req.ethernet_enabled ? 'Ethernet' : 'WiFi'}. This could cause connectivity loss.`,
+        severity: 'hard_block',
+      });
+    }
+
+    if (req.sensor_variant !== deviceConfig.sensor_variant) {
+      hardBlocks.push({
+        field: 'sensor_variant',
+        deviceValue: deviceConfig.sensor_variant,
+        firmwareValue: req.sensor_variant,
+        message: `Sensor mismatch: device has ${deviceConfig.sensor_variant || 'default'} sensor, firmware is for ${req.sensor_variant || 'default'}`,
+        severity: 'hard_block',
+      });
+    }
+
+    // Soft warnings - may cause issues but device will work
+    if (req.co2_enabled !== deviceConfig.co2_enabled) {
+      warnings.push({
+        field: 'co2_enabled',
+        deviceValue: deviceConfig.co2_enabled,
+        firmwareValue: req.co2_enabled,
+        message: `CO2 module mismatch: device has CO2 ${deviceConfig.co2_enabled ? 'enabled' : 'disabled'}, firmware has CO2 ${req.co2_enabled ? 'enabled' : 'disabled'}`,
+        severity: 'warning',
+      });
+    }
+
+    if (req.bluetooth_enabled !== deviceConfig.bluetooth_enabled) {
+      warnings.push({
+        field: 'bluetooth_enabled',
+        deviceValue: deviceConfig.bluetooth_enabled,
+        firmwareValue: req.bluetooth_enabled,
+        message: `Bluetooth mismatch: device has BLE ${deviceConfig.bluetooth_enabled ? 'enabled' : 'disabled'}, firmware has BLE ${req.bluetooth_enabled ? 'enabled' : 'disabled'}`,
+        severity: 'warning',
+      });
+    }
+
+    if (req.board_revision !== deviceConfig.board_revision) {
+      warnings.push({
+        field: 'board_revision',
+        deviceValue: deviceConfig.board_revision,
+        firmwareValue: req.board_revision,
+        message: `Board revision mismatch: device is rev ${deviceConfig.board_revision}, firmware is for rev ${req.board_revision}`,
+        severity: 'warning',
+      });
+    }
+
+    return {
+      valid: hardBlocks.length === 0,
+      hardBlocks,
+      warnings,
+    };
+  }
+
+  /**
+   * Get available updates for a device
+   */
+  async getAvailableUpdates(
+    deviceConfig: DeviceConfig,
+    currentVersion: string
+  ): Promise<AvailableUpdate[]> {
+    const indexes = await this.fetchAllFirmwareIndexes();
+
+    if (indexes.length === 0) {
+      logger.warn('No firmware indexes available');
+      return [];
+    }
+
+    // Find product index
+    const productIndex = indexes.find((idx) => idx.product.id === deviceConfig.model);
+    if (!productIndex) {
+      return [];
+    }
+
+    const updates: AvailableUpdate[] = [];
+
+    // Check each firmware release for matching variants
+    for (const firmware of productIndex.firmwares) {
+      // Only show firmware matching current channel
+      if (firmware.channel !== deviceConfig.firmware_channel) {
+        continue;
+      }
+
+      // Check if this is a newer version
+      if (this.compareVersions(firmware.version, currentVersion) <= 0) {
+        continue;
+      }
+
+      // Find matching variant
+      const variant = firmware.variants.find((v) => {
+        const req = v.requirements;
+        return (
+          req.model === deviceConfig.model &&
+          req.ethernet_enabled === deviceConfig.ethernet_enabled &&
+          req.co2_enabled === deviceConfig.co2_enabled &&
+          req.bluetooth_enabled === deviceConfig.bluetooth_enabled &&
+          req.board_revision === deviceConfig.board_revision &&
+          req.sensor_variant === deviceConfig.sensor_variant
+        );
+      });
+
+      if (variant) {
+        // Check for migrations
+        const migration = productIndex.migrations.find((m) => {
+          // Simple version range check (could be improved with semver library)
+          return this.compareVersions(currentVersion, '2.0.0') < 0 &&
+                 this.compareVersions(firmware.version, '2.0.0') >= 0 &&
+                 m.id === 'rectangular-to-polygon-zones';
+        });
+
+        updates.push({
+          currentVersion,
+          newVersion: firmware.version,
+          channel: firmware.channel,
+          releaseNotes: firmware.releaseNotes,
+          variant,
+          migration,
+        });
+      }
+    }
+
+    return updates;
+  }
+
+  /**
+   * Clear the firmware index cache
+   */
+  clearIndexCache(): void {
+    this.indexCache.clear();
+    logger.info('Firmware index cache cleared');
+  }
+}

--- a/everything-presence-mmwave-configurator/backend/src/domain/mappingUtils.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/mappingUtils.ts
@@ -27,6 +27,7 @@ export const canonicalKeyPairs: Array<[string, string]> = [
   ['mmwaveThresholdFactor', 'thresholdFactorEntity'],
   ['microMotion', 'microMotionEntity'],
   ['updateRate', 'updateRateEntity'],
+  ['firmwareUpdate', 'firmwareUpdateEntity'],
   ['installationAngle', 'installationAngleEntity'],
   ['polygonZonesEnabled', 'polygonZonesEnabledEntity'],
 ];

--- a/everything-presence-mmwave-configurator/backend/src/domain/migrationService.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/migrationService.ts
@@ -67,6 +67,7 @@ class MigrationServiceImpl {
     if (em.installationAngleEntity) mappings['installationAngle'] = em.installationAngleEntity;
     if (em.polygonZonesEnabledEntity) mappings['polygonZonesEnabled'] = em.polygonZonesEnabledEntity;
     if (em.trackingTargetCountEntity) mappings['trackingTargetCount'] = em.trackingTargetCountEntity;
+    if (em.firmwareUpdateEntity) mappings['firmwareUpdate'] = em.firmwareUpdateEntity;
 
     // Zone config entities (rectangular)
     this.flattenZoneEntities(mappings, em.zoneConfigEntities, 'zone');

--- a/everything-presence-mmwave-configurator/backend/src/domain/types.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/types.ts
@@ -131,6 +131,7 @@ export interface EntityMappings {
   thresholdFactorEntity?: string;
   microMotionEntity?: string;
   updateRateEntity?: string;
+  firmwareUpdateEntity?: string;
   installationAngleEntity?: string;
   polygonZonesEnabledEntity?: string;
 

--- a/everything-presence-mmwave-configurator/backend/src/index.ts
+++ b/everything-presence-mmwave-configurator/backend/src/index.ts
@@ -7,6 +7,7 @@ import { HaWriteClient } from './ha/writeClient';
 import { createReadTransport, TransportFactoryResult } from './ha/transportFactory';
 import { DeviceProfileLoader } from './domain/deviceProfiles';
 import { createLiveWebSocketServer } from './routes/liveWs';
+import { createLanFirmwareServer } from './lanFirmwareServer';
 
 const start = async () => {
   try {
@@ -81,11 +82,15 @@ const start = async () => {
     // 6. Attach WebSocket server for live tracking (frontend connections)
     createLiveWebSocketServer(httpServer, readTransport, profileLoader);
 
-    // 7. Start listening
+    // 7. Start LAN Firmware Server (separate port for device firmware downloads)
+    createLanFirmwareServer(config.firmware.lanPort);
+
+    // 8. Start main server listening
     httpServer.listen(config.port, () => {
       logger.info(
         {
           port: config.port,
+          firmwareLanPort: config.firmware.lanPort,
           ha: redactedHaConfig(config.ha),
           readTransport: activeTransport,
           writeTransport: 'rest',

--- a/everything-presence-mmwave-configurator/backend/src/lanFirmwareServer.ts
+++ b/everything-presence-mmwave-configurator/backend/src/lanFirmwareServer.ts
@@ -1,0 +1,176 @@
+import express from 'express';
+import http from 'http';
+import path from 'path';
+import fs from 'fs';
+import { logger } from './logger';
+import { firmwareStorage } from './config/firmwareStorage';
+
+/**
+ * Create a dedicated HTTP server for serving firmware files to ESP devices
+ * This server runs on a separate port (default 38080) and serves firmware
+ * over plain HTTP (no TLS) for compatibility with ESP devices that have
+ * limited memory for HTTPS connections.
+ */
+export const createLanFirmwareServer = (port: number): http.Server => {
+  const app = express();
+
+  // Middleware to log requests
+  app.use((req, res, next) => {
+    logger.debug({ method: req.method, url: req.url }, 'LAN firmware server request');
+    next();
+  });
+
+  /**
+   * Health check endpoint
+   */
+  app.get('/health', (_req, res) => {
+    res.json({ status: 'ok', server: 'lan-firmware', port });
+  });
+
+  /**
+   * Serve the rewritten manifest for a device/token
+   * URL: /fw/:deviceId/:token/manifest.json
+   */
+  app.get('/fw/:deviceId/:token/manifest.json', (req, res) => {
+    const { deviceId, token } = req.params;
+
+    logger.info({ deviceId, token }, 'Manifest requested');
+
+    // Look up the cache entry
+    const entry = firmwareStorage.getCacheEntry(deviceId, token);
+
+    if (!entry) {
+      logger.warn({ deviceId, token }, 'Manifest not found or expired');
+      return res.status(404).json({ error: 'Firmware not found or expired' });
+    }
+
+    // Check if file exists
+    if (!fs.existsSync(entry.manifestPath)) {
+      logger.error({ deviceId, token, manifestPath: entry.manifestPath }, 'Manifest file missing');
+      return res.status(404).json({ error: 'Manifest file not found' });
+    }
+
+    // Set appropriate headers
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('Cache-Control', 'no-cache');
+
+    // Send the manifest file
+    res.sendFile(entry.manifestPath, (err) => {
+      if (err) {
+        logger.error({ error: err, deviceId, token }, 'Error sending manifest');
+        if (!res.headersSent) {
+          res.status(500).json({ error: 'Failed to send manifest' });
+        }
+      } else {
+        logger.info({ deviceId, token }, 'Manifest served successfully');
+      }
+    });
+  });
+
+  /**
+   * Serve firmware binary files
+   * URL: /fw/:deviceId/:token/:filename
+   */
+  app.get('/fw/:deviceId/:token/:filename', (req, res) => {
+    const { deviceId, token, filename } = req.params;
+
+    // Prevent directory traversal
+    if (filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
+      logger.warn({ deviceId, token, filename }, 'Invalid filename - possible directory traversal');
+      return res.status(400).json({ error: 'Invalid filename' });
+    }
+
+    logger.info({ deviceId, token, filename }, 'Binary requested');
+
+    // Look up the cache entry
+    const entry = firmwareStorage.getCacheEntry(deviceId, token);
+
+    if (!entry) {
+      logger.warn({ deviceId, token }, 'Cache entry not found');
+      return res.status(404).json({ error: 'Firmware not found or expired' });
+    }
+
+    // Find the binary path matching the requested filename
+    const binaryPath = entry.binaryPaths.find((p) => path.basename(p) === filename);
+
+    if (!binaryPath) {
+      logger.warn({ deviceId, token, filename, availableFiles: entry.binaryPaths.map(p => path.basename(p)) }, 'Binary file not found in cache entry');
+      return res.status(404).json({ error: 'Binary file not found' });
+    }
+
+    // Check if file exists
+    if (!fs.existsSync(binaryPath)) {
+      logger.error({ deviceId, token, binaryPath }, 'Binary file missing from disk');
+      return res.status(404).json({ error: 'Binary file not found on disk' });
+    }
+
+    // Get file stats for Content-Length header
+    const stats = fs.statSync(binaryPath);
+
+    // Set appropriate headers for binary download
+    res.setHeader('Content-Type', 'application/octet-stream');
+    res.setHeader('Content-Length', stats.size);
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+
+    // Send the binary file
+    res.sendFile(binaryPath, (err) => {
+      if (err) {
+        logger.error({ error: err, deviceId, token, filename }, 'Error sending binary');
+        if (!res.headersSent) {
+          res.status(500).json({ error: 'Failed to send binary' });
+        }
+      } else {
+        logger.info({ deviceId, token, filename, size: stats.size }, 'Binary served successfully');
+      }
+    });
+  });
+
+  /**
+   * List cached firmware (for debugging)
+   * URL: /fw/list
+   */
+  app.get('/fw/list', (_req, res) => {
+    const entries = firmwareStorage.getAllEntries();
+    res.json({
+      count: entries.length,
+      entries: entries.map((e) => ({
+        deviceId: e.deviceId,
+        token: e.token,
+        version: e.version,
+        cachedAt: new Date(e.cachedAt).toISOString(),
+        binaryCount: e.binaryPaths.length,
+      })),
+    });
+  });
+
+  // 404 handler
+  app.use((_req, res) => {
+    res.status(404).json({ error: 'Not found' });
+  });
+
+  // Error handler
+  app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    logger.error({ error: err.message }, 'LAN firmware server error');
+    res.status(500).json({ error: 'Internal server error' });
+  });
+
+  // Create HTTP server
+  const server = http.createServer(app);
+
+  // Start listening
+  server.listen(port, '0.0.0.0', () => {
+    logger.info({ port }, 'LAN Firmware Server started (plain HTTP for ESP devices)');
+  });
+
+  // Handle server errors
+  server.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EADDRINUSE') {
+      logger.error({ port }, 'LAN Firmware Server port already in use');
+    } else {
+      logger.error({ error: err.message }, 'LAN Firmware Server error');
+    }
+  });
+
+  return server;
+};

--- a/everything-presence-mmwave-configurator/backend/src/routes/firmware.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/firmware.ts
@@ -1,0 +1,625 @@
+import { Router } from 'express';
+import { FirmwareService } from '../domain/firmwareService';
+import { firmwareStorage } from '../config/firmwareStorage';
+import { logger } from '../logger';
+import type { IHaWriteClient } from '../ha/writeClient';
+import type { IHaReadTransport } from '../ha/readTransport';
+import type { FirmwareConfig } from '../config';
+import { DEFAULT_FIRMWARE_INDEX_URLS } from '../types/firmware';
+import { deviceEntityService } from '../domain/deviceEntityService';
+
+export interface FirmwareRouterDependencies {
+  config: FirmwareConfig;
+  writeClient: IHaWriteClient;
+  readTransport?: IHaReadTransport;
+}
+
+export const createFirmwareRouter = (deps: FirmwareRouterDependencies): Router => {
+  const router = Router();
+  const firmwareService = new FirmwareService({
+    config: deps.config,
+    writeClient: deps.writeClient,
+    readTransport: deps.readTransport,
+  });
+
+  /**
+   * GET /api/firmware/settings
+   * Get firmware update settings and auto-detected LAN IP
+   */
+  router.get('/settings', (_req, res) => {
+    try {
+      const settings = firmwareStorage.getSettings();
+      const autoDetectedIp = firmwareService.getLanIp();
+      const lanPort = deps.config.lanPort;
+      const effectiveCacheKeepCount =
+        typeof settings.cacheKeepCount === 'number' && settings.cacheKeepCount > 0
+          ? Math.floor(settings.cacheKeepCount)
+          : deps.config.maxVersionsPerDevice;
+
+      res.json({
+        settings: {
+          ...settings,
+          cacheKeepCount: effectiveCacheKeepCount,
+        },
+        autoDetectedIp,
+        lanPort,
+        // Computed URL that devices will use
+        firmwareServerUrl: `http://${autoDetectedIp}:${lanPort}`,
+        // Default firmware index URLs (for reference)
+        defaultIndexUrls: DEFAULT_FIRMWARE_INDEX_URLS,
+      });
+    } catch (error) {
+      logger.error({ error }, 'Failed to get firmware settings');
+      res.status(500).json({ error: 'Failed to get firmware settings' });
+    }
+  });
+
+  /**
+   * PUT /api/firmware/settings
+   * Update firmware settings (LAN IP override, firmware base URL, index URLs)
+   */
+  router.put('/settings', (req, res) => {
+    try {
+      const updates: Record<string, unknown> = {};
+
+      if (typeof req.body?.lanIpOverride === 'string') {
+        updates.lanIpOverride = req.body.lanIpOverride || undefined; // Empty string = clear
+      } else if (req.body?.lanIpOverride === null) {
+        updates.lanIpOverride = undefined;
+      }
+
+      if (typeof req.body?.firmwareBaseUrl === 'string') {
+        updates.firmwareBaseUrl = req.body.firmwareBaseUrl || undefined;
+      } else if (req.body?.firmwareBaseUrl === null) {
+        updates.firmwareBaseUrl = undefined;
+      }
+
+      // Handle firmwareIndexUrls
+      if (Array.isArray(req.body?.firmwareIndexUrls)) {
+        const urls = req.body.firmwareIndexUrls.filter(
+          (url: unknown) => typeof url === 'string' && url.trim()
+        );
+        updates.firmwareIndexUrls = urls.length > 0 ? urls : undefined;
+      } else if (req.body?.firmwareIndexUrls === null) {
+        updates.firmwareIndexUrls = undefined;
+      }
+
+      if (typeof req.body?.cacheKeepCount === 'number') {
+        const normalized = Math.floor(req.body.cacheKeepCount);
+        updates.cacheKeepCount = normalized > 0 ? normalized : undefined;
+      } else if (typeof req.body?.cacheKeepCount === 'string') {
+        const parsed = Number(req.body.cacheKeepCount);
+        if (Number.isFinite(parsed)) {
+          const normalized = Math.floor(parsed);
+          updates.cacheKeepCount = normalized > 0 ? normalized : undefined;
+        }
+      } else if (req.body?.cacheKeepCount === null) {
+        updates.cacheKeepCount = undefined;
+      }
+
+      const settings = firmwareStorage.saveSettings(updates);
+      const autoDetectedIp = firmwareService.getLanIp();
+      const effectiveCacheKeepCount =
+        typeof settings.cacheKeepCount === 'number' && settings.cacheKeepCount > 0
+          ? Math.floor(settings.cacheKeepCount)
+          : deps.config.maxVersionsPerDevice;
+
+      // Clear index cache when URLs change
+      if ('firmwareIndexUrls' in updates) {
+        firmwareService.clearIndexCache();
+      }
+
+      res.json({
+        settings: {
+          ...settings,
+          cacheKeepCount: effectiveCacheKeepCount,
+        },
+        autoDetectedIp,
+        lanPort: deps.config.lanPort,
+        firmwareServerUrl: `http://${autoDetectedIp}:${deps.config.lanPort}`,
+        defaultIndexUrls: DEFAULT_FIRMWARE_INDEX_URLS,
+      });
+    } catch (error) {
+      logger.error({ error }, 'Failed to update firmware settings');
+      res.status(500).json({ error: 'Failed to update firmware settings' });
+    }
+  });
+
+  /**
+   * POST /api/firmware/prepare
+   * Download and cache firmware for a device
+   * Body: { deviceId: string, manifestUrl: string }
+   */
+  router.post('/prepare', async (req, res) => {
+    try {
+      const { deviceId, manifestUrl, deviceModel, firmwareVersion } = req.body;
+
+      if (!deviceId || typeof deviceId !== 'string') {
+        return res.status(400).json({ error: 'deviceId is required' });
+      }
+
+      if (!manifestUrl || typeof manifestUrl !== 'string') {
+        return res.status(400).json({ error: 'manifestUrl is required' });
+      }
+
+      if (!deviceModel || typeof deviceModel !== 'string') {
+        return res.status(400).json({ error: 'deviceModel is required' });
+      }
+
+      if (!firmwareVersion || typeof firmwareVersion !== 'string') {
+        return res.status(400).json({ error: 'firmwareVersion is required' });
+      }
+
+      // Validate URL format
+      try {
+        new URL(manifestUrl);
+      } catch {
+        return res.status(400).json({ error: 'Invalid manifestUrl format' });
+      }
+
+      const deviceConfig = await firmwareService.getDeviceConfig(
+        deviceModel,
+        firmwareVersion,
+        deviceId
+      );
+
+      if (deviceConfig.configSource !== 'entities') {
+        return res.status(409).json({
+          error: 'Device build config not available. Firmware updates are disabled to prevent mismatched installs.',
+          deviceConfig,
+        });
+      }
+
+      logger.info({ deviceId, manifestUrl }, 'Preparing firmware');
+
+      const result = await firmwareService.prepareFirmwareForDevice(deviceId, manifestUrl);
+
+      res.json({
+        success: true,
+        deviceId: result.deviceId,
+        token: result.token,
+        version: result.version,
+        localManifestUrl: result.localManifestUrl,
+        releaseSummary: result.releaseSummary,
+        releaseUrl: result.releaseUrl,
+      });
+    } catch (error) {
+      logger.error({ error }, 'Failed to prepare firmware');
+      res.status(500).json({
+        error: 'Failed to prepare firmware',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  });
+
+  /**
+   * POST /api/firmware/update/:deviceId
+   * Trigger a device to update using the prepared firmware
+   * Body: { token: string }
+   */
+  router.post('/update/:deviceId', async (req, res) => {
+    try {
+      const { deviceId } = req.params;
+      const { token } = req.body;
+
+      if (!token || typeof token !== 'string') {
+        return res.status(400).json({ error: 'token is required' });
+      }
+
+      // Verify the cache entry exists
+      const entry = firmwareStorage.getCacheEntry(deviceId, token);
+      if (!entry) {
+        return res.status(404).json({ error: 'Firmware cache entry not found' });
+      }
+
+      const updateService = deviceEntityService.getService(deviceId, 'setUpdateManifest');
+      if (!updateService) {
+        return res.status(409).json({
+          error: 'Firmware update service not mapped. Run entity discovery to sync device entities.',
+          code: 'SERVICE_NOT_MAPPED',
+          serviceKey: 'setUpdateManifest',
+        });
+      }
+
+      const lanIp = firmwareService.getLanIp();
+      const localManifestUrl = `http://${lanIp}:${deps.config.lanPort}/fw/${deviceId}/${token}/manifest.json`;
+
+      logger.info({ deviceId, token, localManifestUrl }, 'Triggering device update');
+
+      // Call the ESPHome service to set manifest URL and trigger update
+      await firmwareService.triggerDeviceUpdate(deviceId, localManifestUrl);
+
+      res.json({
+        success: true,
+        deviceId,
+        localManifestUrl,
+        version: entry.version,
+      });
+    } catch (error) {
+      logger.error({ error }, 'Failed to trigger device update');
+      res.status(500).json({
+        error: 'Failed to trigger device update',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  });
+
+  /**
+   * GET /api/firmware/update-status/:deviceId
+   * Get the update entity state for a device
+   */
+  router.get('/update-status/:deviceId', async (req, res) => {
+    try {
+      if (!deps.readTransport) {
+        return res.status(503).json({ error: 'Read transport not available' });
+      }
+
+      const { deviceId } = req.params;
+      const mapping = deviceEntityService.getMapping(deviceId);
+      if (!mapping) {
+        return res.status(404).json({
+          error: 'Device mapping not found',
+          code: 'MAPPING_NOT_FOUND',
+        });
+      }
+
+      const updateEntityId = deviceEntityService.getEntityId(deviceId, 'firmwareUpdateEntity');
+      if (!updateEntityId) {
+        return res.status(404).json({
+          error: 'Firmware update entity not mapped',
+          code: 'ENTITY_NOT_FOUND',
+          entityKey: 'firmwareUpdateEntity',
+        });
+      }
+
+      const state = await deps.readTransport.getState(updateEntityId);
+      if (!state) {
+        return res.status(503).json({ error: 'Update entity state unavailable' });
+      }
+
+      res.json({
+        entityId: updateEntityId,
+        name: null,
+        state: state.state,
+        attributes: state.attributes,
+        lastChanged: state.last_changed,
+        lastUpdated: state.last_updated,
+      });
+    } catch (error) {
+      logger.error({ error }, 'Failed to fetch update entity status');
+      res.status(500).json({ error: 'Failed to fetch update status' });
+    }
+  });
+
+  /**
+   * GET /api/firmware/cache
+   * List all cached firmware entries
+   */
+  router.get('/cache', (_req, res) => {
+    try {
+      const entries = firmwareService.getCachedFirmware();
+      res.json({
+        entries: entries.map((e) => ({
+          deviceId: e.deviceId,
+          token: e.token,
+          version: e.version,
+          originalManifestUrl: e.originalManifestUrl,
+          cachedAt: e.cachedAt,
+          binaryCount: e.binaryPaths.length,
+        })),
+      });
+    } catch (error) {
+      logger.error({ error }, 'Failed to list firmware cache');
+      res.status(500).json({ error: 'Failed to list firmware cache' });
+    }
+  });
+
+  /**
+   * GET /api/firmware/cache/:deviceId
+   * List cached firmware for a specific device
+   */
+  router.get('/cache/:deviceId', (req, res) => {
+    try {
+      const { deviceId } = req.params;
+      const entries = firmwareService.getDeviceCachedFirmware(deviceId);
+      res.json({
+        deviceId,
+        entries: entries.map((e) => ({
+          token: e.token,
+          version: e.version,
+          originalManifestUrl: e.originalManifestUrl,
+          cachedAt: e.cachedAt,
+          binaryCount: e.binaryPaths.length,
+        })),
+      });
+    } catch (error) {
+      logger.error({ error }, 'Failed to list device firmware cache');
+      res.status(500).json({ error: 'Failed to list device firmware cache' });
+    }
+  });
+
+  /**
+   * DELETE /api/firmware/cache/:deviceId/:token
+   * Delete a specific cached firmware entry
+   */
+  router.delete('/cache/:deviceId/:token', (req, res) => {
+    try {
+      const { deviceId, token } = req.params;
+      const deleted = firmwareService.deleteCachedFirmware(deviceId, token);
+
+      if (!deleted) {
+        return res.status(404).json({ error: 'Cache entry not found' });
+      }
+
+      res.json({ success: true, deviceId, token });
+    } catch (error) {
+      logger.error({ error }, 'Failed to delete firmware cache entry');
+      res.status(500).json({ error: 'Failed to delete firmware cache entry' });
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Auto-Update System Endpoints
+  // ─────────────────────────────────────────────────────────────────
+
+  /**
+   * GET /api/firmware/index
+   * Fetch all firmware indexes from configured URLs
+   */
+  router.get('/index', async (_req, res) => {
+    try {
+      const indexes = await firmwareService.fetchAllFirmwareIndexes();
+      res.json({
+        indexes,
+        count: indexes.length,
+        fetchedAt: new Date().toISOString(),
+      });
+    } catch (error) {
+      logger.error({ error }, 'Failed to fetch firmware indexes');
+      res.status(500).json({ error: 'Failed to fetch firmware indexes' });
+    }
+  });
+
+  /**
+   * POST /api/firmware/index/refresh
+   * Clear the firmware index cache and refetch
+   */
+  router.post('/index/refresh', async (_req, res) => {
+    try {
+      firmwareService.clearIndexCache();
+      const indexes = await firmwareService.fetchAllFirmwareIndexes();
+      res.json({
+        indexes,
+        count: indexes.length,
+        fetchedAt: new Date().toISOString(),
+      });
+    } catch (error) {
+      logger.error({ error }, 'Failed to refresh firmware indexes');
+      res.status(500).json({ error: 'Failed to refresh firmware indexes' });
+    }
+  });
+
+  /**
+   * POST /api/firmware/device-config
+   * Get device configuration by reading firmware info entities
+   * Body: { deviceModel: string, firmwareVersion: string, deviceId: string }
+   */
+  router.post('/device-config', async (req, res) => {
+    try {
+      const { deviceModel, firmwareVersion, deviceId } = req.body;
+
+      if (!deviceModel || typeof deviceModel !== 'string') {
+        return res.status(400).json({ error: 'deviceModel is required' });
+      }
+
+      if (!firmwareVersion || typeof firmwareVersion !== 'string') {
+        return res.status(400).json({ error: 'firmwareVersion is required' });
+      }
+
+      if (!deviceId || typeof deviceId !== 'string') {
+        return res.status(400).json({ error: 'deviceId is required' });
+      }
+
+      const config = await firmwareService.getDeviceConfig(deviceModel, firmwareVersion, deviceId);
+      res.json({ config });
+    } catch (error) {
+      logger.error({ error }, 'Failed to get device config');
+      res.status(500).json({
+        error: 'Failed to get device config',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  });
+
+  /**
+   * POST /api/firmware/available
+   * Get available firmware updates for a device
+   * Body: { deviceModel: string, currentVersion: string, deviceId: string }
+   */
+  router.post('/available', async (req, res) => {
+    try {
+      const { deviceModel, currentVersion, deviceId } = req.body;
+
+      if (!deviceModel || typeof deviceModel !== 'string') {
+        return res.status(400).json({ error: 'deviceModel is required' });
+      }
+
+      if (!currentVersion || typeof currentVersion !== 'string') {
+        return res.status(400).json({ error: 'currentVersion is required' });
+      }
+
+      if (!deviceId || typeof deviceId !== 'string') {
+        return res.status(400).json({ error: 'deviceId is required' });
+      }
+
+      const deviceConfig = await firmwareService.getDeviceConfig(deviceModel, currentVersion, deviceId);
+
+      if (deviceConfig.configSource !== 'entities') {
+        return res.status(409).json({
+          error: 'Device build config not available. Firmware updates are disabled to prevent mismatched installs.',
+          deviceConfig,
+        });
+      }
+
+      const updates = await firmwareService.getAvailableUpdates(deviceConfig, currentVersion);
+      res.json({
+        updates,
+        hasUpdates: updates.length > 0,
+      });
+    } catch (error) {
+      logger.error({ error }, 'Failed to get available updates');
+      res.status(500).json({
+        error: 'Failed to get available updates',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  });
+
+  /**
+   * POST /api/firmware/validate
+   * Validate firmware compatibility with a device
+   * Body: { deviceConfig: DeviceConfig, firmwareVariantId: string, productId: string }
+   */
+  router.post('/validate', async (req, res) => {
+    try {
+      const { deviceConfig, firmwareVariantId, productId } = req.body;
+
+      if (!deviceConfig || typeof deviceConfig !== 'object') {
+        return res.status(400).json({ error: 'deviceConfig is required' });
+      }
+
+      if (!firmwareVariantId || typeof firmwareVariantId !== 'string') {
+        return res.status(400).json({ error: 'firmwareVariantId is required' });
+      }
+
+      if (!productId || typeof productId !== 'string') {
+        return res.status(400).json({ error: 'productId is required' });
+      }
+
+      // Fetch indexes to find the variant
+      const indexes = await firmwareService.fetchAllFirmwareIndexes();
+      const productIndex = indexes.find((idx) => idx.product.id === productId);
+
+      if (!productIndex) {
+        return res.status(404).json({ error: `Product index not found for ${productId}` });
+      }
+
+      // Find the variant in any firmware release
+      let firmwareVariant = null;
+      for (const firmware of productIndex.firmwares) {
+        const variant = firmware.variants.find((v) => v.id === firmwareVariantId);
+        if (variant) {
+          firmwareVariant = variant;
+          break;
+        }
+      }
+
+      if (!firmwareVariant) {
+        return res.status(404).json({ error: `Firmware variant ${firmwareVariantId} not found` });
+      }
+
+      const validation = firmwareService.validateFirmwareCompatibility(deviceConfig, firmwareVariant);
+      res.json({ validation });
+    } catch (error) {
+      logger.error({ error }, 'Failed to validate firmware');
+      res.status(500).json({
+        error: 'Failed to validate firmware',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  });
+
+  /**
+   * POST /api/firmware/auto-prepare
+   * Auto-detect device config, find matching firmware, and prepare for update
+   * Body: { deviceModel: string, currentVersion: string, deviceId: string }
+   */
+  router.post('/auto-prepare', async (req, res) => {
+    try {
+      const { deviceModel, currentVersion, deviceId } = req.body;
+
+      if (!deviceModel || typeof deviceModel !== 'string') {
+        return res.status(400).json({ error: 'deviceModel is required' });
+      }
+
+      if (!currentVersion || typeof currentVersion !== 'string') {
+        return res.status(400).json({ error: 'currentVersion is required' });
+      }
+
+      if (!deviceId || typeof deviceId !== 'string') {
+        return res.status(400).json({ error: 'deviceId is required' });
+      }
+
+      // Get device config
+      const deviceConfig = await firmwareService.getDeviceConfig(deviceModel, currentVersion, deviceId);
+
+      if (deviceConfig.configSource !== 'entities') {
+        return res.status(409).json({
+          error: 'Device build config not available. Firmware updates are disabled to prevent mismatched installs.',
+          deviceConfig,
+        });
+      }
+
+      // Fetch indexes and find matching firmware
+      const indexes = await firmwareService.fetchAllFirmwareIndexes();
+      const matchingVariant = firmwareService.findMatchingFirmware(deviceConfig, indexes);
+
+      if (!matchingVariant) {
+        return res.status(404).json({
+          error: 'No matching firmware found',
+          deviceConfig,
+        });
+      }
+
+      // Find the product index to get the base URL
+      const productIndex = indexes.find((idx) => idx.product.id === deviceConfig.model);
+      if (!productIndex) {
+        return res.status(404).json({ error: 'Product index not found' });
+      }
+
+      // Construct the full manifest URL
+      // The manifestUrl in variant is relative, so we need to build the full URL
+      const settings = firmwareStorage.getSettings();
+      const baseUrl = settings.firmwareIndexUrls?.[0]?.replace('/firmware-index.json', '') ||
+                     DEFAULT_FIRMWARE_INDEX_URLS[deviceConfig.model]?.replace('/firmware-index.json', '');
+
+      if (!baseUrl) {
+        return res.status(500).json({ error: 'Could not determine firmware base URL' });
+      }
+
+      const fullManifestUrl = `${baseUrl}/${matchingVariant.manifestUrl}`;
+
+      // Validate compatibility
+      const validation = firmwareService.validateFirmwareCompatibility(deviceConfig, matchingVariant);
+
+      if (!validation.valid) {
+        return res.status(400).json({
+          error: 'Firmware compatibility check failed',
+          validation,
+          deviceConfig,
+          matchingVariant,
+        });
+      }
+
+      // Prepare the firmware
+      const prepared = await firmwareService.prepareFirmwareForDevice(deviceId, fullManifestUrl);
+
+      res.json({
+        success: true,
+        deviceConfig,
+        matchingVariant,
+        validation,
+        prepared,
+        newVersion: productIndex.product.latestVersion,
+      });
+    } catch (error) {
+      logger.error({ error }, 'Failed to auto-prepare firmware');
+      res.status(500).json({
+        error: 'Failed to auto-prepare firmware',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  });
+
+  return router;
+};

--- a/everything-presence-mmwave-configurator/backend/src/server.ts
+++ b/everything-presence-mmwave-configurator/backend/src/server.ts
@@ -14,6 +14,7 @@ import { createLiveRouter } from './routes/live';
 import { createCustomAssetsRouter } from './routes/customAssets';
 import { createHeatmapRouter } from './routes/heatmap';
 import { createDeviceMappingsRouter } from './routes/deviceMappings';
+import { createFirmwareRouter } from './routes/firmware';
 import type { IHaReadTransport } from './ha/readTransport';
 import type { IHaWriteClient } from './ha/writeClient';
 import type { DeviceProfileLoader } from './domain/deviceProfiles';
@@ -78,6 +79,13 @@ export const createServer = (config: AppConfig, deps?: ServerDependencies): expr
       profileLoader: deps.profileLoader,
     }));
     app.use('/api/live', createLiveRouter(deps.readTransport, deps.writeClient, deps.profileLoader));
+
+    // Firmware update routes
+    app.use('/api/firmware', createFirmwareRouter({
+      config: config.firmware,
+      writeClient: deps.writeClient,
+      readTransport: deps.readTransport,
+    }));
   }
 
   app.use('/api/health', (_req, res) => {

--- a/everything-presence-mmwave-configurator/backend/src/types/firmware.ts
+++ b/everything-presence-mmwave-configurator/backend/src/types/firmware.ts
@@ -1,0 +1,133 @@
+/**
+ * Firmware-related type definitions for the auto-update system
+ */
+
+/**
+ * How the device configuration was determined
+ * - 'entities': Read from device firmware entities (reliable)
+ * - 'inferred': Guessed from device model/version (unreliable, device needs firmware update first)
+ */
+export type ConfigSource = 'entities' | 'inferred';
+
+/**
+ * Device configuration as reported by firmware
+ * Maps to the device_config substitution in ESPHome YAML files
+ */
+export interface DeviceConfig {
+  model: 'everything-presence-one' | 'everything-presence-lite' | 'everything-presence-pro';
+  ethernet_enabled: boolean;
+  co2_enabled: boolean;
+  bluetooth_enabled: boolean;
+  board_revision: string;
+  sensor_variant: string;
+  firmware_channel: 'stable' | 'beta' | 'smartthings';
+  /** How the config was determined - 'entities' means read from device, 'inferred' means guessed */
+  configSource: ConfigSource;
+}
+
+/**
+ * Firmware variant requirements - must match device config for installation
+ */
+export interface FirmwareRequirements {
+  model: string;
+  ethernet_enabled: boolean;
+  co2_enabled: boolean;
+  bluetooth_enabled: boolean;
+  board_revision: string;
+  sensor_variant: string;
+  firmware_channel: string;
+}
+
+/**
+ * A specific firmware variant (e.g., EPL with CO2 and BLE)
+ */
+export interface FirmwareVariant {
+  id: string;
+  manifestUrl: string;
+  requirements: FirmwareRequirements;
+}
+
+/**
+ * A firmware release containing multiple variants
+ */
+export interface FirmwareRelease {
+  version: string;
+  channel: 'stable' | 'beta';
+  releaseDate: string;
+  releaseNotes: string;
+  minPreviousVersion?: string;
+  variants: FirmwareVariant[];
+}
+
+/**
+ * Migration definition for handling breaking changes
+ */
+export interface FirmwareMigration {
+  id: string;
+  fromVersion: string;  // semver range like "<2.0.0"
+  toVersion: string;    // semver range like ">=2.0.0"
+  description: string;
+  backupRequired: boolean;
+  handler: string;  // Handler function name
+}
+
+/**
+ * Product information in firmware index
+ */
+export interface FirmwareProduct {
+  id: string;
+  displayName: string;
+  latestVersion: string;
+}
+
+/**
+ * Firmware index for a single product (fetched from GitHub Pages)
+ */
+export interface FirmwareIndex {
+  schemaVersion: string;
+  generatedAt: string;
+  product: FirmwareProduct;
+  firmwares: FirmwareRelease[];
+  migrations: FirmwareMigration[];
+}
+
+/**
+ * Available update for a device
+ */
+export interface AvailableUpdate {
+  currentVersion: string;
+  newVersion: string;
+  channel: string;
+  releaseNotes: string;
+  variant: FirmwareVariant;
+  migration?: FirmwareMigration;
+}
+
+/**
+ * Result of firmware compatibility validation
+ */
+export interface FirmwareValidation {
+  valid: boolean;
+  hardBlocks: ValidationIssue[];  // Cannot proceed
+  warnings: ValidationIssue[];    // Can proceed with confirmation
+}
+
+/**
+ * A single validation issue
+ */
+export interface ValidationIssue {
+  field: string;
+  deviceValue: unknown;
+  firmwareValue: unknown;
+  message: string;
+  severity: 'hard_block' | 'warning';
+}
+
+/**
+ * Default firmware index URLs for each product
+ */
+export const DEFAULT_FIRMWARE_INDEX_URLS: Record<string, string> = {
+  'everything-presence-one': 'https://everythingsmarthome.github.io/everything-presence-one/firmware-index.json',
+  'everything-presence-lite': 'https://everythingsmarthome.github.io/everything-presence-lite/firmware-index.json',
+  'everything-presence-pro': 'https://everythingsmarthome.github.io/everything-presence-pro/firmware-index.json',
+};

--- a/everything-presence-mmwave-configurator/config.yaml
+++ b/everything-presence-mmwave-configurator/config.yaml
@@ -16,18 +16,24 @@ panel_title: Zone Configurator
 watchdog: "http://[HOST]:[PORT:3000]/api/health"
 ports:
   3000/tcp: null
+  38080/tcp: 38080
 ports_description:
   3000/tcp: Optional direct access (ingress preferred)
+  38080/tcp: LAN firmware server for device OTA updates (configurable in add-on settings)
 homeassistant_api: true
 auth_api: true
 hassio_api: true
+host_network: true
 stdin: true
 stdin_open: true
 init: false
 environment:
   PORT: "3000"
+  FIRMWARE_LAN_PORT: "38080"
 map:
   - config:rw
   - share:rw
-options: {}
-schema: {}
+options:
+  firmware_lan_port: 38080
+schema:
+  firmware_lan_port: port

--- a/everything-presence-mmwave-configurator/config/device-profiles/everything_presence_lite.json
+++ b/everything-presence-mmwave-configurator/config/device-profiles/everything_presence_lite.json
@@ -1,6 +1,6 @@
 {
   "id": "everything_presence_lite",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.1",
   "label": "Everything Presence Lite",
   "model": "Everything Presence Lite",
   "manufacturer": "EverythingSmartTechnology",
@@ -27,6 +27,16 @@
     "maxRangeMeters": 6,
     "fieldOfViewDegrees": 120
   },
+  "services": {
+    "getBuildFlags": {
+      "domain": "esphome",
+      "template": "${name}_get_build_flags"
+    },
+    "setUpdateManifest": {
+      "domain": "esphome",
+      "template": "${name}_set_update_manifest"
+    }
+  },
   "entities": {
     "presence": {
       "template": "binary_sensor.${name}_occupancy",
@@ -40,6 +50,13 @@
       "category": "sensor",
       "subcategory": "environment",
       "label": "CO2",
+      "required": false
+    },
+    "firmwareUpdate": {
+      "template": "update.${name}_everything_presence_lite_firmware",
+      "category": "sensor",
+      "subcategory": "firmware",
+      "label": "Firmware Update",
       "required": false
     },
     "maxDistance": {
@@ -745,6 +762,26 @@
       "category": "sensor",
       "subcategory": "zoneTargetCount",
       "zoneIndex": 4,
+      "required": false
+    },
+    "firmwareBle": {
+      "template": "select.${name}_bluetooth_proxy",
+      "category": "setting",
+      "group": "Firmware Info",
+      "label": "Bluetooth Proxy",
+      "controlType": "select",
+      "options": ["Disabled", "Enabled"],
+      "description": "Indicates if Bluetooth proxy is enabled in firmware build",
+      "required": false
+    },
+    "firmwareCo2": {
+      "template": "select.${name}_co2_sensor",
+      "category": "setting",
+      "group": "Firmware Info",
+      "label": "CO2 Sensor",
+      "controlType": "select",
+      "options": ["Disabled", "Enabled"],
+      "description": "Indicates if CO2 sensor is enabled in firmware build",
       "required": false
     }
   },

--- a/everything-presence-mmwave-configurator/config/device-profiles/everything_presence_one.json
+++ b/everything-presence-mmwave-configurator/config/device-profiles/everything_presence_one.json
@@ -1,6 +1,6 @@
 {
   "id": "everything_presence_one",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.1",
   "label": "Everything Presence One",
   "model": "Everything Presence One",
   "manufacturer": "EverythingSmartTechnology",
@@ -24,6 +24,16 @@
     "maxZones": 0,
     "maxRangeMeters": 25,
     "fieldOfViewDegrees": 120
+  },
+  "services": {
+    "getBuildFlags": {
+      "domain": "esphome",
+      "template": "${name}_get_build_flags"
+    },
+    "setUpdateManifest": {
+      "domain": "esphome",
+      "template": "${name}_set_update_manifest"
+    }
   },
   "entities": {
     "presence": {
@@ -73,6 +83,13 @@
       "category": "sensor",
       "subcategory": "environment",
       "label": "CO2",
+      "required": false
+    },
+    "firmwareUpdate": {
+      "template": "update.${name}_everything_presence_one_firmware",
+      "category": "sensor",
+      "subcategory": "firmware",
+      "label": "Firmware Update",
       "required": false
     },
     "distance": {
@@ -294,6 +311,26 @@
       "group": "Advanced",
       "label": "Update Rate",
       "controlType": "select",
+      "required": false
+    },
+    "firmwareBle": {
+      "template": "select.${name}_bluetooth_proxy",
+      "category": "setting",
+      "group": "Firmware Info",
+      "label": "Bluetooth Proxy",
+      "controlType": "select",
+      "options": ["Disabled", "Enabled"],
+      "description": "Indicates if Bluetooth proxy is enabled in firmware build",
+      "required": false
+    },
+    "firmwareCo2": {
+      "template": "select.${name}_co2_sensor",
+      "category": "setting",
+      "group": "Firmware Info",
+      "label": "CO2 Sensor",
+      "controlType": "select",
+      "options": ["Disabled", "Enabled"],
+      "description": "Indicates if CO2 sensor is enabled in firmware build",
       "required": false
     }
   },

--- a/everything-presence-mmwave-configurator/config/device-profiles/everything_presence_pro.json
+++ b/everything-presence-mmwave-configurator/config/device-profiles/everything_presence_pro.json
@@ -1,6 +1,6 @@
 {
   "id": "everything_presence_pro",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.1",
   "label": "Everything Presence Pro",
   "model": "Everything Presence Pro",
   "manufacturer": "EverythingSmartTechnology",
@@ -27,6 +27,16 @@
     "maxRangeMeters": 6,
     "fieldOfViewDegrees": 120
   },
+  "services": {
+    "getBuildFlags": {
+      "domain": "esphome",
+      "template": "${name}_get_build_flags"
+    },
+    "setUpdateManifest": {
+      "domain": "esphome",
+      "template": "${name}_set_update_manifest"
+    }
+  },
   "entities": {
     "presence": {
       "template": "binary_sensor.${name}_occupancy",
@@ -40,6 +50,13 @@
       "category": "sensor",
       "subcategory": "environment",
       "label": "CO2",
+      "required": false
+    },
+    "firmwareUpdate": {
+      "template": "update.${name}_firmware_update",
+      "category": "sensor",
+      "subcategory": "firmware",
+      "label": "Firmware Update",
       "required": false
     },
     "maxDistance": {
@@ -579,6 +596,36 @@
       "subcategory": "zoneTargetCount",
       "zoneType": "regular",
       "zoneIndex": 4,
+      "required": false
+    },
+    "firmwareBle": {
+      "template": "select.${name}_bluetooth_proxy",
+      "category": "setting",
+      "group": "Firmware Info",
+      "label": "Bluetooth Proxy",
+      "controlType": "select",
+      "options": ["Disabled", "Enabled"],
+      "description": "Indicates if Bluetooth proxy is enabled in firmware build",
+      "required": false
+    },
+    "firmwareCo2": {
+      "template": "select.${name}_co2_sensor",
+      "category": "setting",
+      "group": "Firmware Info",
+      "label": "CO2 Sensor",
+      "controlType": "select",
+      "options": ["Disabled", "Enabled"],
+      "description": "Indicates if CO2 sensor is enabled in firmware build",
+      "required": false
+    },
+    "firmwareNetwork": {
+      "template": "select.${name}_network_type",
+      "category": "setting",
+      "group": "Firmware Info",
+      "label": "Network Type",
+      "controlType": "select",
+      "options": ["WiFi", "Ethernet"],
+      "description": "Indicates network type configured in firmware build",
       "required": false
     }
   },

--- a/everything-presence-mmwave-configurator/frontend/src/api/client.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/api/client.ts
@@ -1,4 +1,24 @@
-import { DiscoveredDevice, DeviceProfile, ZoneAvailabilityResponse, CustomFloorMaterial, CustomFurnitureType, HeatmapResponse, EntityMappings } from './types';
+import {
+  DiscoveredDevice,
+  DeviceProfile,
+  ZoneAvailabilityResponse,
+  CustomFloorMaterial,
+  CustomFurnitureType,
+  HeatmapResponse,
+  EntityMappings,
+  FirmwareSettingsResponse,
+  FirmwareSettings,
+  PreparedFirmwareResponse,
+  FirmwareUpdateResponse,
+  CachedFirmwareEntry,
+  FirmwareIndexResponse,
+  DeviceConfigResponse,
+  AvailableUpdatesResponse,
+  FirmwareValidationResponse,
+  AutoPrepareResponse,
+  DeviceConfig,
+  FirmwareUpdateEntityStatus,
+} from './types';
 import { AppSettings } from './types';
 
 const handle = async <T>(res: Response): Promise<T> => {
@@ -148,4 +168,147 @@ export const fetchHeatmap = async (
   }
   const res = await fetch(ingressAware(`api/devices/${deviceId}/heatmap?${params}`));
   return handle<HeatmapResponse>(res);
+};
+
+// ==================== FIRMWARE UPDATE ====================
+
+export const fetchFirmwareSettings = async (): Promise<FirmwareSettingsResponse> => {
+  const res = await fetch(ingressAware('api/firmware/settings'));
+  return handle<FirmwareSettingsResponse>(res);
+};
+
+export const updateFirmwareSettings = async (
+  settings: Partial<FirmwareSettings>
+): Promise<FirmwareSettingsResponse> => {
+  const res = await fetch(ingressAware('api/firmware/settings'), {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(settings),
+  });
+  return handle<FirmwareSettingsResponse>(res);
+};
+
+export const prepareFirmware = async (
+  deviceId: string,
+  manifestUrl: string,
+  deviceInfo: { deviceModel: string; firmwareVersion: string }
+): Promise<PreparedFirmwareResponse> => {
+  const res = await fetch(ingressAware('api/firmware/prepare'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      deviceId,
+      manifestUrl,
+      deviceModel: deviceInfo.deviceModel,
+      firmwareVersion: deviceInfo.firmwareVersion,
+    }),
+  });
+  return handle<PreparedFirmwareResponse>(res);
+};
+
+export const triggerFirmwareUpdate = async (
+  deviceId: string,
+  token: string
+): Promise<FirmwareUpdateResponse> => {
+  const res = await fetch(ingressAware(`api/firmware/update/${deviceId}`), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token }),
+  });
+  return handle<FirmwareUpdateResponse>(res);
+};
+
+export const fetchFirmwareCache = async (): Promise<{ entries: CachedFirmwareEntry[] }> => {
+  const res = await fetch(ingressAware('api/firmware/cache'));
+  return handle<{ entries: CachedFirmwareEntry[] }>(res);
+};
+
+export const fetchDeviceFirmwareCache = async (
+  deviceId: string
+): Promise<{ deviceId: string; entries: CachedFirmwareEntry[] }> => {
+  const res = await fetch(ingressAware(`api/firmware/cache/${deviceId}`));
+  return handle<{ deviceId: string; entries: CachedFirmwareEntry[] }>(res);
+};
+
+export const deleteFirmwareCacheEntry = async (
+  deviceId: string,
+  token: string
+): Promise<{ success: boolean }> => {
+  const res = await fetch(ingressAware(`api/firmware/cache/${deviceId}/${token}`), {
+    method: 'DELETE',
+  });
+  return handle<{ success: boolean }>(res);
+};
+
+export const fetchFirmwareUpdateStatus = async (
+  deviceId: string
+): Promise<FirmwareUpdateEntityStatus> => {
+  const res = await fetch(ingressAware(`api/firmware/update-status/${deviceId}`));
+  return handle<FirmwareUpdateEntityStatus>(res);
+};
+
+// ==================== AUTO-UPDATE SYSTEM ====================
+
+export const fetchFirmwareIndex = async (): Promise<FirmwareIndexResponse> => {
+  const res = await fetch(ingressAware('api/firmware/index'));
+  return handle<FirmwareIndexResponse>(res);
+};
+
+export const refreshFirmwareIndex = async (): Promise<FirmwareIndexResponse> => {
+  const res = await fetch(ingressAware('api/firmware/index/refresh'), {
+    method: 'POST',
+  });
+  return handle<FirmwareIndexResponse>(res);
+};
+
+export const getDeviceConfig = async (
+  deviceModel: string,
+  firmwareVersion: string,
+  deviceId: string
+): Promise<DeviceConfigResponse> => {
+  const res = await fetch(ingressAware('api/firmware/device-config'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ deviceModel, firmwareVersion, deviceId }),
+  });
+  return handle<DeviceConfigResponse>(res);
+};
+
+export const getAvailableUpdates = async (
+  deviceModel: string,
+  currentVersion: string,
+  deviceId: string
+): Promise<AvailableUpdatesResponse> => {
+  const res = await fetch(ingressAware('api/firmware/available'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ deviceModel, currentVersion, deviceId }),
+  });
+  return handle<AvailableUpdatesResponse>(res);
+};
+
+export const validateFirmware = async (
+  deviceConfig: DeviceConfig,
+  firmwareVariantId: string,
+  productId: string
+): Promise<FirmwareValidationResponse> => {
+  const res = await fetch(ingressAware('api/firmware/validate'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ deviceConfig, firmwareVariantId, productId }),
+  });
+  return handle<FirmwareValidationResponse>(res);
+};
+
+export const autoPrepare = async (
+  deviceModel: string,
+  currentVersion: string,
+  deviceId: string
+): Promise<AutoPrepareResponse> => {
+  const res = await fetch(ingressAware('api/firmware/auto-prepare'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ deviceModel, currentVersion, deviceId }),
+  });
+  return handle<AutoPrepareResponse>(res);
 };

--- a/everything-presence-mmwave-configurator/frontend/src/api/entityDiscovery.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/api/entityDiscovery.ts
@@ -202,7 +202,7 @@ export const groupMatchResultsByCategory = (
       groups['Polygon Zones'].push(result);
     } else if (key.includes('trackingTargets')) {
       groups['Tracking Targets'].push(result);
-    } else if (key.includes('max') || key.includes('installation') || key.includes('mode') || key.includes('Enabled')) {
+    } else if (key.includes('max') || key.includes('installation') || key.includes('mode') || key.includes('Enabled') || key.includes('firmwareUpdate')) {
       groups['Configuration'].push(result);
     } else {
       groups['Other'].push(result);
@@ -244,6 +244,7 @@ export const getTemplateKeyLabel = (templateKey: string): string => {
     installationAngleEntity: 'Installation Angle',
     polygonZonesEnabledEntity: 'Polygon Zones Switch',
     trackingTargetCountEntity: 'Tracking Target Count',
+    firmwareUpdateEntity: 'Firmware Update',
     beginX: 'Begin X',
     endX: 'End X',
     beginY: 'Begin Y',

--- a/everything-presence-mmwave-configurator/frontend/src/components/FirmwareUpdateSection.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/FirmwareUpdateSection.tsx
@@ -1,0 +1,1461 @@
+import React, { useState, useEffect, useRef } from 'react';
+import {
+  fetchDevices,
+  fetchFirmwareSettings,
+  updateFirmwareSettings,
+  prepareFirmware,
+  triggerFirmwareUpdate,
+  fetchFirmwareCache,
+  fetchProfiles,
+  deleteFirmwareCacheEntry,
+  getDeviceConfig,
+  getAvailableUpdates,
+  autoPrepare,
+  fetchFirmwareUpdateStatus,
+  ingressAware,
+} from '../api/client';
+import {
+  DiscoveredDevice,
+  CachedFirmwareEntry,
+  FirmwareUpdateStatus,
+  DeviceConfig,
+  AvailableUpdate,
+  FirmwareValidation,
+  FirmwareUpdateEntityStatus,
+  DeviceProfile,
+} from '../api/types';
+import { useDeviceMappings } from '../contexts/DeviceMappingsContext';
+
+interface FirmwareUpdateSectionProps {
+  onError: (error: string) => void;
+  onSuccess: (message: string) => void;
+}
+
+export const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({
+  onError,
+  onSuccess,
+}) => {
+  const buildConfigUnavailableMessage =
+    'Device build config not available. Firmware updates are disabled to prevent mismatched installs.';
+  const onErrorRef = useRef(onError);
+  useEffect(() => {
+    onErrorRef.current = onError;
+  }, [onError]);
+
+  // Devices state
+  const [devices, setDevices] = useState<DiscoveredDevice[]>([]);
+  const [selectedDeviceId, setSelectedDeviceId] = useState<string>('');
+  const [profiles, setProfiles] = useState<DeviceProfile[]>([]);
+
+  // Settings state
+  const [lanIpOverride, setLanIpOverride] = useState('');
+  const [autoDetectedIp, setAutoDetectedIp] = useState('');
+  const [lanPort, setLanPort] = useState(38080);
+  const [cacheKeepCount, setCacheKeepCount] = useState(3);
+
+  // Auto-detection state
+  const [deviceConfig, setDeviceConfig] = useState<DeviceConfig | null>(null);
+  const [availableUpdates, setAvailableUpdates] = useState<AvailableUpdate[]>([]);
+  const [selectedUpdate, setSelectedUpdate] = useState<AvailableUpdate | null>(null);
+  const [validation, setValidation] = useState<FirmwareValidation | null>(null);
+
+  // Update state
+  const [updateStatus, setUpdateStatus] = useState<FirmwareUpdateStatus>('idle');
+  const [preparedToken, setPreparedToken] = useState<string | null>(null);
+  const [preparedVersion, setPreparedVersion] = useState<string | null>(null);
+  const [updateEntityStatus, setUpdateEntityStatus] = useState<FirmwareUpdateEntityStatus | null>(null);
+  const [updateProgress, setUpdateProgress] = useState<number | null>(null);
+  const [updateMonitorMessage, setUpdateMonitorMessage] = useState<string | null>(null);
+  const [monitoringUpdate, setMonitoringUpdate] = useState(false);
+  const [availabilityEntityId, setAvailabilityEntityId] = useState<string | null>(null);
+  const [availabilityState, setAvailabilityState] = useState<string | null>(null);
+  const [rebootConfirmed, setRebootConfirmed] = useState(false);
+  const [updateModalOpen, setUpdateModalOpen] = useState(false);
+  const [showBuildDetails, setShowBuildDetails] = useState(false);
+  const updateMonitorRef = useRef({
+    attempts: 0,
+    seenStart: false,
+    seenInProgress: false,
+    seenRebootDown: false,
+    seenRebootUp: false,
+    rebootStartAt: null as number | null,
+  });
+
+  const { getMapping } = useDeviceMappings();
+
+  // Manual mode state
+  const [showManualMode, setShowManualMode] = useState(false);
+  const [manifestUrl, setManifestUrl] = useState('');
+
+  // Cache state
+  const [cachedEntries, setCachedEntries] = useState<CachedFirmwareEntry[]>([]);
+  const [showCache, setShowCache] = useState(false);
+
+  // Settings visibility
+  const [showSettings, setShowSettings] = useState(false);
+
+  // Loading states
+  const [loading, setLoading] = useState(true);
+  const [savingSettings, setSavingSettings] = useState(false);
+  const [savingCacheSettings, setSavingCacheSettings] = useState(false);
+  const [checkingUpdates, setCheckingUpdates] = useState(false);
+
+  // Load initial data
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [devicesRes, settingsRes, cacheRes, profilesRes] = await Promise.all([
+          fetchDevices(),
+          fetchFirmwareSettings(),
+          fetchFirmwareCache(),
+          fetchProfiles().catch(() => ({ profiles: [] })),
+        ]);
+
+        // Filter to only EP devices
+        const epDevices = devicesRes.devices.filter(
+          (d) =>
+            d.manufacturer?.toLowerCase().includes('everything') ||
+            d.model?.toLowerCase().includes('presence')
+        );
+        setDevices(epDevices);
+        setProfiles(profilesRes.profiles ?? []);
+
+        // Set settings
+        setLanIpOverride(settingsRes.settings.lanIpOverride || '');
+        setAutoDetectedIp(settingsRes.autoDetectedIp);
+        setLanPort(settingsRes.lanPort);
+        setCacheKeepCount(settingsRes.settings.cacheKeepCount ?? 3);
+
+        // Set cache
+        setCachedEntries(cacheRes.entries);
+      } catch (err) {
+        onErrorRef.current(
+          err instanceof Error ? err.message : 'Failed to load firmware settings'
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  // Reset state when device changes
+  const handleDeviceChange = (deviceId: string) => {
+    setSelectedDeviceId(deviceId);
+    setDeviceConfig(null);
+    setAvailableUpdates([]);
+    setSelectedUpdate(null);
+    setValidation(null);
+    setUpdateStatus('idle');
+    setPreparedToken(null);
+    setPreparedVersion(null);
+    setUpdateEntityStatus(null);
+    setUpdateProgress(null);
+    setUpdateMonitorMessage(null);
+    setMonitoringUpdate(false);
+    setAvailabilityEntityId(null);
+    setAvailabilityState(null);
+    setRebootConfirmed(false);
+    setUpdateModalOpen(false);
+    setShowBuildDetails(false);
+    updateMonitorRef.current = {
+      attempts: 0,
+      seenStart: false,
+      seenInProgress: false,
+      seenRebootDown: false,
+      seenRebootUp: false,
+      rebootStartAt: null,
+    };
+  };
+
+  const handleSaveSettings = async () => {
+    setSavingSettings(true);
+    try {
+      const res = await updateFirmwareSettings({
+        lanIpOverride: lanIpOverride || undefined,
+      });
+      setAutoDetectedIp(res.autoDetectedIp);
+      onSuccess('Firmware settings saved');
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Failed to save settings');
+    } finally {
+      setSavingSettings(false);
+    }
+  };
+
+  const handleCheckForUpdates = async () => {
+    const device = devices.find((d) => d.id === selectedDeviceId);
+    if (!device) {
+      onError('Please select a device');
+      return;
+    }
+
+    if (!device.model || !device.firmwareVersion) {
+      onError('Device is missing required information (model or firmware version)');
+      return;
+    }
+
+    setCheckingUpdates(true);
+    setUpdateStatus('checking');
+    setUpdateModalOpen(true);
+    setDeviceConfig(null);
+    setAvailableUpdates([]);
+    setSelectedUpdate(null);
+
+    try {
+      // Get device config via get_build_flags service call
+      const configRes = await getDeviceConfig(
+        device.model,
+        device.firmwareVersion,
+        device.id
+      );
+      setDeviceConfig(configRes.config);
+
+      if (configRes.config.configSource !== 'entities') {
+        onError(buildConfigUnavailableMessage);
+        setUpdateStatus('idle');
+        return;
+      }
+
+      // Get available updates
+      const updatesRes = await getAvailableUpdates(
+        device.model,
+        device.firmwareVersion,
+        device.id
+      );
+      setAvailableUpdates(updatesRes.updates);
+
+      if (updatesRes.hasUpdates) {
+        onSuccess(`Found ${updatesRes.updates.length} available update(s)`);
+      } else {
+        onSuccess('Device is up to date');
+      }
+      setUpdateStatus('idle');
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Failed to check for updates');
+      setUpdateStatus('error');
+    } finally {
+      setCheckingUpdates(false);
+    }
+  };
+
+  const handleManualPrepare = async () => {
+    if (!selectedDeviceId) {
+      onError('Please select a device');
+      return;
+    }
+
+    if (!manifestUrl) {
+      onError('Please enter a firmware manifest URL');
+      return;
+    }
+
+    const device = devices.find((d) => d.id === selectedDeviceId);
+    if (!device || !device.model || !device.firmwareVersion) {
+      onError('Device information incomplete');
+      return;
+    }
+
+    try {
+      let config = deviceConfig;
+      if (!config || config.configSource !== 'entities') {
+        const configRes = await getDeviceConfig(
+          device.model,
+          device.firmwareVersion,
+          device.id
+        );
+        config = configRes.config;
+        setDeviceConfig(configRes.config);
+      }
+
+      if (config.configSource !== 'entities') {
+        onError(buildConfigUnavailableMessage);
+        return;
+      }
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Failed to read device build config');
+      return;
+    }
+
+    try {
+      setUpdateModalOpen(true);
+      setUpdateStatus('preparing');
+      setPreparedToken(null);
+      setPreparedVersion(null);
+
+      setUpdateStatus('downloading');
+      const prepareRes = await prepareFirmware(selectedDeviceId, manifestUrl, {
+        deviceModel: device.model,
+        firmwareVersion: device.firmwareVersion,
+      });
+
+      setPreparedToken(prepareRes.token);
+      setPreparedVersion(prepareRes.version);
+      setUpdateStatus('ready');
+
+      // Refresh cache list
+      const cacheRes = await fetchFirmwareCache();
+      setCachedEntries(cacheRes.entries);
+
+      onSuccess(`Firmware v${prepareRes.version} prepared. Local URL: ${prepareRes.localManifestUrl}`);
+    } catch (err) {
+      setUpdateStatus('error');
+      onError(err instanceof Error ? err.message : 'Failed to prepare firmware');
+    }
+  };
+
+  const triggerUpdateOnDevice = async (token: string) => {
+    if (!selectedDeviceId) {
+      onError('No device selected');
+      return;
+    }
+
+    const device = devices.find((d) => d.id === selectedDeviceId);
+    if (!device) {
+      onError('Device not found');
+      return;
+    }
+
+    const mapping = await getMapping(selectedDeviceId);
+    if (!mapping) {
+      onError('Device mapping not found. Run entity discovery to enable update tracking.');
+      return;
+    }
+
+    const availabilityKeys = [
+      'presenceEntity',
+      'presence',
+      'mmwaveEntity',
+      'mmwave',
+      'pirEntity',
+      'pir',
+      'co2Entity',
+      'co2',
+      'temperatureEntity',
+      'temperature',
+      'humidityEntity',
+      'humidity',
+      'illuminanceEntity',
+      'illuminance',
+    ];
+    const availabilityId = availabilityKeys
+      .map((key) => mapping.mappings[key])
+      .find((value) => typeof value === 'string' && value.trim().length > 0) || null;
+    setAvailabilityEntityId(availabilityId);
+
+    setUpdateStatus('updating');
+    setUpdateProgress(null);
+    setUpdateEntityStatus(null);
+    setUpdateMonitorMessage('Starting firmware update...');
+    setRebootConfirmed(false);
+    updateMonitorRef.current = {
+      attempts: 0,
+      seenStart: false,
+      seenInProgress: false,
+      seenRebootDown: false,
+      seenRebootUp: false,
+      rebootStartAt: null,
+    };
+    await triggerFirmwareUpdate(selectedDeviceId, token);
+
+    setMonitoringUpdate(true);
+    onSuccess('Firmware update started. Monitoring progress...');
+  };
+
+  const handleSaveCacheSettings = async () => {
+    if (!Number.isFinite(cacheKeepCount) || cacheKeepCount < 1) {
+      onError('Cache keep count must be at least 1');
+      return;
+    }
+
+    setSavingCacheSettings(true);
+    try {
+      const res = await updateFirmwareSettings({
+        cacheKeepCount,
+      });
+      setCacheKeepCount(res.settings.cacheKeepCount ?? cacheKeepCount);
+      onSuccess('Cache retention updated');
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Failed to save cache settings');
+    } finally {
+      setSavingCacheSettings(false);
+    }
+  };
+
+  const handleAutoInstall = async () => {
+    const device = devices.find((d) => d.id === selectedDeviceId);
+    if (!device || !device.model || !device.firmwareVersion) {
+      onError('Device information incomplete');
+      return;
+    }
+
+    if (deviceConfig?.configSource !== 'entities') {
+      onError(buildConfigUnavailableMessage);
+      return;
+    }
+
+    try {
+      setUpdateModalOpen(true);
+      setUpdateStatus('preparing');
+      setPreparedToken(null);
+      setPreparedVersion(null);
+      setValidation(null);
+
+      setUpdateStatus('downloading');
+      const res = await autoPrepare(
+        device.model,
+        device.firmwareVersion,
+        device.id
+      );
+
+      setPreparedToken(res.prepared.token);
+      setPreparedVersion(res.newVersion);
+      setValidation(res.validation);
+      setUpdateStatus('ready');
+
+      const cacheRes = await fetchFirmwareCache();
+      setCachedEntries(cacheRes.entries);
+
+      await triggerUpdateOnDevice(res.prepared.token);
+    } catch (err) {
+      setUpdateStatus('error');
+      onError(err instanceof Error ? err.message : 'Failed to install firmware');
+    }
+  };
+
+  const handleTriggerUpdate = async () => {
+    if (!preparedToken) {
+      onError('No prepared firmware available');
+      return;
+    }
+
+    try {
+      setUpdateModalOpen(true);
+      await triggerUpdateOnDevice(preparedToken);
+    } catch (err) {
+      setUpdateStatus('error');
+      onError(err instanceof Error ? err.message : 'Failed to trigger update');
+    }
+  };
+
+  const handleInstallCachedEntry = async (entry: CachedFirmwareEntry) => {
+    if (!selectedDeviceId || selectedDeviceId !== entry.deviceId) {
+      onError('Select the matching device before installing cached firmware.');
+      return;
+    }
+
+    const device = devices.find((d) => d.id === selectedDeviceId);
+    if (!device || !device.model || !device.firmwareVersion) {
+      onError('Device information incomplete');
+      return;
+    }
+
+    try {
+      let config = deviceConfig;
+      if (!config || config.configSource !== 'entities') {
+        const configRes = await getDeviceConfig(
+          device.model,
+          device.firmwareVersion,
+          device.id
+        );
+        config = configRes.config;
+        setDeviceConfig(configRes.config);
+      }
+
+      if (config.configSource !== 'entities') {
+        onError(buildConfigUnavailableMessage);
+        return;
+      }
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Failed to read device build config');
+      return;
+    }
+
+    try {
+      setPreparedToken(entry.token);
+      setPreparedVersion(entry.version);
+      setUpdateModalOpen(true);
+      await triggerUpdateOnDevice(entry.token);
+    } catch (err) {
+      setUpdateStatus('error');
+      onError(err instanceof Error ? err.message : 'Failed to trigger cached firmware update');
+    }
+  };
+
+  const handleDeleteCacheEntry = async (deviceId: string, token: string) => {
+    if (!confirm('Delete this cached firmware?')) return;
+
+    try {
+      await deleteFirmwareCacheEntry(deviceId, token);
+      setCachedEntries((prev) =>
+        prev.filter((e) => !(e.deviceId === deviceId && e.token === token))
+      );
+      onSuccess('Cache entry deleted');
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Failed to delete cache entry');
+    }
+  };
+
+  const selectedDevice = devices.find((d) => d.id === selectedDeviceId);
+  const effectiveLanIp = lanIpOverride || autoDetectedIp;
+  const updatesBlocked = deviceConfig?.configSource === 'inferred';
+  const updatesBlockedMessage = buildConfigUnavailableMessage;
+  const modalLocked = ['checking', 'preparing', 'downloading', 'updating'].includes(updateStatus);
+  const showFirmwareModal = updateModalOpen || updateStatus === 'updating';
+  const canInstall =
+    updateStatus === 'ready' && preparedToken && deviceConfig?.configSource === 'entities';
+  const configStatus = !selectedDeviceId
+    ? 'No device selected'
+    : deviceConfig
+    ? deviceConfig.configSource === 'entities'
+      ? 'Config verified'
+      : 'Config unavailable'
+    : 'Config not checked';
+  const configStatusClass = !selectedDeviceId
+    ? 'border-slate-600/60 bg-slate-800/60 text-slate-400'
+    : deviceConfig?.configSource === 'entities'
+    ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200'
+    : 'border-amber-500/40 bg-amber-500/10 text-amber-200';
+  const updateInstalledVersion =
+    typeof updateEntityStatus?.attributes?.installed_version === 'string'
+      ? updateEntityStatus.attributes.installed_version
+      : null;
+
+  const parseProgress = (attributes: Record<string, unknown>): number | null => {
+    const raw =
+      attributes.progress ??
+      attributes.percentage ??
+      attributes.update_percentage ??
+      attributes.update_progress ??
+      attributes.percent;
+
+    if (typeof raw === 'number') {
+      return raw <= 1 ? Math.round(raw * 100) : Math.round(raw);
+    }
+
+    if (typeof raw === 'string') {
+      const match = raw.match(/(\d+(\.\d+)?)/);
+      if (match) {
+        const value = Number.parseFloat(match[1]);
+        return value <= 1 ? Math.round(value * 100) : Math.round(value);
+      }
+    }
+
+    return null;
+  };
+
+  const isInProgress = (attributes: Record<string, unknown>): boolean => {
+    const raw = attributes.in_progress;
+    if (typeof raw === 'boolean') {
+      return raw;
+    }
+    if (typeof raw === 'string') {
+      return raw.toLowerCase() === 'true';
+    }
+    return false;
+  };
+
+  const normalizeState = (state: string | null | undefined) =>
+    typeof state === 'string' ? state.toLowerCase() : '';
+
+  const isUnavailableState = (state: string | null | undefined) => {
+    const normalized = normalizeState(state);
+    return normalized === 'unavailable' || normalized === 'unknown';
+  };
+
+  const fetchEntityState = async (entityId: string) => {
+    const res = await fetch(ingressAware(`api/live/ha/states/${entityId}`));
+    if (!res.ok) {
+      return null;
+    }
+    return (await res.json()) as { state: string; attributes: Record<string, unknown> };
+  };
+
+  useEffect(() => {
+    if (!monitoringUpdate || !selectedDeviceId) {
+      return;
+    }
+
+    let cancelled = false;
+    const maxAttempts = 240;
+    const pollIntervalMs = 3000;
+    const rebootTimeoutMs = 120000;
+
+    const poll = async () => {
+      updateMonitorRef.current.attempts += 1;
+      try {
+        const status = await fetchFirmwareUpdateStatus(selectedDeviceId);
+        if (cancelled) {
+          return;
+        }
+
+        setUpdateEntityStatus(status);
+        const attributes = status.attributes || {};
+        const progress = parseProgress(attributes);
+        const updateState = normalizeState(status.state);
+        const inProgress = isInProgress(attributes) || updateState === 'installing' || updateState === 'updating';
+        const installedVersion = typeof attributes.installed_version === 'string'
+          ? attributes.installed_version
+          : null;
+        const hasStartSignal = inProgress || (progress !== null && progress > 0);
+
+        if (progress !== null) {
+          setUpdateProgress(progress);
+        }
+
+        if (hasStartSignal) {
+          updateMonitorRef.current.seenStart = true;
+        }
+
+        if (inProgress) {
+          updateMonitorRef.current.seenInProgress = true;
+        }
+
+        const installCompleteSignal =
+          updateMonitorRef.current.seenStart &&
+          !inProgress &&
+          (progress === null || progress >= 100 || updateState === 'off' || updateState === 'idle');
+
+        if (availabilityEntityId) {
+          const availability = await fetchEntityState(availabilityEntityId);
+          const availabilityValue = availability?.state ?? null;
+          setAvailabilityState(availabilityValue);
+          const isUnavailable = isUnavailableState(availabilityValue);
+          if (installCompleteSignal && !updateMonitorRef.current.rebootStartAt) {
+            updateMonitorRef.current.rebootStartAt = Date.now();
+          }
+          if (isUnavailable) {
+            if (!updateMonitorRef.current.seenRebootDown) {
+              updateMonitorRef.current.rebootStartAt = Date.now();
+            }
+            updateMonitorRef.current.seenRebootDown = true;
+          }
+          if (updateMonitorRef.current.seenRebootDown && !isUnavailable) {
+            updateMonitorRef.current.seenRebootUp = true;
+            setRebootConfirmed(true);
+          }
+          const rebootStartAt = updateMonitorRef.current.rebootStartAt;
+          if (rebootStartAt && !updateMonitorRef.current.seenRebootUp) {
+            if (Date.now() - rebootStartAt > rebootTimeoutMs) {
+              setMonitoringUpdate(false);
+              setUpdateStatus('error');
+              onError('Timed out waiting for device to come back online. Check Home Assistant for status.');
+              return;
+            }
+          }
+        }
+
+        const hasRebooted = updateMonitorRef.current.seenRebootDown && updateMonitorRef.current.seenRebootUp;
+
+        if (updateMonitorRef.current.seenStart) {
+          if (availabilityEntityId) {
+            if (hasRebooted && installCompleteSignal) {
+              if (preparedVersion && installedVersion && installedVersion !== preparedVersion) {
+                setMonitoringUpdate(false);
+                setUpdateStatus('error');
+                onError(`Update finished but device reports v${installedVersion}. Expected v${preparedVersion}.`);
+                return;
+              }
+              setRebootConfirmed(true);
+              setMonitoringUpdate(false);
+              setUpdateStatus('complete');
+              onSuccess(
+                `Firmware updated${installedVersion ? ` to v${installedVersion}` : ''}. Device rebooted and is back online.`
+              );
+              return;
+            }
+          } else if (installCompleteSignal) {
+            if (preparedVersion && installedVersion && installedVersion !== preparedVersion) {
+              setMonitoringUpdate(false);
+              setUpdateStatus('error');
+              onError(`Update finished but device reports v${installedVersion}. Expected v${preparedVersion}.`);
+              return;
+            }
+            setRebootConfirmed(false);
+            setMonitoringUpdate(false);
+            setUpdateStatus('complete');
+            onSuccess(
+              `Firmware updated${installedVersion ? ` to v${installedVersion}` : ''}. Device may reboot briefly.`
+            );
+            return;
+          }
+        }
+
+        if (!updateMonitorRef.current.seenStart) {
+          setUpdateMonitorMessage('Waiting for update to begin...');
+        } else if (inProgress) {
+          setUpdateMonitorMessage('Installing firmware...');
+        } else if (availabilityEntityId) {
+          if (!updateMonitorRef.current.seenRebootDown) {
+            setUpdateMonitorMessage('Waiting for device reboot...');
+          } else if (!updateMonitorRef.current.seenRebootUp) {
+            setUpdateMonitorMessage('Device rebooting...');
+          } else {
+            setUpdateMonitorMessage('Verifying update...');
+          }
+        } else {
+          setUpdateMonitorMessage('Finalizing update...');
+        }
+      } catch (err) {
+        if (cancelled) {
+          return;
+        }
+        const message = err instanceof Error ? err.message : '';
+        if (message.includes('ENTITY_NOT_FOUND') || message.includes('MAPPING_NOT_FOUND')) {
+          setMonitoringUpdate(false);
+          setUpdateMonitorMessage('Update entity not mapped. Run entity discovery to enable progress tracking.');
+          return;
+        }
+        if (message.includes('404')) {
+          setMonitoringUpdate(false);
+          setUpdateMonitorMessage('Update status unavailable. Check Home Assistant for progress.');
+          return;
+        }
+      }
+
+      if (updateMonitorRef.current.attempts >= maxAttempts) {
+        setMonitoringUpdate(false);
+        setUpdateStatus('error');
+        onError('Timed out waiting for firmware update status. Check Home Assistant for progress.');
+      }
+    };
+
+    poll();
+    const interval = setInterval(poll, pollIntervalMs);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [monitoringUpdate, selectedDeviceId, preparedVersion, availabilityEntityId, onError, onSuccess]);
+
+  // Format device config for display
+  const formatDeviceConfig = (config: DeviceConfig) => {
+    const features: string[] = [];
+    if (config.bluetooth_enabled) features.push('BLE');
+    if (config.co2_enabled) features.push('CO2');
+    if (config.ethernet_enabled) features.push('Ethernet');
+    return features.length > 0 ? features.join(', ') : 'None';
+  };
+
+  const normalizeValue = (value?: string) => value?.trim().toLowerCase() ?? '';
+
+  const getDeviceProfile = (device: DiscoveredDevice): DeviceProfile | null => {
+    if (!profiles.length) return null;
+    const model = normalizeValue(device.model);
+    const name = normalizeValue(device.name);
+    const manufacturer = normalizeValue(device.manufacturer);
+    const matchKey = model || name;
+    const byModel = profiles.find((profile) => {
+      const profileModel = normalizeValue((profile as DeviceProfile & { model?: string }).model);
+      const profileLabel = normalizeValue(profile.label);
+      const profileManufacturer = normalizeValue(profile.manufacturer);
+      const modelMatch = profileModel && profileModel === matchKey;
+      const labelMatch = profileLabel && profileLabel === matchKey;
+      const manufacturerMatch =
+        !manufacturer || !profileManufacturer || profileManufacturer === manufacturer;
+      return (modelMatch || labelMatch) && manufacturerMatch;
+    });
+    if (byModel) return byModel;
+    if (matchKey) {
+      const matchId = profiles.find((profile) => {
+        const profileId = normalizeValue(profile.id).replace(/_/g, ' ');
+        return profileId && matchKey.includes(profileId);
+      });
+      return matchId ?? null;
+    }
+    return null;
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-slate-700 border-t-cyan-400" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {showFirmwareModal && (
+        <div className="fixed inset-0 z-[110] flex items-center justify-center">
+          <div className="absolute inset-0 bg-slate-950/70 backdrop-blur-sm" />
+          <div className="relative z-10 w-full max-w-lg mx-4 rounded-2xl border border-slate-700/50 bg-slate-900/95 shadow-2xl">
+            <div className="flex items-start justify-between px-6 pt-6">
+              <div>
+                <div className="text-lg font-semibold text-white">Firmware Update</div>
+                <div className="text-xs text-slate-400">
+                  {selectedDevice
+                    ? `${selectedDevice.name}${selectedDevice.firmwareVersion ? ` | v${selectedDevice.firmwareVersion}` : ''}`
+                    : 'Select a device to begin'}
+                </div>
+              </div>
+              {!modalLocked && (
+                <button
+                  type="button"
+                  onClick={() => setUpdateModalOpen(false)}
+                  className="flex h-9 w-9 items-center justify-center rounded-lg border border-slate-700/60 text-slate-400 transition hover:border-slate-600 hover:text-slate-200"
+                >
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              )}
+            </div>
+
+            <div className="p-6 pt-4 space-y-4">
+              {updateStatus === 'checking' && (
+                <div className="flex items-center gap-3 rounded-xl border border-cyan-500/40 bg-cyan-500/10 p-4 text-sm text-cyan-100">
+                  <div className="h-5 w-5 animate-spin rounded-full border-2 border-cyan-300 border-t-transparent" />
+                  Checking for the latest firmware and reading device configuration...
+                </div>
+              )}
+
+              {updateStatus === 'preparing' && (
+                <div className="flex items-center gap-3 rounded-xl border border-cyan-500/40 bg-cyan-500/10 p-4 text-sm text-cyan-100">
+                  <div className="h-5 w-5 animate-spin rounded-full border-2 border-cyan-300 border-t-transparent" />
+                  Preparing firmware for this device...
+                </div>
+              )}
+
+              {updateStatus === 'downloading' && (
+                <div className="flex items-center gap-3 rounded-xl border border-cyan-500/40 bg-cyan-500/10 p-4 text-sm text-cyan-100">
+                  <div className="h-5 w-5 animate-spin rounded-full border-2 border-cyan-300 border-t-transparent" />
+                  Downloading firmware from the remote server...
+                </div>
+              )}
+
+              {updateStatus === 'updating' && (
+                <div className="space-y-4">
+                  <div className="flex items-center gap-4">
+                    <div className="relative h-14 w-14">
+                      <div className="absolute inset-0 rounded-full border-4 border-cyan-500/20 animate-ping" />
+                      <div className="absolute inset-0 rounded-full border-4 border-cyan-400 border-t-transparent animate-spin" />
+                      <div className="absolute inset-2 rounded-full bg-cyan-500/10 animate-pulse" />
+                    </div>
+                    <div>
+                      <div className="text-base font-semibold text-cyan-100">Installing firmware</div>
+                      <div className="text-xs text-slate-400">
+                        {updateMonitorMessage || 'Working on it...'}
+                      </div>
+                    </div>
+                  </div>
+                  {updateProgress !== null ? (
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between text-xs text-cyan-100">
+                        <span>Progress</span>
+                        <span>{updateProgress}%</span>
+                      </div>
+                      <div className="h-2 w-full rounded-full bg-slate-700/70 overflow-hidden">
+                        <div
+                          className="h-2 rounded-full bg-cyan-400 transition-all duration-500"
+                          style={{ width: `${Math.min(100, Math.max(0, updateProgress))}%` }}
+                        />
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="text-xs text-slate-400">Waiting for update progress...</div>
+                  )}
+                  {updateEntityStatus && (
+                    <div className="text-xs text-slate-400">
+                      Update entity: {updateEntityStatus.state}
+                      {updateInstalledVersion ? ` | Installed: ${updateInstalledVersion}` : ''}
+                    </div>
+                  )}
+                  <div className="text-[11px] text-slate-500">
+                    This can take a few minutes. If the device stays offline for 2 minutes, we will stop waiting.
+                    Keep this window open while the update completes.
+                  </div>
+                </div>
+              )}
+
+              {updateStatus === 'ready' && (
+                <div className="space-y-4">
+                  <div className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+                    Firmware {preparedVersion ? `v${preparedVersion}` : 'update'} is ready to install.
+                  </div>
+                  {validation && validation.warnings.length > 0 && (
+                    <div className="rounded-xl border border-amber-500/50 bg-amber-500/10 p-4">
+                      <h4 className="mb-2 text-sm font-semibold text-amber-200">Warnings</h4>
+                      <ul className="space-y-1 text-xs text-amber-200">
+                        {validation.warnings.map((issue, index) => (
+                          <li key={index}>{issue.message}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {canInstall && (
+                    <button
+                      onClick={handleTriggerUpdate}
+                      className="w-full rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-500"
+                    >
+                      Install on Device
+                    </button>
+                  )}
+                </div>
+              )}
+
+              {updateStatus === 'complete' && (
+                <div className="space-y-4">
+                  <div className="flex items-start gap-3 rounded-xl border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+                    <div className="relative mt-0.5 flex h-10 w-10 items-center justify-center rounded-full border border-emerald-400/50 bg-emerald-500/20">
+                      <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400/30" />
+                      <svg
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                        className="relative h-5 w-5 text-emerald-200"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <path d="M5 13l4 4L19 7" />
+                      </svg>
+                    </div>
+                    <div>
+                      <div className="text-sm font-semibold text-emerald-100">
+                        Firmware update successful
+                      </div>
+                      <div className="text-xs text-emerald-100/90">
+                        Firmware updated{updateInstalledVersion ? ` to v${updateInstalledVersion}` : preparedVersion ? ` to v${preparedVersion}` : ''}.{' '}
+                        {rebootConfirmed ? 'Device rebooted and is back online.' : 'Device may reboot briefly.'}
+                      </div>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setUpdateModalOpen(false)}
+                    className="w-full rounded-lg border border-slate-600 bg-slate-800 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:bg-slate-700"
+                  >
+                    Close
+                  </button>
+                </div>
+              )}
+
+              {updateStatus === 'error' && (
+                <div className="space-y-4">
+                  <div className="rounded-xl border border-rose-500/50 bg-rose-500/10 p-4 text-sm text-rose-100">
+                    Update failed. Check the error message above or Home Assistant for details.
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setUpdateModalOpen(false)}
+                    className="w-full rounded-lg border border-slate-600 bg-slate-800 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:bg-slate-700"
+                  >
+                    Close
+                  </button>
+                </div>
+              )}
+
+              {updateStatus === 'idle' && updateModalOpen && (
+                <div className="space-y-4">
+                  {!deviceConfig && (
+                    <div className="rounded-xl border border-slate-700/60 bg-slate-800/40 p-4 text-sm text-slate-300">
+                      Ready to check for updates.
+                    </div>
+                  )}
+
+                  {deviceConfig?.configSource === 'inferred' && (
+                    <div className="rounded-xl border border-amber-500/50 bg-amber-500/10 p-4">
+                      <h4 className="mb-2 text-sm font-semibold text-amber-200">Build Configuration Unavailable</h4>
+                      <p className="mb-3 text-xs text-amber-200">
+                        This device did not return its build configuration via the get_build_flags service.
+                        To avoid installing incompatible firmware, updates are disabled.
+                      </p>
+                      <p className="mb-3 text-xs text-amber-200">
+                        Flash the latest firmware via USB to enable over-the-air updates in this add-on.
+                      </p>
+                      <a
+                        href="https://docs.everythingsmart.io"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-block rounded-lg bg-amber-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-500"
+                      >
+                        View Flashing Instructions
+                      </a>
+                    </div>
+                  )}
+
+                  {deviceConfig?.configSource === 'entities' && availableUpdates.length > 0 && (
+                    <div className="space-y-3">
+                      {availableUpdates.map((update, index) => (
+                        <div
+                          key={index}
+                          className={`rounded-xl border p-3 cursor-pointer transition ${
+                            selectedUpdate === update
+                              ? 'border-emerald-400 bg-emerald-500/20'
+                              : 'border-slate-600/50 bg-slate-800/30 hover:border-emerald-500/50'
+                          }`}
+                          onClick={() => setSelectedUpdate(update)}
+                        >
+                          <div className="flex items-center justify-between">
+                            <div>
+                              <span className="text-sm font-semibold text-emerald-300">
+                                v{update.newVersion}
+                              </span>
+                              <span className="ml-2 text-xs text-slate-400">
+                                ({update.channel})
+                              </span>
+                            </div>
+                            <span className="text-xs text-slate-500">
+                              from v{update.currentVersion}
+                            </span>
+                          </div>
+                          {update.releaseNotes && (
+                            <p className="mt-1 text-xs text-slate-400">{update.releaseNotes}</p>
+                          )}
+                          {update.migration && (
+                            <div className="mt-2 rounded border border-amber-500/50 bg-amber-500/10 p-2 text-xs text-amber-200">
+                              <strong>Migration Required:</strong> {update.migration.description}
+                              {update.migration.backupRequired && (
+                                <span className="ml-1 text-amber-400">(Backup recommended)</span>
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      ))}
+
+                      <button
+                        onClick={handleAutoInstall}
+                        disabled={
+                          updateStatus === 'preparing' ||
+                          updateStatus === 'downloading' ||
+                          updateStatus === 'updating'
+                        }
+                        className="w-full rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        Install Latest Update
+                      </button>
+                    </div>
+                  )}
+
+                  {deviceConfig?.configSource === 'entities' && availableUpdates.length === 0 && (
+                    <div className="rounded-xl border border-slate-700/60 bg-slate-800/40 p-4 text-center">
+                      <div className="text-sm text-slate-300">Your device is running the latest firmware.</div>
+                      <div className="mt-3">
+                        <button
+                          onClick={handleAutoInstall}
+                          disabled={
+                            updateStatus === 'preparing' ||
+                            updateStatus === 'downloading' ||
+                            updateStatus === 'updating'
+                          }
+                          className="rounded-lg border border-slate-600 bg-slate-700 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:bg-slate-600 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          Reinstall Latest Firmware
+                        </button>
+                      </div>
+                    </div>
+                  )}
+
+                  {validation && validation.warnings.length > 0 && (
+                    <div className="rounded-xl border border-amber-500/50 bg-amber-500/10 p-4">
+                      <h4 className="mb-2 text-sm font-semibold text-amber-200">Warnings</h4>
+                      <ul className="space-y-1 text-xs text-amber-200">
+                        {validation.warnings.map((issue, index) => (
+                          <li key={index}>{issue.message}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="rounded-2xl border border-slate-700/60 bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-slate-800/50 p-6 shadow-lg">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-white">Firmware Update</h2>
+            <p className="text-xs text-slate-400">
+              Safely update your device using its build configuration and the local proxy.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-[11px]">
+            {selectedDevice && (
+              <span className="rounded-full border border-slate-700/70 bg-slate-800/60 px-3 py-1 text-slate-300">
+                {selectedDevice.name}
+              </span>
+            )}
+            <span className={`rounded-full border px-3 py-1 ${configStatusClass}`}>
+              {configStatus}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-5 shadow-lg">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <span className="flex h-9 w-9 items-center justify-center rounded-xl border border-cyan-500/30 bg-cyan-500/10 text-sm font-semibold text-cyan-200">
+              1
+            </span>
+            <div>
+              <h3 className="text-sm font-semibold text-slate-200">Select device</h3>
+              <p className="text-xs text-slate-500">Pick a device, then check for updates in the modal.</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-4">
+          {devices.length === 0 ? (
+            <div className="rounded-lg border border-slate-700/60 bg-slate-800/40 p-4 text-sm text-slate-400">
+              No Everything Presence devices found yet.
+            </div>
+          ) : (
+            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+              {devices.map((device) => {
+                const profile = getDeviceProfile(device);
+                const iconUrl = profile?.iconUrl;
+                const isSelected = device.id === selectedDeviceId;
+
+                return (
+                  <button
+                    type="button"
+                    key={device.id}
+                    onClick={() => handleDeviceChange(device.id)}
+                    className={`group w-full rounded-xl border p-4 text-left transition ${
+                      isSelected
+                        ? 'border-cyan-400/70 bg-cyan-500/10 shadow-[0_0_0_1px_rgba(34,211,238,0.35)]'
+                        : 'border-slate-700/60 bg-slate-800/40 hover:border-cyan-500/40 hover:bg-slate-800/70'
+                    }`}
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-12 w-12 items-center justify-center rounded-xl border border-slate-700/60 bg-slate-900/60">
+                        {iconUrl ? (
+                          <img
+                            src={iconUrl}
+                            alt={`${device.name} icon`}
+                            className="h-10 w-10 object-contain"
+                            loading="lazy"
+                          />
+                        ) : (
+                          <span className="text-[10px] font-semibold text-slate-400">EP</span>
+                        )}
+                      </div>
+                      <div className="flex-1">
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="text-sm font-semibold text-slate-100">{device.name}</span>
+                          {isSelected && (
+                            <span className="rounded-full border border-cyan-400/60 bg-cyan-500/10 px-2 py-0.5 text-[10px] text-cyan-100">
+                              Selected
+                            </span>
+                          )}
+                        </div>
+                        <div className="text-xs text-slate-400">
+                          {device.model || profile?.label || 'Unknown model'}
+                        </div>
+                        <div className="mt-1 text-[11px] text-slate-500">
+                          {device.firmwareVersion ? `v${device.firmwareVersion}` : 'Firmware unknown'}
+                          {device.areaName ? ` | ${device.areaName}` : ''}
+                        </div>
+                      </div>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <button
+            onClick={handleCheckForUpdates}
+            disabled={!selectedDeviceId || checkingUpdates}
+            className="w-full rounded-lg bg-cyan-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-cyan-500 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
+          >
+            {checkingUpdates ? (
+              <span className="flex items-center justify-center gap-2">
+                <div className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                Checking for updates...
+              </span>
+            ) : (
+              'Check for Updates'
+            )}
+          </button>
+          {selectedDevice && (
+            <div className="text-[11px] text-slate-500">
+              {selectedDevice.firmwareVersion
+                ? `Current firmware v${selectedDevice.firmwareVersion}`
+                : 'Firmware version unknown'}
+            </div>
+          )}
+        </div>
+
+        {deviceConfig && (
+          <div className="mt-4">
+            <button
+              type="button"
+              onClick={() => setShowBuildDetails((prev) => !prev)}
+              className="flex w-full items-center justify-between text-sm font-semibold text-slate-200"
+            >
+              <span>Build configuration</span>
+              <span className="text-slate-400">{showBuildDetails ? '-' : '+'}</span>
+            </button>
+
+            {showBuildDetails && (
+              <div className="mt-3 rounded-xl border border-slate-700/60 bg-slate-900/40 p-4">
+                <div className="mb-3 flex items-center justify-between">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-slate-300">
+                    Build Configuration
+                  </div>
+                  <span
+                    className={`rounded-full border px-2 py-0.5 text-[10px] ${
+                      deviceConfig.configSource === 'entities'
+                        ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200'
+                        : 'border-amber-500/40 bg-amber-500/10 text-amber-200'
+                    }`}
+                  >
+                    {deviceConfig.configSource === 'entities' ? 'Reported by device' : 'Inferred'}
+                  </span>
+                </div>
+                <div className="grid grid-cols-2 gap-2 text-xs text-slate-400">
+                  <div>
+                    <span className="text-slate-500">Model:</span>{' '}
+                    <span className="text-slate-300">{deviceConfig.model}</span>
+                  </div>
+                  <div>
+                    <span className="text-slate-500">Channel:</span>{' '}
+                    <span className="text-slate-300">{deviceConfig.firmware_channel}</span>
+                  </div>
+                  <div>
+                    <span className="text-slate-500">Features:</span>{' '}
+                    <span className="text-slate-300">{formatDeviceConfig(deviceConfig)}</span>
+                  </div>
+                  <div>
+                    <span className="text-slate-500">Sensor:</span>{' '}
+                    <span className="text-slate-300">{deviceConfig.sensor_variant || 'Default'}</span>
+                  </div>
+                  <div>
+                    <span className="text-slate-500">Board Rev:</span>{' '}
+                    <span className="text-slate-300">{deviceConfig.board_revision}</span>
+                  </div>
+                  <div>
+                    <span className="text-slate-500">Network:</span>{' '}
+                    <span className="text-slate-300">{deviceConfig.ethernet_enabled ? 'Ethernet' : 'WiFi'}</span>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-5 shadow-lg">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3 className="text-sm font-semibold text-slate-200">Advanced options</h3>
+            <p className="text-xs text-slate-500">Manual manifest, LAN proxy, and cache controls.</p>
+          </div>
+        </div>
+
+        <div className="mt-4 divide-y divide-slate-700/60">
+          <div className="py-4">
+            <button
+              onClick={() => setShowManualMode(!showManualMode)}
+              className="flex w-full items-center justify-between text-sm font-semibold text-slate-200"
+            >
+              <span>Manual Firmware URL</span>
+              <span className="text-slate-400">{showManualMode ? '-' : '+'}</span>
+            </button>
+
+            {showManualMode && (
+              <div className="mt-3 space-y-3">
+                {updatesBlocked && (
+                  <div className="rounded border border-amber-500/50 bg-amber-500/10 p-2 text-xs text-amber-200">
+                    {updatesBlockedMessage}
+                  </div>
+                )}
+                <div>
+                  <label className="mb-1 block text-xs text-slate-400">
+                    Firmware Manifest URL
+                  </label>
+                  <input
+                    type="text"
+                    value={manifestUrl}
+                    onChange={(e) => setManifestUrl(e.target.value)}
+                    placeholder="https://example.com/firmware/manifest.json"
+                    disabled={updatesBlocked}
+                    className="w-full rounded border border-slate-600 bg-slate-700 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-cyan-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                  />
+                  <p className="mt-1 text-xs text-slate-500">
+                    Enter the full URL to the firmware manifest.json file
+                  </p>
+                </div>
+                <button
+                  onClick={handleManualPrepare}
+                  disabled={
+                    !selectedDeviceId ||
+                    !manifestUrl ||
+                    updatesBlocked ||
+                    updateStatus === 'preparing' ||
+                    updateStatus === 'downloading' ||
+                    updateStatus === 'updating'
+                  }
+                  className="w-full rounded-lg bg-slate-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-500 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {updateStatus === 'preparing' || updateStatus === 'downloading'
+                    ? 'Preparing...'
+                    : 'Download and Prepare Manual Firmware'}
+                </button>
+              </div>
+            )}
+          </div>
+
+          <div className="py-4">
+            <button
+              onClick={() => setShowSettings(!showSettings)}
+              className="flex w-full items-center justify-between text-sm font-semibold text-slate-200"
+            >
+              <span>LAN Configuration</span>
+              <span className="text-slate-400">{showSettings ? '-' : '+'}</span>
+            </button>
+
+            {showSettings && (
+              <div className="mt-3 space-y-3">
+                <div>
+                  <label className="mb-1 block text-xs text-slate-400">
+                    Auto-detected LAN IP
+                  </label>
+                  <div className="rounded border border-slate-600 bg-slate-700/50 px-3 py-2 text-sm text-slate-300">
+                    {autoDetectedIp || 'Could not detect'}
+                  </div>
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs text-slate-400">
+                    LAN IP Override (optional)
+                  </label>
+                  <input
+                    type="text"
+                    value={lanIpOverride}
+                    onChange={(e) => setLanIpOverride(e.target.value)}
+                    placeholder="e.g., 192.168.1.100"
+                    className="w-full rounded border border-slate-600 bg-slate-700 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-cyan-500 focus:outline-none"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs text-slate-400">
+                    Firmware Server URL (devices will download from here)
+                  </label>
+                  <div className="rounded border border-slate-600 bg-slate-700/50 px-3 py-2 text-sm text-cyan-400">
+                    http://{effectiveLanIp}:{lanPort}
+                  </div>
+                </div>
+                <button
+                  onClick={handleSaveSettings}
+                  disabled={savingSettings}
+                  className="rounded-lg bg-cyan-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-cyan-500 disabled:opacity-50"
+                >
+                  {savingSettings ? 'Saving...' : 'Save Settings'}
+                </button>
+              </div>
+            )}
+          </div>
+
+          <div className="py-4">
+            <button
+              onClick={() => setShowCache(!showCache)}
+              className="flex w-full items-center justify-between text-sm font-semibold text-slate-200"
+            >
+              <span>Cached Firmware ({cachedEntries.length})</span>
+              <span className="text-slate-400">{showCache ? '-' : '+'}</span>
+            </button>
+
+            {showCache && (
+              <div className="mt-3 space-y-3">
+                {cachedEntries.length === 0 ? (
+                  <div className="py-4 text-center text-sm text-slate-500">
+                    No cached firmware
+                  </div>
+                ) : (
+                  cachedEntries.map((entry) => {
+                    const device = devices.find((d) => d.id === entry.deviceId);
+                    const isMatchingDevice = selectedDeviceId === entry.deviceId;
+                    const installDisabled =
+                      !isMatchingDevice ||
+                      updateStatus === 'preparing' ||
+                      updateStatus === 'downloading' ||
+                      updateStatus === 'updating';
+                    return (
+                      <div
+                        key={`${entry.deviceId}-${entry.token}`}
+                        className="flex items-center justify-between rounded border border-slate-700/50 bg-slate-800/40 p-3"
+                      >
+                        <div className="text-xs">
+                          <div className="font-semibold text-slate-200">
+                            {device?.name || entry.deviceId}
+                          </div>
+                          <div className="text-slate-400">
+                            Version: {entry.version} | Files: {entry.binaryCount}
+                          </div>
+                          <div className="text-slate-500">
+                            Cached: {new Date(entry.cachedAt).toLocaleString()}
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <button
+                            onClick={() => handleInstallCachedEntry(entry)}
+                            disabled={installDisabled}
+                            className="rounded bg-cyan-600/20 px-2 py-1 text-xs text-cyan-200 transition hover:bg-cyan-600/30 disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            {isMatchingDevice ? 'Install' : 'Select device'}
+                          </button>
+                          <button
+                            onClick={() => handleDeleteCacheEntry(entry.deviceId, entry.token)}
+                            className="rounded bg-rose-600/20 px-2 py-1 text-xs text-rose-300 transition hover:bg-rose-600/30"
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      </div>
+                    );
+                  })
+                )}
+
+                <div className="rounded-lg border border-slate-700/60 bg-slate-900/40 p-3">
+                  <label className="mb-1 block text-xs text-slate-400">
+                    Versions to keep per device
+                  </label>
+                  <input
+                    type="number"
+                    min={1}
+                    step={1}
+                    value={cacheKeepCount}
+                    onChange={(e) => {
+                      const value = Number(e.target.value);
+                      setCacheKeepCount(Number.isFinite(value) && value > 0 ? value : 1);
+                    }}
+                    className="w-full rounded border border-slate-600 bg-slate-700 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-cyan-500 focus:outline-none"
+                  />
+                  <p className="mt-1 text-xs text-slate-500">
+                    Keeps the most recent distinct firmware versions per device.
+                  </p>
+                  <button
+                    onClick={handleSaveCacheSettings}
+                    disabled={savingCacheSettings}
+                    className="mt-2 rounded-lg bg-cyan-600 px-3 py-2 text-xs font-semibold text-white transition hover:bg-cyan-500 disabled:opacity-50"
+                  >
+                    {savingCacheSettings ? 'Saving...' : 'Save Cache Settings'}
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-4 rounded-lg border border-slate-700/40 bg-slate-800/30 p-3 text-xs text-slate-500">
+          <p className="mb-2">
+            <strong>How it works:</strong> Use "Check for Updates" to read the device build config and match
+            compatible firmware.
+          </p>
+          <p>
+            <strong>Manual mode:</strong> If auto-detection fails, provide a manifest URL to prepare firmware
+            directly.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/everything-presence-mmwave-configurator/frontend/src/pages/SettingsPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/SettingsPage.tsx
@@ -11,6 +11,7 @@ import {
 } from '../api/client';
 import { RoomConfig, CustomFloorMaterial, CustomFurnitureType, EntityMappings } from '../api/types';
 import { EntityDiscovery } from '../components/EntityDiscovery';
+import { FirmwareUpdateSection } from '../components/FirmwareUpdateSection';
 import { useDeviceMappings } from '../contexts/DeviceMappingsContext';
 
 interface SettingsPageProps {
@@ -19,7 +20,10 @@ interface SettingsPageProps {
   onRoomUpdated?: (room: RoomConfig) => void;
 }
 
+type SettingsTab = 'general' | 'firmware';
+
 export const SettingsPage: React.FC<SettingsPageProps> = ({ onBack, onRoomDeleted, onRoomUpdated }) => {
+  const [activeTab, setActiveTab] = useState<SettingsTab>('general');
   const [rooms, setRooms] = useState<RoomConfig[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -509,6 +513,30 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onBack, onRoomDelete
           <div className="w-20" /> {/* Spacer for alignment */}
         </div>
 
+        {/* Tab Navigation */}
+        <div className="mb-6 flex gap-2 border-b border-slate-700/50 pb-2">
+          <button
+            onClick={() => setActiveTab('general')}
+            className={`rounded-lg px-4 py-2 text-sm font-semibold transition ${
+              activeTab === 'general'
+                ? 'bg-cyan-600 text-white'
+                : 'bg-slate-800/50 text-slate-300 hover:bg-slate-800 hover:text-white'
+            }`}
+          >
+            General
+          </button>
+          <button
+            onClick={() => setActiveTab('firmware')}
+            className={`rounded-lg px-4 py-2 text-sm font-semibold transition ${
+              activeTab === 'firmware'
+                ? 'bg-cyan-600 text-white'
+                : 'bg-slate-800/50 text-slate-300 hover:bg-slate-800 hover:text-white'
+            }`}
+          >
+            Firmware Updates
+          </button>
+        </div>
+
         {/* Error Toast */}
         {error && (
           <div className="mb-6 rounded-xl border border-rose-500/50 bg-rose-500/10 px-6 py-3 text-rose-100">
@@ -532,8 +560,11 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onBack, onRoomDelete
             <div className="text-sm text-slate-400">Loading rooms and custom assets…</div>
           </div>
         ) : (
-          <div className="space-y-6">
-            {/* Room Management Section */}
+          <>
+            {/* General Tab */}
+            {activeTab === 'general' && (
+              <div className="space-y-6">
+                {/* Room Management Section */}
             <div className="rounded-xl border border-slate-700/50 bg-slate-900/50 p-6">
               <div className="mb-4 flex items-center justify-between">
                 <h2 className="text-lg font-semibold text-white">Room Management</h2>
@@ -696,9 +727,9 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onBack, onRoomDelete
                 ))}
               </div>
             )}
-          </div>
+              </div>
 
-            {/* Custom Floor Materials Section */}
+                {/* Custom Floor Materials Section */}
             <div className="rounded-xl border border-slate-700/50 bg-slate-900/50 p-6">
               <div className="mb-4 flex items-center justify-between">
                 <h2 className="text-lg font-semibold text-white">Custom Floor Materials</h2>
@@ -976,8 +1007,30 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onBack, onRoomDelete
                 </div>
               )}
             </div>
-        </div>
-      )}
+              </div>
+            )}
+
+            {/* Firmware Tab */}
+            {activeTab === 'firmware' && (
+              <div className="space-y-6">
+                <div className="rounded-xl border border-slate-700/50 bg-slate-900/50 p-6">
+                  <h2 className="mb-4 text-lg font-semibold text-white">Firmware Updates</h2>
+                  <p className="mb-4 text-sm text-slate-400">
+                    Update your Everything Presence devices with firmware downloaded through this local proxy.
+                    This helps ESP devices that have trouble with HTTPS due to memory constraints.
+                  </p>
+                  <FirmwareUpdateSection
+                    onError={(err) => setError(err)}
+                    onSuccess={(msg) => {
+                      setSuccess(msg);
+                      setTimeout(() => setSuccess(null), 5000);
+                    }}
+                  />
+                </div>
+              </div>
+            )}
+          </>
+        )}
       </div>
 
       {/* Entity Re-sync Modal */}

--- a/everything-presence-mmwave-configurator/rootfs/etc/s6-overlay/s6-rc.d/zone-configurator/run
+++ b/everything-presence-mmwave-configurator/rootfs/etc/s6-overlay/s6-rc.d/zone-configurator/run
@@ -5,7 +5,14 @@ set -euo pipefail
 cd /app
 export NODE_ENV="${NODE_ENV:-production}"
 export PORT="${PORT:-3000}"
+FIRMWARE_LAN_PORT_CONFIG="$(bashio::config 'firmware_lan_port')"
+if [ -n "${FIRMWARE_LAN_PORT_CONFIG}" ] && [ "${FIRMWARE_LAN_PORT_CONFIG}" != "null" ]; then
+  export FIRMWARE_LAN_PORT="${FIRMWARE_LAN_PORT_CONFIG}"
+else
+  export FIRMWARE_LAN_PORT="${FIRMWARE_LAN_PORT:-38080}"
+fi
 
 bashio::log.info "Starting Zone Configurator backend on port ${PORT}"
+bashio::log.info "LAN Firmware Server will start on port ${FIRMWARE_LAN_PORT}"
 
 exec node backend/dist/index.js


### PR DESCRIPTION
This update adds a built‑in, local firmware updater for Everything Presence devices. You can now check for updates, install them,
  and watch progress directly in the Zone Configurator, with clear status and reboot confirmation. The updater uses the device’s own
  build info to ensure the correct firmware is chosen, preventing mismatched installs that could take a device offline. It also keeps
  a small cache of recent firmware versions so you can reinstall or roll back if needed, and the update service runs on a
  configurable local port for reliability.