### PR TITLE
Feature: Allow configuring of add-on app port

### DIFF
--- a/everything-presence-mmwave-configurator/config.yaml
+++ b/everything-presence-mmwave-configurator/config.yaml
@@ -18,7 +18,7 @@ ports:
   3000/tcp: null
   38080/tcp: 38080
 ports_description:
-  3000/tcp: Optional direct access (ingress preferred)
+  3000/tcp: Optional direct access (ingress preferred, configurable in add-on settings)
   38080/tcp: LAN firmware server for device OTA updates (configurable in add-on settings)
 homeassistant_api: true
 auth_api: true
@@ -34,6 +34,8 @@ map:
   - config:rw
   - share:rw
 options:
+  port: 3000
   firmware_lan_port: 38080
 schema:
+  port: port
   firmware_lan_port: port

--- a/everything-presence-mmwave-configurator/rootfs/etc/s6-overlay/s6-rc.d/zone-configurator/run
+++ b/everything-presence-mmwave-configurator/rootfs/etc/s6-overlay/s6-rc.d/zone-configurator/run
@@ -4,7 +4,12 @@ set -euo pipefail
 
 cd /app
 export NODE_ENV="${NODE_ENV:-production}"
-export PORT="${PORT:-3000}"
+APP_PORT_CONFIG="$(bashio::config 'port')"
+if [ -n "${APP_PORT_CONFIG}" ] && [ "${APP_PORT_CONFIG}" != "null" ]; then
+  export PORT="${APP_PORT_CONFIG}"
+else
+  export PORT="${PORT:-3000}"
+fi
 FIRMWARE_LAN_PORT_CONFIG="$(bashio::config 'firmware_lan_port')"
 if [ -n "${FIRMWARE_LAN_PORT_CONFIG}" ] && [ "${FIRMWARE_LAN_PORT_CONFIG}" != "null" ]; then
   export FIRMWARE_LAN_PORT="${FIRMWARE_LAN_PORT_CONFIG}"
@@ -13,6 +18,9 @@ else
 fi
 
 bashio::log.info "Starting Zone Configurator backend on port ${PORT}"
+if [ "${PORT}" != "3000" ]; then
+  bashio::log.warning "Ingress is configured for port 3000. Changing the app port may disable ingress access."
+fi
 bashio::log.info "LAN Firmware Server will start on port ${FIRMWARE_LAN_PORT}"
 
 exec node backend/dist/index.js


### PR DESCRIPTION
Allow the app and LAN ports to be configurable. There is a caveat that if you change the add‑on’s app port away from 3000, Home
  Assistant’s built‑in “Open Web UI” button (ingress) will stop
  working because it only proxies to port 3000. You’ll still be able
  to access the UI directly via http://<home-assistant-host>:<new-
  port>, but not through the HA sidebar (unless using an iframe or similar)