### PR TITLE
Feature: Add services to device mapping

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/config/deviceMappingStorage.ts
+++ b/everything-presence-mmwave-configurator/backend/src/config/deviceMappingStorage.ts
@@ -46,6 +46,10 @@ export interface DeviceMapping {
   rawSwVersion?: string;
   /** Schema version from device profile at time of last sync (e.g., "1.0") */
   profileSchemaVersion?: string;
+  /** Manually mapped ESPHome service names (e.g., "getBuildFlags" -> "esphome.device_name_get_build_flags") */
+  serviceMappings?: Record<string, string>;
+  /** Whether service mappings were confirmed by user (don't overwrite during re-sync) */
+  serviceConfirmedByUser?: boolean;
 }
 
 /**

--- a/everything-presence-mmwave-configurator/backend/src/ha/readTransport.ts
+++ b/everything-presence-mmwave-configurator/backend/src/ha/readTransport.ts
@@ -100,6 +100,14 @@ export interface IHaReadTransport {
    */
   getServicesForTarget(target: HaTarget, expandGroup?: boolean): Promise<string[]>;
 
+  /**
+   * List all services for a given domain registered in Home Assistant.
+   * Used for manual service selection when auto-discovery fails.
+   * @param domain - Service domain (e.g., "esphome", "light", "switch")
+   * @returns Array of fully qualified service names (e.g., "esphome.device_get_build_flags")
+   */
+  getServicesByDomain(domain: string): Promise<string[]>;
+
   // ─────────────────────────────────────────────────────────────────
   // State Queries
   // ─────────────────────────────────────────────────────────────────

--- a/everything-presence-mmwave-configurator/backend/src/ha/restReadTransport.ts
+++ b/everything-presence-mmwave-configurator/backend/src/ha/restReadTransport.ts
@@ -269,6 +269,11 @@ export class RestReadTransport implements IHaReadTransport {
     return [];
   }
 
+  async getServicesByDomain(_domain: string): Promise<string[]> {
+    logger.debug('RestReadTransport: getServicesByDomain not supported, returning empty list');
+    return [];
+  }
+
   /**
    * Fallback: Query area registry via HA template API.
    */

--- a/everything-presence-mmwave-configurator/backend/src/ha/wsReadTransport.ts
+++ b/everything-presence-mmwave-configurator/backend/src/ha/wsReadTransport.ts
@@ -245,6 +245,28 @@ export class WsReadTransport implements IHaReadTransport {
     return [];
   }
 
+  async getServicesByDomain(domain: string): Promise<string[]> {
+    const response = (await this.call({
+      type: 'get_services',
+    })) as HaWsMessage & { result?: Record<string, Record<string, unknown>> };
+
+    if (response.type === 'result' && (response as any).success) {
+      const allServices = (response as any).result ?? {};
+      const domainServices: string[] = [];
+
+      if (allServices[domain]) {
+        for (const serviceName of Object.keys(allServices[domain])) {
+          domainServices.push(`${domain}.${serviceName}`);
+        }
+      }
+
+      return domainServices.sort();
+    }
+
+    logger.warn({ response, domain }, 'WsReadTransport: Unexpected response when listing services');
+    return [];
+  }
+
   // ─────────────────────────────────────────────────────────────────
   // State Queries
   // ─────────────────────────────────────────────────────────────────

--- a/everything-presence-mmwave-configurator/backend/src/routes/firmware.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/firmware.ts
@@ -20,7 +20,6 @@ export const createFirmwareRouter = (deps: FirmwareRouterDependencies): Router =
   const firmwareService = new FirmwareService({
     config: deps.config,
     writeClient: deps.writeClient,
-    readTransport: deps.readTransport,
   });
 
   /**

--- a/everything-presence-mmwave-configurator/frontend/src/api/deviceMappings.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/api/deviceMappings.ts
@@ -46,6 +46,8 @@ export interface DeviceMapping {
   deviceId: string;
   profileId: string;
   deviceName: string;
+  /** ESPHome node name extracted from device identifiers or inferred from device name */
+  esphomeNodeName?: string;
   discoveredAt: string;
   lastUpdated: string;
   confirmedByUser: boolean;
@@ -65,6 +67,10 @@ export interface DeviceMapping {
   profileSchemaVersion?: string;
   /** Zone labels keyed by zone ID (e.g., "Zone 1" -> "Bed", "Exclusion 2" -> "Window") */
   zoneLabels?: Record<string, string>;
+  /** Manually mapped ESPHome service names (e.g., "getBuildFlags" -> "esphome.device_name_get_build_flags") */
+  serviceMappings?: Record<string, string>;
+  /** Whether service mappings were confirmed by user (won't be overwritten during re-sync) */
+  serviceConfirmedByUser?: boolean;
 }
 
 /**

--- a/everything-presence-mmwave-configurator/frontend/src/api/entityDiscovery.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/api/entityDiscovery.ts
@@ -45,6 +45,8 @@ export interface DiscoveryResult {
   results: EntityMatchResult[];
   suggestedMappings: Partial<EntityMappings>;
   deviceEntities: EntityRegistryEntry[];
+  /** Auto-discovered ESPHome services (if any), e.g. getBuildFlags */
+  serviceMappings?: Record<string, string>;
 }
 
 /**

--- a/everything-presence-mmwave-configurator/frontend/src/api/serviceDiscovery.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/api/serviceDiscovery.ts
@@ -1,0 +1,67 @@
+import { ingressAware } from './client';
+
+export interface ServicesResponse {
+  services: string[];
+  domain: string;
+  message?: string;
+}
+
+export interface ServiceMappingsUpdateResponse {
+  mapping: {
+    deviceId: string;
+    serviceMappings?: Record<string, string>;
+    serviceConfirmedByUser?: boolean;
+  };
+}
+
+/**
+ * Fetch all services for a given domain registered in Home Assistant.
+ * @param domain - Service domain (e.g., "esphome", "light", "switch"). Defaults to "esphome".
+ * @param pattern - Optional glob pattern to filter service names (e.g., "*_get_build_flags")
+ * @returns Array of fully qualified service names
+ */
+export const getServices = async (domain: string = 'esphome', pattern?: string): Promise<string[]> => {
+  const params = new URLSearchParams();
+  params.set('domain', domain);
+  if (pattern) {
+    params.set('pattern', pattern);
+  }
+
+  const url = ingressAware(`api/device-mappings/services?${params.toString()}`);
+  const res = await fetch(url);
+
+  if (!res.ok) {
+    console.error('Failed to fetch services:', res.status);
+    return [];
+  }
+
+  const data = (await res.json()) as ServicesResponse;
+  return data.services;
+};
+
+/**
+ * Convenience function to fetch ESPHome services.
+ * Optionally filter by glob pattern (e.g., "*_get_build_flags").
+ */
+export const getEsphomeServices = async (pattern?: string): Promise<string[]> => {
+  return getServices('esphome', pattern);
+};
+
+/**
+ * Update service mappings for a device.
+ * Setting confirmed=true will protect these mappings from being overwritten during re-sync.
+ */
+export const updateServiceMappings = async (
+  deviceId: string,
+  serviceMappings: Record<string, string>,
+  confirmed: boolean = true
+): Promise<boolean> => {
+  const url = ingressAware(`api/device-mappings/${deviceId}/service-mappings`);
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ serviceMappings, confirmed }),
+  });
+
+  return res.ok;
+};

--- a/everything-presence-mmwave-configurator/frontend/src/components/ServiceMappingSelector.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/ServiceMappingSelector.tsx
@@ -1,0 +1,276 @@
+import React, { useState, useEffect } from 'react';
+import { getEsphomeServices, updateServiceMappings } from '../api/serviceDiscovery';
+import type { DeviceMapping } from '../api/deviceMappings';
+
+interface ServiceMappingSelectorProps {
+  deviceId: string;
+  mapping: DeviceMapping;
+  discoveredServices?: Record<string, string>;
+  onUpdated: () => void;
+}
+
+/**
+ * Component for manually selecting ESPHome service mappings when auto-discovery fails.
+ * Displays a dropdown filtered to _get_build_flags services with confirmation status.
+ */
+export const ServiceMappingSelector: React.FC<ServiceMappingSelectorProps> = ({
+  deviceId,
+  mapping,
+  discoveredServices,
+  onUpdated,
+}) => {
+  const serviceDefinitions = [
+    {
+      key: 'getBuildFlags',
+      label: 'Build Flags Service',
+      pattern: '*_get_build_flags',
+      emptyMessage: 'No _get_build_flags services found. Firmware checks may not be available.',
+    },
+    {
+      key: 'setUpdateManifest',
+      label: 'Update Manifest Service',
+      pattern: '*_set_update_manifest',
+      emptyMessage: 'No _set_update_manifest services found. Firmware updates may not be available.',
+    },
+  ] as const;
+
+  const [servicesByKey, setServicesByKey] = useState<Record<string, string[]>>({});
+  const [loadingByKey, setLoadingByKey] = useState<Record<string, boolean>>({});
+  const [saving, setSaving] = useState(false);
+  const [errorByKey, setErrorByKey] = useState<Record<string, string | null>>({});
+  const [selectedByKey, setSelectedByKey] = useState<Record<string, string>>({});
+  const [editingByKey, setEditingByKey] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    const nextSelected: Record<string, string> = {};
+    const nextEditing: Record<string, boolean> = {};
+
+    for (const def of serviceDefinitions) {
+      const current = mapping.serviceMappings?.[def.key] ?? discoveredServices?.[def.key] ?? '';
+      nextSelected[def.key] = current;
+      nextEditing[def.key] = !current;
+    }
+
+    setSelectedByKey(nextSelected);
+    setEditingByKey((prev) => {
+      if (Object.keys(prev).length === 0) return nextEditing;
+      const merged: Record<string, boolean> = {};
+      for (const def of serviceDefinitions) {
+        merged[def.key] = prev[def.key] ?? nextEditing[def.key];
+      }
+      return merged;
+    });
+  }, [
+    mapping.serviceMappings?.getBuildFlags,
+    mapping.serviceMappings?.setUpdateManifest,
+    discoveredServices?.getBuildFlags,
+    discoveredServices?.setUpdateManifest,
+  ]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadServices = async () => {
+      const nextLoading: Record<string, boolean> = {};
+      const nextErrors: Record<string, string | null> = {};
+      for (const def of serviceDefinitions) {
+        nextLoading[def.key] = true;
+        nextErrors[def.key] = null;
+      }
+      setLoadingByKey(nextLoading);
+      setErrorByKey(nextErrors);
+
+      await Promise.all(
+        serviceDefinitions.map(async (def) => {
+          try {
+            const result = await getEsphomeServices(def.pattern);
+            if (!cancelled) {
+              setServicesByKey((prev) => ({ ...prev, [def.key]: result }));
+            }
+          } catch (err) {
+            if (!cancelled) {
+              setErrorByKey((prev) => ({
+                ...prev,
+                [def.key]: err instanceof Error ? err.message : 'Failed to load services',
+              }));
+            }
+          } finally {
+            if (!cancelled) {
+              setLoadingByKey((prev) => ({ ...prev, [def.key]: false }));
+            }
+          }
+        })
+      );
+    };
+
+    loadServices();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleSave = async (serviceKey: string) => {
+    const selected = selectedByKey[serviceKey];
+    if (!selected) return;
+    setSaving(true);
+    setErrorByKey((prev) => ({ ...prev, [serviceKey]: null }));
+
+    try {
+      const success = await updateServiceMappings(
+        deviceId,
+        {
+          ...mapping.serviceMappings,
+          [serviceKey]: selected,
+        },
+        true
+      );
+
+      if (success) {
+        onUpdated();
+        setEditingByKey((prev) => ({ ...prev, [serviceKey]: false }));
+      } else {
+        setErrorByKey((prev) => ({ ...prev, [serviceKey]: 'Failed to save service mapping' }));
+      }
+    } catch (err) {
+      setErrorByKey((prev) => ({
+        ...prev,
+        [serviceKey]: err instanceof Error ? err.message : 'Failed to save',
+      }));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const isConfirmed = mapping.serviceConfirmedByUser;
+
+  return (
+    <div className="p-4 bg-slate-800/50 rounded-lg border border-slate-700">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <svg className="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+            />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+          <span className="text-sm font-medium text-slate-200">Firmware Service Mapping</span>
+        </div>
+        {isConfirmed && (
+          <span className="text-xs px-2 py-0.5 bg-green-500/20 text-green-400 rounded border border-green-500/30">
+            Confirmed
+          </span>
+        )}
+      </div>
+
+      <p className="text-xs text-slate-400 mb-3">
+        If firmware checks fail due to device renaming, select the correct service below.
+      </p>
+
+      {serviceDefinitions.map((def, index) => {
+        const storedCurrent = mapping.serviceMappings?.[def.key];
+        const discovered = discoveredServices?.[def.key];
+        const current = storedCurrent ?? discovered ?? '';
+        const isAuto = !storedCurrent && !!discovered;
+        const isEditing = editingByKey[def.key] ?? !current;
+        const selected = selectedByKey[def.key] ?? '';
+        const services = servicesByKey[def.key] ?? [];
+        const loading = loadingByKey[def.key] ?? false;
+        const error = errorByKey[def.key];
+        const hasChanged = selected !== (current || '');
+        const serviceOptions =
+          selected && !services.includes(selected) ? [selected, ...services] : services;
+
+        return (
+          <div key={def.key} className={index === 0 ? '' : 'mt-4'}>
+            <div className="flex items-center justify-between mb-2">
+              <div className="text-xs text-slate-300">{def.label}</div>
+              {isAuto && (
+                <span className="text-[10px] px-2 py-0.5 bg-emerald-500/20 text-emerald-300 rounded border border-emerald-500/30">
+                  Auto-matched
+                </span>
+              )}
+            </div>
+
+            {loading ? (
+              <div className="flex items-center gap-2 py-2">
+                <div className="w-4 h-4 border-2 border-aqua-500 border-t-transparent rounded-full animate-spin" />
+                <span className="text-sm text-slate-400">Loading available services...</span>
+              </div>
+            ) : (
+              <>
+                {!isEditing && current ? (
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="flex-1 text-xs text-slate-400 font-mono break-all"
+                      title={current}
+                    >
+                      {current}
+                    </span>
+                    <button
+                      onClick={() => setEditingByKey((prev) => ({ ...prev, [def.key]: true }))}
+                      className="text-xs text-slate-500 hover:text-slate-300"
+                      type="button"
+                    >
+                      Edit
+                    </button>
+                  </div>
+                ) : (
+                  <div className="flex gap-2">
+                    <select
+                      value={selected}
+                      onChange={(e) =>
+                        setSelectedByKey((prev) => ({ ...prev, [def.key]: e.target.value }))
+                      }
+                      disabled={saving}
+                      className="flex-1 text-sm bg-slate-900 border border-slate-600 rounded px-3 py-2 text-slate-200 focus:border-aqua-500 focus:outline-none disabled:opacity-50"
+                    >
+                      <option value="">Select service...</option>
+                      {serviceOptions.map((s) => (
+                        <option key={s} value={s}>
+                          {s}
+                        </option>
+                      ))}
+                    </select>
+
+                    <button
+                      onClick={() => handleSave(def.key)}
+                      disabled={!selected || saving || !hasChanged}
+                      className="px-4 py-2 bg-aqua-500 hover:bg-aqua-400 text-slate-900 rounded font-medium text-sm disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    >
+                      {saving ? 'Saving...' : 'Save'}
+                    </button>
+                  </div>
+                )}
+
+                {error && (
+                  <p className="text-xs text-amber-400 mt-2 flex items-center gap-1">
+                    <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+                      <path
+                        fillRule="evenodd"
+                        d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                    {error}
+                  </p>
+                )}
+
+                {!loading && services.length === 0 && !error && (
+                  <p className="text-xs text-slate-500 mt-2">{def.emptyMessage}</p>
+                )}
+
+                {!current && !loading && (
+                  <p className="text-xs text-amber-300 mt-2">
+                    Could not auto-discover this service. Please select it above.
+                  </p>
+                )}
+              </>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};


### PR DESCRIPTION
Entity re‑sync now auto‑discovers ESPHome firmware services (get_build_flags and set_update_manifest) alongside entity mappings. 

These are stored in the device mapping and used as the single source of truth for update checks and OTA installs. If auto‑discovery fails, the  UI warns the user and provides manual selection, with confirmed mappings preserved across re‑syncs.