### PR TITLE
Support HA_LONG_LIVED_TOKEN_FILE for standalone auth

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/config.ts
+++ b/everything-presence-mmwave-configurator/backend/src/config.ts
@@ -98,7 +98,7 @@ const detectHaConfig = (): HaConfig => {
   }
 
   throw new Error(
-    'Home Assistant credentials are not configured. Provide SUPERVISOR_TOKEN (add-on) or HA_BASE_URL and HA_LONG_LIVED_TOKEN (standalone).',
+    'Home Assistant credentials are not configured. Provide SUPERVISOR_TOKEN (add-on) or HA_BASE_URL and HA_LONG_LIVED_TOKEN/HA_LONG_LIVED_TOKEN_FILE (standalone).',
   );
 };
 


### PR DESCRIPTION
### Why
This enables Docker/Kubernetes secret mounts and avoids storing tokens directly in environment variables.
https://docs.docker.com/engine/swarm/secrets/#build-support-for-docker-secrets-into-your-images
### Notes
**This change was not tested locally.**
- File content is read synchronously and trimmed
- File value takes precedence over `HA_LONG_LIVED_TOKEN`

Fixes #62