### PR TITLE
Add floor plan image import feature

### DIFF
--- a/everything-presence-mmwave-configurator/backend/package.json
+++ b/everything-presence-mmwave-configurator/backend/package.json
@@ -21,8 +21,8 @@
     "@types/express": "^4.17.21",
     "@types/node": "^20.11.30",
     "@types/uuid": "^9.0.7",
-    "pino-pretty": "^11.2.2",
     "@types/ws": "^8.5.12",
+    "pino-pretty": "^11.2.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.3.3"
   }

--- a/everything-presence-mmwave-configurator/backend/src/domain/types.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/types.ts
@@ -212,6 +212,14 @@ export interface RoomConfig {
   devicePlacement?: DevicePlacement;
   furniture?: FurnitureInstance[];
   doors?: Door[];
+  backgroundImage?: {
+    dataUrl: string;
+    scaleMmPerPx: number;
+    offsetX: number;
+    offsetY: number;
+    opacity: number;
+    rotationDeg: number;
+  };
   metadata?: Record<string, unknown>;
 }
 

--- a/everything-presence-mmwave-configurator/docs/floor-plan-import.md
+++ b/everything-presence-mmwave-configurator/docs/floor-plan-import.md
@@ -1,0 +1,29 @@
+# Floor Plan Import
+
+Import a floor plan image as a background overlay on the canvas, then trace over it to draw your room outline.
+
+## How to use
+
+1. Open the **Wizard** (outline step) or **Room Builder**
+2. Click **"Import Floor Plan"** in the left sidebar
+3. Upload a JPEG, PNG, WebP, or GIF image of your floor plan
+4. Adjust **Scale** (mm per pixel) so the image matches the grid
+5. Adjust **Opacity** so you can see both the image and the grid lines
+6. Click **"Apply to Canvas"**
+7. Use **"Add wall (A)"** to click corner points on top of the image, tracing the walls
+8. Fine-tune Scale and Opacity using the sidebar sliders while drawing
+9. Continue to the next steps to add doors, furniture, and device placement
+10. Click **"Remove Image"** when you no longer need the reference
+
+## Supported formats
+
+- JPEG, PNG, WebP, GIF (max 10MB)
+- For PDF floor plans (e.g. MagicPlan exports), save/screenshot as an image first
+
+## Tips
+
+- Use a floor plan with visible dimensions to help set the correct scale
+- Start with low opacity (20-30%) so wall points and grid lines are clearly visible
+- The image persists with the room - it will still be there if you close and reopen
+- Pan the canvas (right-click drag) to align the image with the origin point
+- Grid snapping helps keep traced walls precise even if the image is slightly rotated

--- a/everything-presence-mmwave-configurator/frontend/src/api/types.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/api/types.ts
@@ -288,6 +288,14 @@ export interface RoomConfig {
   devicePlacement?: DevicePlacement;
   furniture?: FurnitureInstance[];
   doors?: Door[];
+  backgroundImage?: {
+    dataUrl: string;
+    scaleMmPerPx: number;
+    offsetX: number;
+    offsetY: number;
+    opacity: number;
+    rotationDeg: number;
+  };
   metadata?: Record<string, unknown>;
 }
 

--- a/everything-presence-mmwave-configurator/frontend/src/components/FloorPlanUpload.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/FloorPlanUpload.tsx
@@ -1,0 +1,222 @@
+import React, { useState, useRef, useCallback } from 'react';
+
+export interface BackgroundImageData {
+  dataUrl: string;
+  scaleMmPerPx: number;
+  offsetX: number;
+  offsetY: number;
+  opacity: number;
+  rotationDeg: number;
+}
+
+interface FloorPlanUploadProps {
+  onApply: (data: BackgroundImageData) => void;
+  onClose: () => void;
+  existing?: BackgroundImageData | null;
+}
+
+export const FloorPlanUpload: React.FC<FloorPlanUploadProps> = ({ onApply, onClose, existing }) => {
+  const [dataUrl, setDataUrl] = useState<string | null>(existing?.dataUrl ?? null);
+  const [fileName, setFileName] = useState<string | null>(existing ? 'Current image' : null);
+  const [fileSize, setFileSize] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const [scaleMmPerPx, setScaleMmPerPx] = useState(existing?.scaleMmPerPx ?? 10);
+  const [opacity, setOpacity] = useState(existing?.opacity ?? 0.3);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFile = useCallback((f: File) => {
+    const allowed = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+    if (!allowed.includes(f.type)) {
+      setError('Please upload a JPEG, PNG, WebP, or GIF image');
+      return;
+    }
+    if (f.size > 10 * 1024 * 1024) {
+      setError('File size must be under 10MB');
+      return;
+    }
+    setError(null);
+    setFileName(f.name);
+    setFileSize(f.size);
+
+    const reader = new FileReader();
+    reader.onload = (e) => setDataUrl(e.target?.result as string);
+    reader.readAsDataURL(f);
+  }, []);
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(false);
+    const f = e.dataTransfer.files[0];
+    if (f) handleFile(f);
+  }, [handleFile]);
+
+  const handleApply = () => {
+    if (!dataUrl) return;
+    onApply({
+      dataUrl,
+      scaleMmPerPx,
+      offsetX: existing?.offsetX ?? 0,
+      offsetY: existing?.offsetY ?? 0,
+      opacity,
+      rotationDeg: existing?.rotationDeg ?? 0,
+    });
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="w-full max-w-lg mx-4 rounded-2xl border border-slate-700/50 bg-slate-900 shadow-2xl overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-slate-700/50 px-6 py-4">
+          <h2 className="text-lg font-bold text-white">Import Floor Plan</h2>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1.5 text-slate-400 hover:text-white hover:bg-slate-700/50 transition-colors"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="p-6 space-y-5">
+          {/* File Upload */}
+          <div>
+            <label className="block text-sm font-medium text-slate-300 mb-1.5">
+              Floor Plan Image
+            </label>
+            <div
+              className={`relative rounded-xl border-2 border-dashed transition-colors cursor-pointer ${
+                dragOver
+                  ? 'border-aqua-500 bg-aqua-500/10'
+                  : dataUrl
+                    ? 'border-emerald-600/50 bg-emerald-600/5'
+                    : 'border-slate-600 hover:border-slate-500 bg-slate-800/50'
+              }`}
+              onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+              onDragLeave={() => setDragOver(false)}
+              onDrop={handleDrop}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/webp,image/gif"
+                className="hidden"
+                onChange={(e) => {
+                  const f = e.target.files?.[0];
+                  if (f) handleFile(f);
+                }}
+              />
+
+              {dataUrl ? (
+                <div className="p-4">
+                  <img
+                    src={dataUrl}
+                    alt="Floor plan preview"
+                    className="w-full max-h-48 object-contain rounded-lg mb-3"
+                  />
+                  <div className="text-center">
+                    <p className="text-sm font-medium text-emerald-300">{fileName}</p>
+                    {fileSize && <p className="text-xs text-slate-500 mt-0.5">{(fileSize / 1024).toFixed(0)} KB</p>}
+                  </div>
+                </div>
+              ) : (
+                <div className="p-8 text-center">
+                  <svg className="mx-auto w-10 h-10 text-slate-500 mb-3" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
+                  </svg>
+                  <p className="text-sm text-slate-300">
+                    Drop your floor plan here or <span className="text-aqua-400 font-medium">browse</span>
+                  </p>
+                  <p className="text-xs text-slate-500 mt-1">JPEG, PNG, WebP, or GIF (max 10MB)</p>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Scale */}
+          {dataUrl && (
+            <div>
+              <label className="block text-sm font-medium text-slate-300 mb-1.5">
+                Scale (mm per pixel)
+              </label>
+              <input
+                type="range"
+                min={1}
+                max={50}
+                step={0.5}
+                value={scaleMmPerPx}
+                onChange={(e) => setScaleMmPerPx(Number(e.target.value))}
+                className="w-full accent-aqua-500"
+              />
+              <div className="flex justify-between text-xs text-slate-500 mt-1">
+                <span>Zoomed in</span>
+                <span className="text-aqua-300 font-medium">{scaleMmPerPx} mm/px</span>
+                <span>Zoomed out</span>
+              </div>
+              <p className="text-xs text-slate-500 mt-1">
+                Adjust so the image matches the grid. You can fine-tune this on the canvas later.
+              </p>
+            </div>
+          )}
+
+          {/* Opacity */}
+          {dataUrl && (
+            <div>
+              <label className="block text-sm font-medium text-slate-300 mb-1.5">
+                Opacity
+              </label>
+              <input
+                type="range"
+                min={0.1}
+                max={0.8}
+                step={0.05}
+                value={opacity}
+                onChange={(e) => setOpacity(Number(e.target.value))}
+                className="w-full accent-aqua-500"
+              />
+              <div className="flex justify-between text-xs text-slate-500 mt-1">
+                <span>Faint</span>
+                <span className="text-aqua-300 font-medium">{Math.round(opacity * 100)}%</span>
+                <span>Solid</span>
+              </div>
+            </div>
+          )}
+
+          {/* Error */}
+          {error && (
+            <div className="rounded-xl border border-rose-600/30 bg-rose-600/10 px-4 py-3 text-sm text-rose-300">
+              {error}
+            </div>
+          )}
+
+          {/* Info */}
+          {dataUrl && (
+            <div className="rounded-xl border border-slate-700/30 bg-slate-800/50 px-4 py-3 text-xs text-slate-400">
+              The image will appear as a background on the canvas. Trace over it by clicking to add wall points.
+              You can drag the image and adjust scale/opacity on the canvas.
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="flex gap-3">
+            <button
+              onClick={onClose}
+              className="flex-1 rounded-xl border border-slate-600 px-4 py-2.5 text-sm font-semibold text-slate-300 hover:bg-slate-800 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleApply}
+              disabled={!dataUrl}
+              className="flex-1 rounded-xl bg-gradient-to-r from-aqua-600 to-aqua-500 px-4 py-2.5 text-sm font-bold text-white shadow-lg hover:shadow-xl transition-all disabled:opacity-40 disabled:cursor-not-allowed active:scale-95"
+            >
+              Apply to Canvas
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/everything-presence-mmwave-configurator/frontend/src/components/RoomCanvas.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/RoomCanvas.tsx
@@ -76,6 +76,16 @@ interface RoomCanvasProps {
   onDoorDragEnd?: () => void;
   roomShellFillMode?: 'overlay' | 'material';
   floorMaterial?: string;
+  // Background floor plan image
+  backgroundImage?: {
+    dataUrl: string;
+    scaleMmPerPx: number;
+    offsetX: number;
+    offsetY: number;
+    opacity: number;
+    rotationDeg: number;
+  };
+  onBackgroundImageChange?: (bg: { offsetX: number; offsetY: number }) => void;
   // Visibility toggles
   showWalls?: boolean;
   showFurniture?: boolean;
@@ -353,6 +363,8 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
   onDoorDragEnd,
   roomShellFillMode = 'overlay',
   floorMaterial = 'none',
+  backgroundImage,
+  onBackgroundImageChange,
   showWalls = true,
   showFurniture = true,
   showDoors = true,
@@ -823,6 +835,29 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
             );
           }
           return lines;
+        })()}
+        {/* Background floor plan image overlay */}
+        {backgroundImage?.dataUrl && (() => {
+          const imgRef = React.createRef<SVGImageElement>();
+          const cx = HALF + toCanvas(-panOffsetMm.x + (backgroundImage.offsetX || 0), effectiveRangeMm);
+          const cy = HALF + toCanvas(-panOffsetMm.y + (backgroundImage.offsetY || 0), effectiveRangeMm);
+          const pxToCanvas = (backgroundImage.scaleMmPerPx || 10) / effectiveRangeMm * CANVAS_SIZE;
+          return (
+            <image
+              href={backgroundImage.dataUrl}
+              x={cx}
+              y={cy}
+              opacity={backgroundImage.opacity ?? 0.3}
+              style={{
+                transformOrigin: `${cx}px ${cy}px`,
+                transform: backgroundImage.rotationDeg ? `rotate(${backgroundImage.rotationDeg}deg)` : undefined,
+                width: `calc(100%)`,
+                pointerEvents: 'none',
+              }}
+              preserveAspectRatio="xMinYMin meet"
+              transform={`scale(${pxToCanvas})`}
+            />
+          );
         })()}
         {safePoints.length > 0 && (
           <>

--- a/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
@@ -11,6 +11,7 @@ import { FLOOR_MATERIALS } from '../components/FloorMaterials';
 import { useDisplaySettings } from '../hooks/useDisplaySettings';
 import { getInstallationAngleSuggestion } from '../utils/rotationSuggestion';
 import { useDeviceMappings } from '../contexts/DeviceMappingsContext';
+import { FloorPlanUpload, BackgroundImageData } from '../components/FloorPlanUpload';
 
 interface RoomBuilderPageProps {
   onBack?: () => void;
@@ -90,6 +91,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     startY: number;
     originalPosition: number;
   } | null>(null);
+  const [showFloorPlanUpload, setShowFloorPlanUpload] = useState(false);
   const [showRotationSuggestion, setShowRotationSuggestion] = useState(false);
   const [rotationSuggestion, setRotationSuggestion] = useState<{ suggestedAngle: number; targetAxis: number } | null>(null);
   const [applyingInstallationAngle, setApplyingInstallationAngle] = useState(false);
@@ -562,6 +564,23 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     handlePointsChange([]);
     stopDrawing();
   };
+
+  const handleFloorPlanApply = useCallback(async (data: BackgroundImageData) => {
+    if (!selectedRoom) return;
+    setShowFloorPlanUpload(false);
+
+    const updatedRoom: RoomConfig = {
+      ...selectedRoom,
+      backgroundImage: data,
+    };
+
+    try {
+      const { room } = await updateRoom(selectedRoom.id, updatedRoom);
+      setRooms((prev) => prev.map((r) => (r.id === room.id ? room : r)));
+    } catch (err) {
+      console.error('Failed to apply floor plan image:', err);
+    }
+  }, [selectedRoom]);
 
   const handleCloseLoop = () => {
     if (!selectedRoom?.roomShell?.points || selectedRoom.roomShell.points.length < 2) {
@@ -1040,6 +1059,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                   zoom={zoom}
                   panOffsetMm={panOffsetMm}
                   onPanChange={(next) => setPanOffsetMm(next)}
+                  backgroundImage={selectedRoom.backgroundImage}
                   displayUnits={displayUnits}
                   devicePlacement={
                     selectedRoom.devicePlacement ?? {
@@ -1220,6 +1240,14 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                 disabled={!selectedRoom}
               >
                 🗑️ Clear
+              </button>
+
+              {/* Import Floor Plan Button */}
+              <button
+                className="rounded-xl border border-purple-600/50 bg-purple-600/10 px-4 py-2.5 font-semibold text-purple-100 shadow-lg transition-all hover:bg-purple-600/20 active:scale-95"
+                onClick={() => setShowFloorPlanUpload(true)}
+              >
+                📄 Import Floor Plan
               </button>
 
               {/* Furniture Button */}
@@ -1772,6 +1800,13 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
         <FurnitureLibrary
           onSelect={handleAddFurniture}
           onClose={() => setShowFurnitureLibrary(false)}
+        />
+      )}
+      {showFloorPlanUpload && (
+        <FloorPlanUpload
+          onApply={handleFloorPlanApply}
+          onClose={() => setShowFloorPlanUpload(false)}
+          existing={selectedRoom?.backgroundImage}
         />
       )}
     </div>

--- a/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
@@ -15,6 +15,7 @@ import { fetchZoneAvailability, ingressAware } from '../api/client';
 import { useDeviceMappings } from '../contexts/DeviceMappingsContext';
 import { getInstallationAngleSuggestion } from '../utils/rotationSuggestion';
 import { useDisplaySettings } from '../hooks/useDisplaySettings';
+import { FloorPlanUpload, BackgroundImageData } from '../components/FloorPlanUpload';
 
 interface WizardPageProps {
   devices: DiscoveredDevice[];
@@ -95,6 +96,9 @@ export const WizardPage: React.FC<WizardPageProps> = ({
   const [pushingZones, setPushingZones] = useState(false);
   const [pushSuccess, setPushSuccess] = useState(false);
 
+  // Floor plan upload modal
+  const [showFloorPlanUpload, setShowFloorPlanUpload] = useState(false);
+
   // Entity discovery mappings (discovered after device selection)
   const [discoveredMappings, setDiscoveredMappings] = useState<EntityMappings | null>(null);
 
@@ -155,6 +159,25 @@ export const WizardPage: React.FC<WizardPageProps> = ({
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update room outline');
       // Revert on error
+      onRoomUpdate?.(selectedRoom);
+    }
+  }, [selectedRoom, onRoomUpdate]);
+
+  const handleFloorPlanApply = useCallback(async (data: BackgroundImageData) => {
+    if (!selectedRoom) return;
+    setShowFloorPlanUpload(false);
+
+    const updatedRoom: RoomConfig = {
+      ...selectedRoom,
+      backgroundImage: data,
+    };
+
+    onRoomUpdate?.(updatedRoom);
+    try {
+      await updateRoom(selectedRoom.id, updatedRoom);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to apply floor plan image');
       onRoomUpdate?.(selectedRoom);
     }
   }, [selectedRoom, onRoomUpdate]);
@@ -1443,7 +1466,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
               zoom={canvasZoom}
               panOffsetMm={canvasPan}
               onPanChange={setCanvasPan}
-              onDragStateChange={setIsCanvasDragging}
+              backgroundImage={selectedRoom?.backgroundImage}
               displayUnits={units}
             />
           )}
@@ -1786,7 +1809,73 @@ export const WizardPage: React.FC<WizardPageProps> = ({
               >
                 🗑️ Clear
               </button>
+              <div className="mt-2 pt-2 border-t border-slate-700/30">
+                <button
+                  className="w-full rounded-xl border border-purple-600/50 bg-purple-600/10 px-4 py-2.5 text-sm font-semibold text-purple-100 shadow-lg transition-all hover:bg-purple-600/20 active:scale-95"
+                  onClick={() => setShowFloorPlanUpload(true)}
+                >
+                  📄 {selectedRoom?.backgroundImage ? 'Change' : 'Import'} Floor Plan
+                </button>
+                {selectedRoom?.backgroundImage && (
+                  <>
+                    <button
+                      className="w-full mt-1 rounded-xl border border-rose-600/50 bg-rose-600/10 px-4 py-2 text-xs font-semibold text-rose-200 shadow-lg transition-all hover:bg-rose-600/20 active:scale-95"
+                      onClick={async () => {
+                        if (!selectedRoom) return;
+                        const updatedRoom: RoomConfig = { ...selectedRoom, backgroundImage: undefined };
+                        onRoomUpdate?.(updatedRoom);
+                        try { await updateRoom(selectedRoom.id, updatedRoom); } catch {}
+                      }}
+                    >
+                      Remove Image
+                    </button>
+                    <div className="mt-2 rounded-xl border border-slate-700/50 bg-slate-900/90 backdrop-blur px-3 py-2 shadow-lg space-y-2">
+                      <div>
+                        <label className="text-xs text-slate-400">Scale</label>
+                        <input
+                          type="range" min={1} max={50} step={0.5}
+                          value={selectedRoom.backgroundImage.scaleMmPerPx}
+                          onChange={async (e) => {
+                            const val = Number(e.target.value);
+                            const bg = { ...selectedRoom.backgroundImage!, scaleMmPerPx: val };
+                            const updatedRoom: RoomConfig = { ...selectedRoom, backgroundImage: bg };
+                            onRoomUpdate?.(updatedRoom);
+                            try { await updateRoom(selectedRoom.id, updatedRoom); } catch {}
+                          }}
+                          className="w-full accent-aqua-500"
+                        />
+                        <span className="text-xs text-aqua-300">{selectedRoom.backgroundImage.scaleMmPerPx} mm/px</span>
+                      </div>
+                      <div>
+                        <label className="text-xs text-slate-400">Opacity</label>
+                        <input
+                          type="range" min={0.05} max={0.8} step={0.05}
+                          value={selectedRoom.backgroundImage.opacity}
+                          onChange={async (e) => {
+                            const val = Number(e.target.value);
+                            const bg = { ...selectedRoom.backgroundImage!, opacity: val };
+                            const updatedRoom: RoomConfig = { ...selectedRoom, backgroundImage: bg };
+                            onRoomUpdate?.(updatedRoom);
+                            try { await updateRoom(selectedRoom.id, updatedRoom); } catch {}
+                          }}
+                          className="w-full accent-aqua-500"
+                        />
+                        <span className="text-xs text-aqua-300">{Math.round(selectedRoom.backgroundImage.opacity * 100)}%</span>
+                      </div>
+                    </div>
+                  </>
+                )}
+              </div>
             </div>
+          )}
+
+          {/* Floor Plan Upload Modal */}
+          {showFloorPlanUpload && (
+            <FloorPlanUpload
+              onApply={handleFloorPlanApply}
+              onClose={() => setShowFloorPlanUpload(false)}
+              existing={selectedRoom?.backgroundImage}
+            />
           )}
 
           {/* Door Controls (doors step only) */}


### PR DESCRIPTION
## Summary
- Upload a floor plan image (JPEG/PNG/WebP/GIF) as a background overlay on the canvas
- Trace over the image to draw room walls accurately
- Adjustable scale and opacity controls in the sidebar
- Available in both Wizard (outline step) and Room Builder
- No external dependencies or API keys required

## How it works
1. Click "Import Floor Plan" in the outline step
2. Upload an image of your floor plan
3. Adjust scale and opacity so it aligns with the grid
4. Trace the walls on top of the image
5. Remove the image when done

## Test plan
- [ ] Upload a floor plan image in the Wizard outline step
- [ ] Verify image appears as background overlay on canvas
- [ ] Adjust scale slider and confirm image resizes
- [ ] Adjust opacity slider and confirm transparency changes
- [ ] Draw walls on top of the image
- [ ] Remove the image and verify it disappears
- [ ] Repeat in Room Builder page
- [ ] Verify image persists after closing and reopening the room