### PR TITLE
Fix: Change default  port to avoid conflicting with other add-ons

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ everythingsmarthome/everything-presence-mmwave-configurator:latest
 
 Set `HA_BASE_URL` and `HA_LONG_LIVED_TOKEN` for standalone mode. The `:addon` tag is the Home Assistant add-on base image and requires Supervisor to run.
 
+**Port change (v2.0.11):** The default app port is now `42069`. Existing Docker users can either update their port mapping to `42069:42069` or keep the old behavior by setting `PORT=3000` and continuing to map `3000:3000`.
+
 Example `docker-compose.yaml`:
 
 ```yaml
@@ -53,7 +55,7 @@ services:
     container_name: everything-presence-mmwave-configurator
     restart: unless-stopped
     ports:
-      - "3000:3000"
+      - "42069:42069"
       - "38080:38080"
     environment:
       HA_BASE_URL: "http://homeassistant.local:8123"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     container_name: everything-presence-mmwave-configurator
     restart: unless-stopped
     ports:
-      - "3000:3000"
+      - "42069:42069"
       - "38080:38080"
     environment:
       HA_BASE_URL: "http://homeassistant.local:8123"

--- a/everything-presence-mmwave-configurator/Dockerfile
+++ b/everything-presence-mmwave-configurator/Dockerfile
@@ -19,7 +19,7 @@ RUN npm prune --omit=dev --workspaces
 FROM ${BUILD_FROM} AS addon
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV NODE_ENV=production \
-    PORT=3000 \
+    PORT=42069 \
     FIRMWARE_LAN_PORT=38080 \
     FRONTEND_DIST=/app/frontend/dist
 WORKDIR /app
@@ -38,12 +38,12 @@ COPY rootfs/ /
 RUN rm -rf /etc/services.d/zone-configurator && \
     chmod +x /etc/s6-overlay/s6-rc.d/zone-configurator/run
 
-EXPOSE 3000/tcp 38080/tcp
+EXPOSE 42069/tcp 38080/tcp
 
 FROM node:20-alpine AS standalone
 WORKDIR /app
 ENV NODE_ENV=production \
-    PORT=3000 \
+    PORT=42069 \
     FIRMWARE_LAN_PORT=38080 \
     FRONTEND_DIST=/app/frontend/dist
 
@@ -55,7 +55,7 @@ COPY --from=build /app/backend/dist ./backend/dist
 COPY --from=build /app/frontend/dist ./frontend/dist
 COPY config ./config
 
-EXPOSE 3000/tcp 38080/tcp
+EXPOSE 42069/tcp 38080/tcp
 CMD ["node", "backend/dist/index.js"]
 
 # Default build target for Home Assistant add-on builds.

--- a/everything-presence-mmwave-configurator/backend/src/config.ts
+++ b/everything-presence-mmwave-configurator/backend/src/config.ts
@@ -26,7 +26,7 @@ export interface AppConfig {
   firmware: FirmwareConfig;
 }
 
-const DEFAULT_PORT = 3000;
+const DEFAULT_PORT = 42069;
 const DEFAULT_FIRMWARE_LAN_PORT = 38080;
 const DEFAULT_MAX_VERSIONS_PER_DEVICE = 3;
 const DEFAULT_FRONTEND_DIST = path.resolve(__dirname, '../../frontend/dist');

--- a/everything-presence-mmwave-configurator/config.yaml
+++ b/everything-presence-mmwave-configurator/config.yaml
@@ -10,15 +10,15 @@ arch:
 startup: services
 boot: auto
 ingress: true
-ingress_port: 3000
+ingress_port: 42069
 panel_icon: mdi:radar
 panel_title: Zone Configurator
-watchdog: "http://[HOST]:[PORT:3000]/api/health"
+watchdog: "http://[HOST]:[PORT:42069]/api/health"
 ports:
-  3000/tcp: null
+  42069/tcp: null
   38080/tcp: 38080
 ports_description:
-  3000/tcp: Optional direct access (ingress preferred, configurable in add-on settings)
+  42069/tcp: Optional direct access (ingress preferred, configurable in add-on settings)
   38080/tcp: LAN firmware server for device OTA updates (configurable in add-on settings)
 homeassistant_api: true
 auth_api: true
@@ -28,13 +28,13 @@ stdin: true
 stdin_open: true
 init: false
 environment:
-  PORT: "3000"
+  PORT: "42069"
   FIRMWARE_LAN_PORT: "38080"
 map:
   - config:rw
   - share:rw
 options:
-  port: 3000
+  port: 42069
   firmware_lan_port: 38080
 schema:
   port: port

--- a/everything-presence-mmwave-configurator/rootfs/etc/s6-overlay/s6-rc.d/zone-configurator/run
+++ b/everything-presence-mmwave-configurator/rootfs/etc/s6-overlay/s6-rc.d/zone-configurator/run
@@ -8,7 +8,7 @@ APP_PORT_CONFIG="$(bashio::config 'port')"
 if [ -n "${APP_PORT_CONFIG}" ] && [ "${APP_PORT_CONFIG}" != "null" ]; then
   export PORT="${APP_PORT_CONFIG}"
 else
-  export PORT="${PORT:-3000}"
+  export PORT="${PORT:-42069}"
 fi
 FIRMWARE_LAN_PORT_CONFIG="$(bashio::config 'firmware_lan_port')"
 if [ -n "${FIRMWARE_LAN_PORT_CONFIG}" ] && [ "${FIRMWARE_LAN_PORT_CONFIG}" != "null" ]; then
@@ -18,8 +18,8 @@ else
 fi
 
 bashio::log.info "Starting Zone Configurator backend on port ${PORT}"
-if [ "${PORT}" != "3000" ]; then
-  bashio::log.warning "Ingress is configured for port 3000. Changing the app port may disable ingress access."
+if [ "${PORT}" != "42069" ]; then
+  bashio::log.warning "Ingress is configured for port 42069. Changing the app port may disable ingress access."
 fi
 bashio::log.info "LAN Firmware Server will start on port ${FIRMWARE_LAN_PORT}"
 


### PR DESCRIPTION
## Breaking change for Docker users

The default port changes in this release from 3000 to 42069, this avoids conflicting  with other addons that are using  port 3000, such as zwave-js-ui