### PR TITLE
fix stale installation angle synchronization after applying rotation suggestion

### DIFF
--- a/everything-presence-mmwave-configurator/frontend/src/App.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/App.tsx
@@ -98,6 +98,49 @@ function App() {
     [profiles, selectedProfileId]
   );
 
+  const refreshLiveState = React.useCallback(async () => {
+    if (!selectedRoom || !selectedRoom.deviceId || !selectedProfile) {
+      setLiveState(null);
+      return;
+    }
+
+    const entityParam = selectedRoom.entityNamePrefix
+      ? `&entityNamePrefix=${encodeURIComponent(selectedRoom.entityNamePrefix)}`
+      : '';
+    const mappingsParam = selectedRoom.entityMappings
+      ? `&entityMappings=${encodeURIComponent(JSON.stringify(selectedRoom.entityMappings))}`
+      : '';
+    const restUrl = ingressAware(
+      `api/live/${selectedRoom.deviceId}/state?profileId=${selectedProfile.id}${entityParam}${mappingsParam}`
+    );
+
+    try {
+      const res = await fetch(restUrl);
+      if (!res.ok) {
+        throw new Error('Failed to refresh live state');
+      }
+      const data = await res.json() as { state?: LiveState };
+      setLiveState(data.state ?? null);
+    } catch {
+      // Keep the current live state if the refresh fails.
+    }
+  }, [selectedProfile, selectedRoom]);
+
+  useEffect(() => {
+    const handleRefresh = (event: Event) => {
+      const detail = (event as CustomEvent<{ deviceId?: string }>).detail;
+      if (detail?.deviceId && detail.deviceId !== selectedRoom?.deviceId) {
+        return;
+      }
+      void refreshLiveState();
+    };
+
+    window.addEventListener('ep:refresh-live-state', handleRefresh as EventListener);
+    return () => {
+      window.removeEventListener('ep:refresh-live-state', handleRefresh as EventListener);
+    };
+  }, [refreshLiveState, selectedRoom?.deviceId]);
+
   // WebSocket connection for real-time state updates (global)
   useEffect(() => {
     if (!selectedRoom || !selectedRoom.deviceId || !selectedProfile) {
@@ -149,14 +192,7 @@ function App() {
               if (message.hasMappings === false) {
                 console.warn('Device subscribed but no mappings available');
               }
-              // Fetch initial state via REST as fallback
-              const entityParam = selectedRoom.entityNamePrefix ? `&entityNamePrefix=${selectedRoom.entityNamePrefix}` : '';
-              const mappingsParam = selectedRoom.entityMappings ? `&entityMappings=${encodeURIComponent(JSON.stringify(selectedRoom.entityMappings))}` : '';
-              const restUrl = ingressAware(`api/live/${selectedRoom.deviceId}/state?profileId=${selectedProfile.id}${entityParam}${mappingsParam}`);
-              fetch(restUrl)
-                .then((res) => res.json())
-                .then((data) => setLiveState(data.state))
-                .catch(() => null);
+              void refreshLiveState();
             } else if (message.type === 'state_update') {
               // Update live state with new entity value
               setLiveState((prev) => {
@@ -461,7 +497,7 @@ function App() {
       }
     };
     // Depend on memoized room/profile objects - only changes when the actual objects change
-  }, [selectedRoom, selectedProfile]);
+  }, [refreshLiveState, selectedRoom, selectedProfile]);
 
   // Transform device-relative coordinates to room coordinates
   const installationAngle =

--- a/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
@@ -257,6 +257,11 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
         throw new Error('Failed to update installation angle');
       }
 
+      window.dispatchEvent(
+        new CustomEvent('ep:refresh-live-state', {
+          detail: { deviceId: selectedRoom.deviceId },
+        })
+      );
       setShowRotationSuggestion(false);
     } catch (err) {
       setRotationSuggestionError('Failed to update installation angle.');
@@ -847,20 +852,34 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     }
   };
 
-  const handleSaveRoom = async () => {
-    if (!selectedRoom) return;
+  const handleSaveRoom = async (): Promise<boolean> => {
+    if (!selectedRoom) return false;
     setSaving(true);
     try {
       const result = await updateRoom(selectedRoom.id, selectedRoom);
       setRooms((prev) => prev.map((r) => (r.id === selectedRoom.id ? result.room : r)));
       onWizardProgress?.({ outlineDone: true, placementDone: true });
       setError(null);
+      return true;
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save room');
+      return false;
     } finally {
       setSaving(false);
     }
   };
+
+  const navigateWithSave = useCallback(
+    async (view: 'wizard' | 'zoneEditor' | 'roomBuilder' | 'settings' | 'liveDashboard') => {
+      if (!onNavigate) return;
+      if (selectedRoom) {
+        const saved = await handleSaveRoom();
+        if (!saved) return;
+      }
+      onNavigate(view);
+    },
+    [onNavigate, selectedRoom, handleSaveRoom]
+  );
 
   const handleAutoZoom = useCallback((room: RoomConfig | null) => {
     if (!room?.roomShell?.points?.length) {
@@ -1002,8 +1021,8 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
               <div className="absolute top-14 left-0 z-50 min-w-[200px] rounded-xl border border-slate-700/50 bg-slate-900/95 backdrop-blur shadow-2xl overflow-hidden">
                 <div className="p-2 space-y-1">
                   <button
-                    onClick={() => {
-                      onNavigate('liveDashboard');
+                    onClick={async () => {
+                      await navigateWithSave('liveDashboard');
                       setShowNavMenu(false);
                     }}
                     className="w-full text-left px-4 py-2.5 text-sm font-medium text-slate-100 rounded-lg transition-all hover:bg-aqua-600/20 hover:text-aqua-400 active:scale-95"
@@ -1011,8 +1030,8 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                     📡 Live Dashboard
                   </button>
                   <button
-                    onClick={() => {
-                      onNavigate('wizard');
+                    onClick={async () => {
+                      await navigateWithSave('wizard');
                       setShowNavMenu(false);
                     }}
                     className="w-full text-left px-4 py-2.5 text-sm font-medium text-slate-100 rounded-lg transition-all hover:bg-aqua-600/20 hover:text-aqua-400 active:scale-95"
@@ -1020,8 +1039,8 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                     ➕ Add Device
                   </button>
                   <button
-                    onClick={() => {
-                      onNavigate('zoneEditor');
+                    onClick={async () => {
+                      await navigateWithSave('zoneEditor');
                       setShowNavMenu(false);
                     }}
                     className="w-full text-left px-4 py-2.5 text-sm font-medium text-slate-100 rounded-lg transition-all hover:bg-aqua-600/20 hover:text-aqua-400 active:scale-95"
@@ -1029,8 +1048,8 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                     📐 Zone Editor
                   </button>
                   <button
-                    onClick={() => {
-                      onNavigate('settings');
+                    onClick={async () => {
+                      await navigateWithSave('settings');
                       setShowNavMenu(false);
                     }}
                     className="w-full text-left px-4 py-2.5 text-sm font-medium text-slate-100 rounded-lg transition-all hover:bg-aqua-600/20 hover:text-aqua-400 active:scale-95"

--- a/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
@@ -79,6 +79,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
   const [showModeChangeConfirm, setShowModeChangeConfirm] = useState(false);
   // Zone labels from device mapping (stored separately from zone coordinates)
   const [deviceZoneLabels, setDeviceZoneLabels] = useState<Record<string, string>>({});
+  const [roomLiveState, setRoomLiveState] = useState<LiveState | null>(null);
   // Display settings (persisted to localStorage)
   const {
     showWalls, setShowWalls,
@@ -89,9 +90,6 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
     showTargets, setShowTargets,
     clipRadarToWalls,
   } = useDisplaySettings();
-  const liveState = propLiveState;
-  const installationAngle =
-    typeof liveState?.config?.installationAngle === 'number' ? liveState.config.installationAngle : 0;
   const loadedRoomRef = useRef<string | null>(null);
   const previousRoomIdRef = useRef<string | null>(null);
 
@@ -131,6 +129,12 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
   // Device mappings context - used to check if device has valid entity mappings
   const { hasValidMappings, clearCache } = useDeviceMappings();
   const deviceHasValidMappings = selectedRoom?.deviceId ? hasValidMappings(selectedRoom.deviceId) : false;
+  const hasPropLiveStateForRoom = Boolean(
+    propLiveState && selectedRoom?.deviceId && propLiveState.deviceId === selectedRoom.deviceId
+  );
+  const liveState = hasPropLiveStateForRoom ? propLiveState : roomLiveState;
+  const installationAngle =
+    typeof liveState?.config?.installationAngle === 'number' ? liveState.config.installationAngle : 0;
 
   // Generate all possible zone slots based on profile limits
   const allPossibleZones = useMemo(() => {
@@ -223,6 +227,64 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
     if (availability.status === 'disabled' || availability.status === 'unavailable') return false;
     return true;
   };
+
+  useEffect(() => {
+    if (hasPropLiveStateForRoom) {
+      setRoomLiveState(propLiveState);
+    }
+  }, [hasPropLiveStateForRoom, propLiveState]);
+
+  useEffect(() => {
+    if (!selectedRoom?.deviceId || !selectedRoom.profileId) {
+      setRoomLiveState(null);
+      return;
+    }
+
+    if (hasPropLiveStateForRoom) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadLiveState = async () => {
+      try {
+        const entityParam = selectedRoom.entityNamePrefix
+          ? `&entityNamePrefix=${encodeURIComponent(selectedRoom.entityNamePrefix)}`
+          : '';
+        const mappingsParam = selectedRoom.entityMappings
+          ? `&entityMappings=${encodeURIComponent(JSON.stringify(selectedRoom.entityMappings))}`
+          : '';
+        const res = await fetch(
+          ingressAware(
+            `api/live/${selectedRoom.deviceId}/state?profileId=${selectedRoom.profileId}${entityParam}${mappingsParam}`
+          )
+        );
+        if (!res.ok) {
+          throw new Error('Failed to load live state');
+        }
+        const data = await res.json() as { state?: LiveState };
+        if (!cancelled) {
+          setRoomLiveState(data.state ?? null);
+        }
+      } catch {
+        if (!cancelled) {
+          setRoomLiveState(null);
+        }
+      }
+    };
+
+    loadLiveState();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    hasPropLiveStateForRoom,
+    selectedRoom?.deviceId,
+    selectedRoom?.entityMappings,
+    selectedRoom?.entityNamePrefix,
+    selectedRoom?.profileId,
+  ]);
 
   const getZoneStatus = (zone: ZoneRect): 'enabled' | 'disabled' | 'unavailable' | 'unknown' => {
     const key = getAvailabilityKey(zone.id, zone.type);


### PR DESCRIPTION
Fix intermittent zone rotation after applying installation angle suggestions. 

This change keeps device rotation and installation angle in sync across Room Builder, Zone Editor, and Live Dashboard by saving room placement before navigation, fixing stale live states in Zone Editor, and forcing an live refresh afterapplying an installation angle update