### PR TITLE
Add ceiling zone editing for EP Pro

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/domain/entityDiscovery.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/entityDiscovery.ts
@@ -602,6 +602,10 @@ export class EntityDiscoveryService {
     const category = def.category;
 
     if (category === 'sensor') {
+      if (def.subcategory === 'zoneOccupancy' || def.subcategory === 'zoneTargetCount') {
+        (suggestedMappings as Record<string, unknown>)[entityKey] = entityId;
+        return;
+      }
       // Core sensors go at the root with Entity suffix for legacy compatibility
       const legacyKey = entityKey.endsWith('Entity') ? entityKey : `${entityKey}Entity`;
       (suggestedMappings as Record<string, unknown>)[legacyKey] = entityId;

--- a/everything-presence-mmwave-configurator/backend/src/domain/mappingUtils.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/mappingUtils.ts
@@ -30,6 +30,14 @@ export const canonicalKeyPairs: Array<[string, string]> = [
   ['firmwareUpdate', 'firmwareUpdateEntity'],
   ['installationAngle', 'installationAngleEntity'],
   ['polygonZonesEnabled', 'polygonZonesEnabledEntity'],
+  ['zone1OccupancyEntity', 'zone1Occupancy'],
+  ['zone2OccupancyEntity', 'zone2Occupancy'],
+  ['zone3OccupancyEntity', 'zone3Occupancy'],
+  ['zone4OccupancyEntity', 'zone4Occupancy'],
+  ['zone1TargetCountEntity', 'zone1TargetCount'],
+  ['zone2TargetCountEntity', 'zone2TargetCount'],
+  ['zone3TargetCountEntity', 'zone3TargetCount'],
+  ['zone4TargetCountEntity', 'zone4TargetCount'],
 ];
 
 export const canonicalKeys = canonicalKeyPairs.map(([, canonical]) => canonical);

--- a/everything-presence-mmwave-configurator/backend/src/routes/live.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/live.ts
@@ -344,6 +344,32 @@ export function createLiveRouter(
         liveState.config = config;
       }
 
+      // Zone occupancy states (EPL/EPP) from confirmed mappings only.
+      if (capabilities?.zones) {
+        for (let i = 1; i <= 4; i++) {
+          const mappingKey = `zone${i}Occupancy`;
+          let entityId: string | null = null;
+          if (hasDeviceMapping) {
+            entityId = deviceEntityService.getEntityId(deviceId, mappingKey);
+          } else {
+            const mapped = (entityMappings as Record<string, unknown> | undefined)?.[mappingKey];
+            entityId = typeof mapped === 'string' ? mapped : null;
+          }
+          if (!entityId) continue;
+
+          const occupancyState = await readTransport.getState(entityId).catch(() => null);
+          if (!occupancyState) continue;
+
+          markAvailability(mappingKey, occupancyState);
+          if (!isUnavailableState(occupancyState.state)) {
+            if (!liveState.zoneOccupancy) {
+              liveState.zoneOccupancy = {};
+            }
+            liveState.zoneOccupancy[`zone${i}`] = occupancyState.state === 'on';
+          }
+        }
+      }
+
       // Configuration entities (EP1)
       if (capabilities?.distanceOnlyTracking) {
         const config: any = {};

--- a/everything-presence-mmwave-configurator/backend/src/routes/liveWs.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/liveWs.ts
@@ -13,6 +13,7 @@ interface LiveClientSubscription {
   deviceId: string;
   profileId: string;
   entityIds: Set<string>;
+  entityKeysById: Map<string, string>;
   subscriptionId: string;
 }
 
@@ -33,10 +34,12 @@ export function createLiveWebSocketServer(
       // Broadcast to clients subscribed to this entity
       clients.forEach((subscription, clientWs) => {
         if (subscription.entityIds.has(entityId) && clientWs.readyState === WebSocket.OPEN) {
+          const entityKey = subscription.entityKeysById.get(entityId);
           try {
             clientWs.send(
               JSON.stringify({
                 type: 'state_update',
+                entityKey,
                 entityId,
                 state: newState.state,
                 attributes: newState.attributes,
@@ -115,6 +118,7 @@ export function createLiveWebSocketServer(
 
           // Build list of entity IDs to monitor using EntityResolver
           const entityIds = new Set<string>();
+          const entityKeysById = new Map<string, string>();
           const entityMap = profile.entityMap as any;
 
           // Helper to resolve entity ID - tries device mapping first, then legacy
@@ -130,6 +134,21 @@ export function createLiveWebSocketServer(
             }
             if (entityId) {
               entityIds.add(entityId);
+              entityKeysById.set(entityId, mappingKey);
+            }
+          };
+
+          const addMappedEntity = (mappingKey: string) => {
+            let entityId: string | null = null;
+            if (hasDeviceMapping) {
+              entityId = deviceEntityService.getEntityId(deviceId, mappingKey);
+            } else {
+              const mapped = (parsedMappings as Record<string, unknown> | undefined)?.[mappingKey];
+              entityId = typeof mapped === 'string' ? mapped : null;
+            }
+            if (entityId) {
+              entityIds.add(entityId);
+              entityKeysById.set(entityId, mappingKey);
             }
           };
 
@@ -186,7 +205,7 @@ export function createLiveWebSocketServer(
                 addEntity(zoneTargetCountKey, targetCountTemplate);
               }
               if (occupancyTemplate) {
-                addEntity(zoneOccupancyKey, occupancyTemplate);
+                addMappedEntity(zoneOccupancyKey);
               }
             }
           }
@@ -234,6 +253,7 @@ export function createLiveWebSocketServer(
             deviceId,
             profileId,
             entityIds,
+            entityKeysById,
             subscriptionId,
           });
 

--- a/everything-presence-mmwave-configurator/frontend/src/App.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/App.tsx
@@ -233,16 +233,16 @@ function App() {
 
                 // Helper to check zone occupancy entities from mappings
                 const checkZoneOccupancy = (): { matched: boolean; zoneNum?: number } => {
-                  // Check mapped zone occupancy entities first
-                  if (mappings?.trackingTargets) {
-                    // Zone occupancy entities aren't in trackingTargets, check settingsEntities or dedicated zone mappings
-                  }
-                  // For now, check each zone individually - these would be in a zoneOccupancyEntities mapping
-                  // Fall back to pattern matching for legacy rooms
-                  if (!mappings) {
-                    const match = message.entityId.match(/zone_(\d+)_(occupancy|presence)/);
-                    if (match) {
-                      return { matched: true, zoneNum: parseInt(match[1], 10) };
+                  const entityKey = typeof message.entityKey === 'string' ? message.entityKey : '';
+                  for (let zoneNum = 1; zoneNum <= (selectedProfile.limits.maxZones ?? 4); zoneNum += 1) {
+                    const mappingKey = `zone${zoneNum}Occupancy`;
+                    if (entityKey === mappingKey) {
+                      return { matched: true, zoneNum };
+                    }
+
+                    const mappedEntity = (mappings as Record<string, unknown> | undefined)?.[mappingKey];
+                    if (typeof mappedEntity === 'string' && message.entityId === mappedEntity) {
+                      return { matched: true, zoneNum };
                     }
                   }
                   return { matched: false };

--- a/everything-presence-mmwave-configurator/frontend/src/components/ZoneCanvas.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/ZoneCanvas.tsx
@@ -12,6 +12,8 @@ interface ZoneCanvasProps {
   polygonZones?: ZonePolygon[];
   onPolygonZonesChange?: (zones: ZonePolygon[]) => void;
   polygonMode?: boolean; // Whether we're in polygon editing mode
+  polygonReadOnly?: boolean;
+  polygonLateralOnlyAxis?: 'x' | 'y';
   selectedId?: string | null;
   onSelect?: (id: string | null) => void;
   rangeMm?: number;
@@ -67,6 +69,8 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
   polygonZones = [],
   onPolygonZonesChange,
   polygonMode = false,
+  polygonReadOnly = false,
+  polygonLateralOnlyAxis,
   selectedId,
   onSelect,
   rangeMm = 6000,
@@ -243,7 +247,7 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
         }
 
         // Handle polygon vertex dragging
-        if (draggingVertex && onPolygonZonesChange) {
+        if (!polygonReadOnly && draggingVertex && onPolygonZonesChange) {
           const idx = polygonZones.findIndex((z) => z.id === draggingVertex.zoneId);
           if (idx === -1) return;
 
@@ -261,8 +265,28 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
             newY = Math.round(newY / step) * step;
           }
 
-          vertices[draggingVertex.vertexIndex] = { x: newX, y: newY };
-          polygon.vertices = vertices;
+          if (polygonLateralOnlyAxis) {
+            const axis = polygonLateralOnlyAxis;
+            const previousValue = vertices[draggingVertex.vertexIndex][axis];
+            const nextValue = axis === 'x' ? newX : newY;
+            const next = polygonZones.map((candidate) => (
+              candidate.id === polygon.id
+                ? {
+                    ...candidate,
+                    vertices: candidate.vertices.map((vertex) => (
+                      Math.abs(vertex[axis] - previousValue) < 1
+                        ? { ...vertex, [axis]: nextValue }
+                        : vertex
+                    )),
+                  }
+                : candidate
+            ));
+            onPolygonZonesChange(next);
+            return;
+          } else {
+            vertices[draggingVertex.vertexIndex] = { x: newX, y: newY };
+            polygon.vertices = vertices;
+          }
 
           const next = [...polygonZones];
           next[idx] = polygon;
@@ -271,7 +295,7 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
         }
 
         // Handle moving entire polygon
-        if (draggingPolygonId && onPolygonZonesChange) {
+        if (!polygonReadOnly && draggingPolygonId && onPolygonZonesChange) {
           const idx = polygonZones.findIndex((z) => z.id === draggingPolygonId);
           if (idx === -1) return;
 
@@ -291,6 +315,27 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
             const step = snapGridMm;
             deltaX = Math.round(deltaX / step) * step;
             deltaY = Math.round(deltaY / step) * step;
+          }
+
+          if (polygonLateralOnlyAxis === 'x') {
+            deltaY = 0;
+          } else if (polygonLateralOnlyAxis === 'y') {
+            deltaX = 0;
+          }
+
+          if (polygonLateralOnlyAxis) {
+            const axis = polygonLateralOnlyAxis;
+            const delta = axis === 'x' ? deltaX : deltaY;
+            if (Math.abs(delta) < 0.5) return;
+
+            const nextZones = polygonZones.map((candidate) => ({
+              ...candidate,
+              vertices: candidate.id === polygon.id
+                ? candidate.vertices.map((vertex) => ({ ...vertex, [axis]: vertex[axis] + delta }))
+                : candidate.vertices,
+            }));
+            onPolygonZonesChange(nextZones);
+            return;
           }
 
           // Move all vertices
@@ -560,13 +605,17 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
                 fill={`${color}33`}
                 stroke={color}
                 strokeWidth={isSelected ? 3 : 1}
-                style={{ cursor: draggingPolygonId === polygon.id ? 'move' : 'pointer' }}
+                style={{ cursor: polygonReadOnly ? 'pointer' : polygonLateralOnlyAxis ? (polygonLateralOnlyAxis === 'x' ? 'ew-resize' : 'ns-resize') : draggingPolygonId === polygon.id ? 'move' : 'pointer' }}
                 onClick={(e) => {
                   e.stopPropagation();
                 }}
                 onMouseDown={(e) => {
                   if ((e as any).button !== 0) return;
                   e.stopPropagation();
+                  if (polygonReadOnly) {
+                    onSelect?.(polygon.id);
+                    return;
+                  }
                   const world = toWorldFromEvent(e);
                   if (!world) return;
                   setDraggingPolygonId(polygon.id);
@@ -593,7 +642,7 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
                 {zoneLabels?.[polygon.id] || polygon.label || polygon.id}
               </text>
               {/* Vertex handles (only when selected) */}
-              {isSelected && canvasVertices.map((v, idx) => (
+              {isSelected && !polygonReadOnly && canvasVertices.map((v, idx) => (
                 <circle
                   key={`vertex-${idx}`}
                   cx={v.x}
@@ -602,7 +651,7 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
                   fill="white"
                   stroke={color}
                   strokeWidth={2}
-                  style={{ cursor: 'move' }}
+                  style={{ cursor: polygonLateralOnlyAxis === 'x' ? 'ew-resize' : polygonLateralOnlyAxis === 'y' ? 'ns-resize' : 'move' }}
                   onClick={(e) => {
                     e.stopPropagation();
                   }}
@@ -616,7 +665,7 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
                 />
               ))}
               {/* Edge midpoints for adding vertices (only when selected) */}
-              {isSelected && canvasVertices.map((v, idx) => {
+              {isSelected && !polygonReadOnly && !polygonLateralOnlyAxis && canvasVertices.map((v, idx) => {
                 const nextIdx = (idx + 1) % canvasVertices.length;
                 const nextV = canvasVertices[nextIdx];
                 const midX = (v.x + nextV.x) / 2;

--- a/everything-presence-mmwave-configurator/frontend/src/pages/LiveTrackingPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/LiveTrackingPage.tsx
@@ -21,6 +21,13 @@ import { useHeatmap } from '../hooks/useHeatmap';
 import { useDeviceMappings, useDeviceMapping } from '../contexts/DeviceMappingsContext';
 import { getDeviceIconUrl } from '../utils/deviceIcon';
 import { resolveCoverageFov } from '../utils/coverage';
+import {
+  buildCeilingExclusionZones,
+  buildCeilingSliceZones,
+  getCeilingSliceLineDepth,
+  getCeilingSlicePosition,
+  normalizeCeilingSliceConfig,
+} from '../utils/ceilingSlices';
 
 // Recording mode trail point
 interface RecordedPoint {
@@ -134,6 +141,18 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
   const effectiveCoverageMaxRangeMeters = coverageFov?.maxRangeMeters ?? selectedProfile?.limits?.maxRangeMeters;
 
   const isCeilingMount = selectedRoom?.devicePlacement?.mountType === 'ceiling';
+  const isCeilingSliceMode =
+    selectedProfile?.id === 'everything_presence_pro' &&
+    selectedRoom?.devicePlacement?.mountType === 'ceiling';
+  const isEP1 = selectedRoom?.profileId === 'everything_presence_one';
+  const hasLiveStateForRoom = Boolean(
+    liveState && selectedRoom?.deviceId && liveState.deviceId === selectedRoom.deviceId
+  );
+  const showLiveOverlays = isEP1 ? true : hasLiveStateForRoom;
+  const installationAngle =
+    hasLiveStateForRoom && typeof liveState?.config?.installationAngle === 'number'
+      ? liveState.config.installationAngle
+      : 0;
 
   const heightCoverageConfig = useMemo(() => {
     if (!selectedRoom?.devicePlacement || !isCeilingMount) return null;
@@ -152,29 +171,100 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
       maxRangeMeters: coverageFov.maxRangeMeters,
     };
   }, [coverageFov, selectedRoom?.devicePlacement, isCeilingMount]);
+  const ceilingSliceConfig = useMemo(
+    () => normalizeCeilingSliceConfig(
+      selectedRoom?.metadata?.ceilingSliceConfig,
+      (selectedProfile?.limits?.maxRangeMeters ?? 6) * 1000,
+      true,
+    ),
+    [selectedProfile?.limits?.maxRangeMeters, selectedRoom?.metadata?.ceilingSliceConfig],
+  );
+  const deviceLocalToRoom = useCallback((deviceX: number, deviceY: number) => {
+    if (!selectedRoom?.devicePlacement) {
+      return { x: deviceX, y: deviceY };
+    }
+    const { x, y, rotationDeg } = selectedRoom.devicePlacement;
+    const angleRad = (((rotationDeg ?? 0) + installationAngle) * Math.PI) / 180;
+    const cos = Math.cos(angleRad);
+    const sin = Math.sin(angleRad);
+    return {
+      x: deviceX * cos - deviceY * sin + x,
+      y: deviceX * sin + deviceY * cos + y,
+    };
+  }, [installationAngle, selectedRoom?.devicePlacement]);
 
   const showCoverageOverlay = showDeviceRadar;
-
-  // Check if the selected room is using EP1
-  const isEP1 = selectedRoom?.profileId === 'everything_presence_one';
 
   // Check if device supports tracking (EP Lite only for heatmap)
   const supportsHeatmap = selectedProfile?.capabilities &&
     (selectedProfile.capabilities as { tracking?: boolean }).tracking === true && !isEP1;
 
-  const hasLiveStateForRoom = Boolean(
-    liveState && selectedRoom?.deviceId && liveState.deviceId === selectedRoom.deviceId
-  );
-  const showLiveOverlays = isEP1 ? true : hasLiveStateForRoom;
-  const installationAngle =
-    hasLiveStateForRoom && typeof liveState?.config?.installationAngle === 'number'
-      ? liveState.config.installationAngle
-      : 0;
-
   // Device mappings context - used to check if device has valid entity mappings
   // useDeviceMapping triggers loading the mapping into cache, useDeviceMappings provides the check
   const { hasValidMappings } = useDeviceMappings();
   const { mapping: deviceMapping, loading: mappingLoading } = useDeviceMapping(selectedRoom?.deviceId);
+  const lastZonesFetchedRoomId = React.useRef<string | null>(null);
+  const ceilingSliceDisplayZones = useMemo(
+    () => buildCeilingSliceZones(
+      ceilingSliceConfig,
+      {},
+      'display',
+      false,
+      heightCoverageConfig,
+      (selectedProfile?.limits?.maxRangeMeters ?? 6) * 1000,
+    ),
+    [ceilingSliceConfig, heightCoverageConfig, selectedProfile?.limits?.maxRangeMeters],
+  );
+  const ceilingExclusionDisplayZones = useMemo(
+    () => buildCeilingExclusionZones(
+      ceilingSliceConfig,
+      {},
+      'display',
+      false,
+      heightCoverageConfig,
+      (selectedProfile?.limits?.maxRangeMeters ?? 6) * 1000,
+    ),
+    [ceilingSliceConfig, heightCoverageConfig, selectedProfile?.limits?.maxRangeMeters],
+  );
+  const displayPolygonZones = isCeilingSliceMode ? [...ceilingSliceDisplayZones, ...ceilingExclusionDisplayZones] : polygonZones;
+  const getZoneLabel = useCallback((zoneNum: number): string => {
+    const candidates = [`Zone ${zoneNum}`, `zone${zoneNum}`, `zone_${zoneNum}`, `zone-${zoneNum}`];
+    const source = polygonModeStatus.enabled ? displayPolygonZones : selectedRoom?.zones ?? [];
+    const regularZones = source.filter((zone) => zone.type === 'regular');
+    const matchingZone =
+      source.find((zone) => candidates.includes(zone.id)) ??
+      regularZones[zoneNum - 1];
+
+    if (isCeilingSliceMode) {
+      return matchingZone?.label || `Zone ${zoneNum}`;
+    }
+
+    for (const candidate of candidates) {
+      const label = deviceMapping?.zoneLabels?.[candidate];
+      if (label) return label;
+    }
+
+    if (matchingZone?.id && deviceMapping?.zoneLabels?.[matchingZone.id]) {
+      return deviceMapping.zoneLabels[matchingZone.id];
+    }
+
+    return matchingZone?.label || `Zone ${zoneNum}`;
+  }, [
+    deviceMapping?.zoneLabels,
+    displayPolygonZones,
+    isCeilingSliceMode,
+    polygonModeStatus.enabled,
+    selectedRoom?.zones,
+  ]);
+  const zoneOccupancyNumbers = useMemo(() => {
+    const configuredMax = selectedProfile?.limits?.maxZones ?? 4;
+    const liveMax = Object.keys(liveState?.zoneOccupancy ?? {}).reduce((max, key) => {
+      const match = key.match(/^zone(\d+)$/);
+      return match ? Math.max(max, Number(match[1])) : max;
+    }, 0);
+    const count = Math.max(configuredMax, liveMax, 1);
+    return Array.from({ length: count }, (_, index) => index + 1);
+  }, [liveState?.zoneOccupancy, selectedProfile?.limits?.maxZones]);
   // Check validity: mapping must be loaded AND schema versions must match
   // If profile has a schemaVersion, the mapping must have a matching profileSchemaVersion
   // This ensures users are prompted to resync when profile schema changes
@@ -468,6 +558,8 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
         if (cancelled) {
           return;
         }
+
+        lastZonesFetchedRoomId.current = selectedRoom.id;
 
         // Avoid replacing known-good stored zones with a transient empty device read.
         if (deviceZones.length === 0 && (selectedRoom.zones?.length ?? 0) > 0) {
@@ -892,7 +984,7 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
             zones={selectedRoom.zones ?? []}
             onZonesChange={() => {}}
             // Polygon zones support - show polygon zones when polygon mode is enabled
-            polygonZones={polygonZones}
+            polygonZones={displayPolygonZones}
             onPolygonZonesChange={() => {}}
             polygonMode={polygonModeStatus.enabled}
             selectedId={null}
@@ -917,7 +1009,7 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
             clipRadarToWalls={clipRadarToWalls}
             furniture={selectedRoom.furniture ?? []}
             doors={selectedRoom.doors ?? []}
-            zoneLabels={deviceMapping?.zoneLabels}
+            zoneLabels={isCeilingSliceMode ? undefined : deviceMapping?.zoneLabels}
             showWalls={showWalls}
             showFurniture={showFurniture}
             showDoors={showDoors}
@@ -1000,8 +1092,83 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
                 </g>
               ) : null;
 
+              const ceilingTargetElements = showTargets && isCeilingMount && liveState?.targets && liveState.targets.length > 0 ? (
+                <g>
+                  {liveState.targets.map((target) => {
+                    if (target.active === false) return null;
+                    const lateral = getCeilingSlicePosition(target, ceilingSliceConfig);
+                    if (lateral === null) return null;
+                    const depth = getCeilingSliceLineDepth(lateral, ceilingSliceConfig, heightCoverageConfig, (selectedProfile?.limits?.maxRangeMeters ?? 6) * 1000);
+                    if (!depth) return null;
+                    const endpoints = ceilingSliceConfig.axis === 'x'
+                      ? [
+                          deviceLocalToRoom(lateral, depth.min),
+                          deviceLocalToRoom(lateral, depth.max),
+                        ]
+                      : [
+                          deviceLocalToRoom(depth.min, lateral),
+                          deviceLocalToRoom(depth.max, lateral),
+                        ];
+                    const start = toCanvas(endpoints[0]);
+                    const end = toCanvas(endpoints[1]);
+                    const label = toCanvas(deviceLocalToRoom(
+                      ceilingSliceConfig.axis === 'x' ? lateral : 0,
+                      ceilingSliceConfig.axis === 'x' ? 0 : lateral,
+                    ));
+                    const colorIndex = (target.id - 1) % targetColors.length;
+                    const color = targetColors[colorIndex];
+
+                    return (
+                      <g key={`ceiling-target-${target.id}`}>
+                        <line
+                          x1={start.x}
+                          y1={start.y}
+                          x2={end.x}
+                          y2={end.y}
+                          stroke="rgba(15, 23, 42, 0.85)"
+                          strokeWidth={8}
+                          strokeLinecap="round"
+                          opacity={0.9}
+                        />
+                        <line
+                          x1={start.x}
+                          y1={start.y}
+                          x2={end.x}
+                          y2={end.y}
+                          stroke={color.fill}
+                          strokeWidth={4}
+                          strokeLinecap="round"
+                          opacity={0.95}
+                          strokeDasharray="10 7"
+                        />
+                        <circle
+                          cx={label.x}
+                          cy={label.y}
+                          r={8}
+                          fill={color.fill}
+                          stroke="white"
+                          strokeWidth={2}
+                        />
+                        <text
+                          x={label.x}
+                          y={label.y - 14}
+                          textAnchor="middle"
+                          fill="white"
+                          fontSize="12"
+                          fontWeight="bold"
+                          className="pointer-events-none"
+                          style={{ filter: 'drop-shadow(0 1px 2px rgb(0 0 0 / 0.9))' }}
+                        >
+                          T{target.id}
+                        </text>
+                      </g>
+                    );
+                  })}
+                </g>
+              ) : null;
+
               // Render live target positions (EP Lite with tracking)
-              const targetElements = showTargets && displayTargetPositions.length > 0 ? (
+              const targetElements = !isCeilingMount && showTargets && displayTargetPositions.length > 0 ? (
                 <g>
                   {/* Render trails first (so they appear behind targets) */}
                   {showTrails && displayTargetPositions.map((target) => {
@@ -1179,6 +1346,7 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
                     {recordedTrailOverlay}
 
                     {/* Targets (if any) */}
+                    {ceilingTargetElements}
                     {targetElements}
 
                     {/* Max Distance Arc */}
@@ -1413,11 +1581,11 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
                     {/* Show polygon zones when polygon mode is enabled, otherwise show rectangle zones */}
                     {polygonModeStatus.enabled ? (
                       // Polygon zones legend
-                      polygonZones.filter(z => z.type === 'regular').length > 0 && (
+                      displayPolygonZones.filter(z => z.type === 'regular').length > 0 && (
                         <div className="flex flex-wrap items-center gap-2 text-[11px]">
                           {(() => {
                             const regularZoneColors = ['#3b82f6', '#8b5cf6', '#ec4899', '#f59e0b', '#06b6d4'];
-                            const regularZones = polygonZones.filter(z => z.type === 'regular');
+                            const regularZones = displayPolygonZones.filter(z => z.type === 'regular');
 
                             return regularZones.map((zone, index) => (
                               <div key={zone.id} className="flex items-center gap-1.5">
@@ -1425,7 +1593,7 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
                                   className="w-3 h-3 rounded border border-white/50"
                                   style={{ backgroundColor: regularZoneColors[index % regularZoneColors.length] }}
                                 />
-                                <span className="text-slate-300">{deviceMapping?.zoneLabels?.[zone.id] || zone.label || zone.id}</span>
+                                <span className="text-slate-300">{getZoneLabel(index + 1)}</span>
                               </div>
                             ));
                           })()}
@@ -1445,7 +1613,7 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
                                   className="w-3 h-3 rounded border border-white/50"
                                   style={{ backgroundColor: regularZoneColors[index % regularZoneColors.length] }}
                                 />
-                                <span className="text-slate-300">{deviceMapping?.zoneLabels?.[zone.id] || zone.label || zone.id}</span>
+                                <span className="text-slate-300">{getZoneLabel(index + 1)}</span>
                               </div>
                             ));
                           })()}
@@ -1555,13 +1723,12 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
                     <div>
                       <div className="text-[10px] font-semibold text-slate-400 uppercase tracking-wide mb-2">Zone Occupancy</div>
                       <div className="grid grid-cols-2 gap-2">
-                        {[1, 2, 3, 4].map((zoneNum) => {
-                          const zoneKey = `zone${zoneNum}` as 'zone1' | 'zone2' | 'zone3' | 'zone4';
-                          const isOccupied = liveState?.zoneOccupancy?.[zoneKey] ?? false;
-                          const regularZoneColors = ['#3b82f6', '#8b5cf6', '#ec4899', '#f59e0b'];
-                          // Find the matching zone to get its label
-                          const matchingZone = selectedRoom?.zones?.find(z => z.id === `Zone ${zoneNum}` || z.id === `zone${zoneNum}` || z.id === `zone_${zoneNum}`);
-                          const zoneLabel = (matchingZone && deviceMapping?.zoneLabels?.[matchingZone.id]) || matchingZone?.label || `Zone ${zoneNum}`;
+                        {zoneOccupancyNumbers.map((zoneNum) => {
+                          const zoneKey = `zone${zoneNum}`;
+                          const zoneOccupancy = liveState?.zoneOccupancy as Record<string, boolean | undefined> | undefined;
+                          const isOccupied = zoneOccupancy?.[zoneKey] ?? false;
+                          const regularZoneColors = ['#3b82f6', '#8b5cf6', '#ec4899', '#f59e0b', '#06b6d4'];
+                          const zoneLabel = getZoneLabel(zoneNum);
 
                           return (
                             <div

--- a/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
@@ -13,6 +13,11 @@ import { getInstallationAngleSuggestion } from '../utils/rotationSuggestion';
 import { useDeviceMappings } from '../contexts/DeviceMappingsContext';
 import { getDeviceIconUrl } from '../utils/deviceIcon';
 import { resolveCoverageFov } from '../utils/coverage';
+import {
+  getCeilingSliceLineDepth,
+  getCeilingSlicePosition,
+  normalizeCeilingSliceConfig,
+} from '../utils/ceilingSlices';
 
 interface RoomBuilderPageProps {
   onBack?: () => void;
@@ -128,6 +133,14 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   const effectiveCoverageMaxRangeMeters = coverageFov?.maxRangeMeters ?? selectedProfile?.limits?.maxRangeMeters;
 
   const isCeilingMount = selectedRoom?.devicePlacement?.mountType === 'ceiling';
+  const isCeilingSliceMode =
+    selectedProfile?.id === 'everything_presence_pro' &&
+    selectedRoom?.devicePlacement?.mountType === 'ceiling';
+  const trackingMaxRangeMm = (selectedProfile?.limits?.maxRangeMeters ?? 6) * 1000;
+  const ceilingSliceConfig = useMemo(
+    () => normalizeCeilingSliceConfig(selectedRoom?.metadata?.ceilingSliceConfig, trackingMaxRangeMm, true),
+    [selectedRoom?.metadata?.ceilingSliceConfig, trackingMaxRangeMm],
+  );
 
   const heightCoverageConfig = useMemo(() => {
     if (!selectedRoom?.devicePlacement || !isCeilingMount) return null;
@@ -189,6 +202,19 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
 
   const currentInstallationAngle =
     typeof liveState?.config?.installationAngle === 'number' ? liveState.config.installationAngle : null;
+  const deviceLocalToRoom = useCallback((deviceX: number, deviceY: number) => {
+    if (!selectedRoom?.devicePlacement) {
+      return { x: deviceX, y: deviceY };
+    }
+    const { x, y, rotationDeg } = selectedRoom.devicePlacement;
+    const angleRad = (((rotationDeg ?? 0) + (currentInstallationAngle ?? 0)) * Math.PI) / 180;
+    const cos = Math.cos(angleRad);
+    const sin = Math.sin(angleRad);
+    return {
+      x: deviceX * cos - deviceY * sin + x,
+      y: deviceX * sin + deviceY * cos + y,
+    };
+  }, [currentInstallationAngle, selectedRoom?.devicePlacement]);
 
   const isEplDevice = useMemo(() => {
     const caps = selectedProfile?.capabilities as { tracking?: boolean; distanceOnlyTracking?: boolean } | undefined;
@@ -1196,13 +1222,90 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                   showDoors={showDoors}
                   showDevice={showDeviceIcon}
                   renderOverlay={({ toCanvas }) => {
-                    if (!showTargets || !targetPositions?.length) return null;
+                    if (!showTargets) return null;
 
                     const targetColors = [
                       { fill: '#3b82f6', fillOpacity: 'rgba(59, 130, 246, 0.2)' },
                       { fill: '#10b981', fillOpacity: 'rgba(16, 185, 129, 0.2)' },
                       { fill: '#f59e0b', fillOpacity: 'rgba(245, 158, 11, 0.2)' },
                     ];
+
+                    if (isCeilingSliceMode && liveState?.targets?.length) {
+                      return (
+                        <g style={{ pointerEvents: 'none' }}>
+                          {liveState.targets.map((target, idx) => {
+                            if (target.active === false) return null;
+                            const lateral = getCeilingSlicePosition(target, ceilingSliceConfig);
+                            if (lateral === null) return null;
+                            const depth = getCeilingSliceLineDepth(lateral, ceilingSliceConfig, heightCoverageConfig, trackingMaxRangeMm);
+                            if (!depth) return null;
+                            const endpoints = ceilingSliceConfig.axis === 'x'
+                              ? [
+                                  deviceLocalToRoom(lateral, depth.min),
+                                  deviceLocalToRoom(lateral, depth.max),
+                                ]
+                              : [
+                                  deviceLocalToRoom(depth.min, lateral),
+                                  deviceLocalToRoom(depth.max, lateral),
+                                ];
+                            const start = toCanvas(endpoints[0]);
+                            const end = toCanvas(endpoints[1]);
+                            const label = toCanvas(deviceLocalToRoom(
+                              ceilingSliceConfig.axis === 'x' ? lateral : 0,
+                              ceilingSliceConfig.axis === 'x' ? 0 : lateral,
+                            ));
+                            const colors = targetColors[idx % targetColors.length];
+                            return (
+                              <g key={target.id}>
+                                <line
+                                  x1={start.x}
+                                  y1={start.y}
+                                  x2={end.x}
+                                  y2={end.y}
+                                  stroke="rgba(15, 23, 42, 0.85)"
+                                  strokeWidth={8}
+                                  strokeLinecap="round"
+                                  opacity={0.9}
+                                />
+                                <line
+                                  x1={start.x}
+                                  y1={start.y}
+                                  x2={end.x}
+                                  y2={end.y}
+                                  stroke={colors.fill}
+                                  strokeWidth={4}
+                                  strokeLinecap="round"
+                                  opacity={0.95}
+                                  strokeDasharray="10 7"
+                                />
+                                <circle
+                                  cx={label.x}
+                                  cy={label.y}
+                                  r={8}
+                                  fill={colors.fill}
+                                  stroke="white"
+                                  strokeWidth={2}
+                                />
+                                <text
+                                  x={label.x}
+                                  y={label.y - 14}
+                                  textAnchor="middle"
+                                  fill="white"
+                                  fontSize="12"
+                                  fontWeight="bold"
+                                  className="pointer-events-none"
+                                  style={{ filter: 'drop-shadow(0 1px 2px rgb(0 0 0 / 0.9))' }}
+                                >
+                                  T{target.id}
+                                </text>
+                              </g>
+                            );
+                          })}
+                        </g>
+                      );
+                    }
+
+                    if (!targetPositions?.length) return null;
 
                     return (
                       <g style={{ pointerEvents: 'none' }}>

--- a/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
@@ -18,6 +18,14 @@ import { useDisplaySettings } from '../hooks/useDisplaySettings';
 import { useDeviceMappings } from '../contexts/DeviceMappingsContext';
 import { getDeviceIconUrl } from '../utils/deviceIcon';
 import { resolveCoverageFov, resolveTrackingCoverageFov } from '../utils/coverage';
+import {
+  buildCeilingExclusionZones,
+  buildCeilingSliceZones,
+  CeilingSliceConfig,
+  getCeilingSliceLineDepth,
+  getCeilingSlicePosition,
+  normalizeCeilingSliceConfig,
+} from '../utils/ceilingSlices';
 
 interface ZoneEditorPageProps {
   onBack?: () => void;
@@ -92,6 +100,8 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
   } = useDisplaySettings();
   const loadedRoomRef = useRef<string | null>(null);
   const previousRoomIdRef = useRef<string | null>(null);
+  const pendingCeilingSliceConfigRef = useRef<CeilingSliceConfig | null>(null);
+  const ceilingSliceSaveSeqRef = useRef(0);
 
   const selectedRoom = useMemo(
     () => (selectedRoomId ? rooms.find((r) => r.id === selectedRoomId) ?? null : null),
@@ -125,6 +135,62 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
   const effectiveCoverageMaxRangeMeters = coverageFov?.maxRangeMeters ?? selectedProfile?.limits?.maxRangeMeters;
   const trackingMaxRangeMeters = trackingCoverageFov?.maxRangeMeters ?? selectedProfile?.limits?.maxRangeMeters;
   const trackingFieldOfViewDeg = trackingCoverageFov?.horizontalFovDeg ?? selectedProfile?.limits?.fieldOfViewDegrees;
+  const trackingMaxRangeMm = (trackingMaxRangeMeters ?? 6) * 1000;
+  const isCeilingSliceMode =
+    selectedProfile?.id === 'everything_presence_pro' &&
+    selectedRoom?.devicePlacement?.mountType === 'ceiling';
+  const heightCoverageConfig = useMemo(() => {
+    if (!selectedRoom?.devicePlacement || !isCeilingSliceMode) return null;
+    if (!coverageFov) return null;
+    const heightMm = selectedRoom.devicePlacement.heightMm;
+    const pitchDeg = Number.isFinite(selectedRoom.devicePlacement.pitchDeg)
+      ? Number(selectedRoom.devicePlacement.pitchDeg)
+      : 90;
+    if (!Number.isFinite(heightMm) || !Number.isFinite(pitchDeg)) return null;
+    return {
+      enabled: true,
+      heightMm: Number(heightMm),
+      pitchDeg,
+      horizontalFovDeg: coverageFov.horizontalFovDeg,
+      verticalFovDeg: coverageFov.verticalFovDeg,
+      maxRangeMeters: coverageFov.maxRangeMeters,
+    };
+  }, [coverageFov, selectedRoom?.devicePlacement, isCeilingSliceMode]);
+  const ceilingSliceConfig = useMemo(
+    () => normalizeCeilingSliceConfig(selectedRoom?.metadata?.ceilingSliceConfig, trackingMaxRangeMm, true),
+    [selectedRoom?.metadata?.ceilingSliceConfig, trackingMaxRangeMm],
+  );
+  const ceilingSliceDisplayZones = useMemo(
+    () => buildCeilingSliceZones(
+      ceilingSliceConfig,
+      deviceZoneLabels,
+      'display',
+      true,
+      heightCoverageConfig,
+      trackingMaxRangeMm,
+    ),
+    [ceilingSliceConfig, deviceZoneLabels, heightCoverageConfig, trackingMaxRangeMm],
+  );
+  const ceilingExclusionDisplayZones = useMemo(
+    () => buildCeilingExclusionZones(
+      ceilingSliceConfig,
+      deviceZoneLabels,
+      'display',
+      true,
+      heightCoverageConfig,
+      trackingMaxRangeMm,
+    ),
+    [ceilingSliceConfig, deviceZoneLabels, heightCoverageConfig, trackingMaxRangeMm],
+  );
+  const ceilingSliceDeviceZones = useMemo(
+    () => buildCeilingSliceZones(ceilingSliceConfig, deviceZoneLabels, 'device'),
+    [ceilingSliceConfig, deviceZoneLabels],
+  );
+  const ceilingExclusionDeviceZones = useMemo(
+    () => buildCeilingExclusionZones(ceilingSliceConfig, deviceZoneLabels, 'device'),
+    [ceilingSliceConfig, deviceZoneLabels],
+  );
+  const activePolygonZones = isCeilingSliceMode ? [...ceilingSliceDisplayZones, ...ceilingExclusionDisplayZones] : polygonZones;
 
   // Device mappings context - used to check if device has valid entity mappings
   const { hasValidMappings, clearCache } = useDeviceMappings();
@@ -601,9 +667,95 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
   };
 
   const handlePolygonZonesChange = (nextZones: ZonePolygon[]) => {
+    if (isCeilingSliceMode) {
+      const regularZones = nextZones
+        .filter((zone) => zone.type === 'regular')
+        .slice(0, ceilingSliceConfig.sliceCount);
+      const lateralRangesMm = regularZones.map((zone) => {
+        const values = zone.vertices
+          .map((vertex) => ceilingSliceConfig.axis === 'x' ? vertex.x : vertex.y)
+          .filter((value) => Number.isFinite(value));
+        const min = Math.min(...values);
+        const max = Math.max(...values);
+        return { min: Math.min(min, max - 100), max: Math.max(max, min + 100) };
+      });
+
+      if (lateralRangesMm.length === ceilingSliceConfig.sliceCount) {
+        const exclusionRangesMm = nextZones
+          .filter((zone) => zone.type === 'exclusion')
+          .map((zone) => {
+            const values = zone.vertices
+              .map((vertex) => ceilingSliceConfig.axis === 'x' ? vertex.x : vertex.y)
+              .filter((value) => Number.isFinite(value));
+            const min = Math.min(...values);
+            const max = Math.max(...values);
+            return { min: Math.min(min, max - 100), max: Math.max(max, min + 100) };
+          });
+        updateCeilingSliceConfig({
+          lateralMinMm: Math.min(...lateralRangesMm.map((range) => range.min)),
+          lateralMaxMm: Math.max(...lateralRangesMm.map((range) => range.max)),
+          lateralBreakpointsMm: undefined,
+          lateralRangesMm,
+          exclusionRangesMm,
+        }, { persist: false });
+      }
+      return;
+    }
     setPolygonZones(nextZones);
     if (nextZones.length && !selectedZoneId) {
       setSelectedZoneId(nextZones[0].id);
+    }
+  };
+
+  const persistCeilingSliceConfig = useCallback(async (config: CeilingSliceConfig | null = pendingCeilingSliceConfigRef.current) => {
+    if (!selectedRoom || !config) return;
+    pendingCeilingSliceConfigRef.current = null;
+    const saveSeq = ++ceilingSliceSaveSeqRef.current;
+    const metadata = {
+      ...(selectedRoom.metadata ?? {}),
+      ceilingSliceConfig: config,
+    };
+
+    try {
+      const result = await updateRoom(selectedRoom.id, { metadata });
+      if (saveSeq === ceilingSliceSaveSeqRef.current) {
+        setRooms((prev) => prev.map((room) => (room.id === selectedRoom.id ? result.room : room)));
+      }
+    } catch (err) {
+      pendingCeilingSliceConfigRef.current = config;
+      setError(err instanceof Error ? err.message : 'Failed to update ceiling slice settings');
+    }
+  }, [selectedRoom]);
+
+  const updateCeilingSliceConfig = (
+    updates: Partial<CeilingSliceConfig>,
+    options: { persist?: boolean } = {},
+  ) => {
+    if (!selectedRoom) return;
+    const nextConfig = normalizeCeilingSliceConfig(
+      { ...ceilingSliceConfig, ...updates },
+      trackingMaxRangeMm,
+      true,
+    );
+    const nextRoom: RoomConfig = {
+      ...selectedRoom,
+      metadata: {
+        ...(selectedRoom.metadata ?? {}),
+        ceilingSliceConfig: nextConfig,
+      },
+    };
+    setRooms((prev) => prev.map((room) => (room.id === selectedRoom.id ? nextRoom : room)));
+    if (options.persist === false) {
+      pendingCeilingSliceConfigRef.current = nextConfig;
+    } else {
+      void persistCeilingSliceConfig(nextConfig);
+    }
+  };
+
+  const handleZoneCanvasDragStateChange = (dragging: boolean) => {
+    setIsDraggingZone(dragging);
+    if (!dragging && isCeilingSliceMode) {
+      void persistCeilingSliceConfig();
     }
   };
 
@@ -739,18 +891,25 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
 
   const handleSaveZones = async () => {
     if (!selectedRoom) return;
+    if (isCeilingSliceMode && !polygonModeStatus.enabled) {
+      setError('Ceiling slice zones require polygon mode. Enable polygon mode before saving slices to the device.');
+      return;
+    }
 
     // Check if zones are outside max range
     const maxRangeMeters = trackingMaxRangeMeters ?? 6;
     const maxRangeMm = maxRangeMeters * 1000;
 
     const rectZones = (selectedRoom.zones ?? []).filter(zone => isZoneAvailable(zone));
-    const outOfRangeZones = getOutOfRangeZones(
-      rectZones,
-      polygonZones,
-      maxRangeMm,
-      polygonModeStatus.enabled
-    );
+    const zonesToWrite = isCeilingSliceMode ? [...ceilingSliceDeviceZones, ...ceilingExclusionDeviceZones] : polygonZones;
+    const outOfRangeZones = isCeilingSliceMode
+      ? []
+      : getOutOfRangeZones(
+          rectZones,
+          polygonZones,
+          maxRangeMm,
+          polygonModeStatus.enabled
+        );
 
     if (outOfRangeZones.length > 0) {
       setError(
@@ -780,7 +939,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
           const result = await pushPolygonZonesToDevice(
             selectedRoom.deviceId,
             effectiveProfile,
-            polygonZones,
+            zonesToWrite,
             entityNamePrefix,
             entityMappingsToUse
           );
@@ -863,7 +1022,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
         const labelsToSave: Record<string, string> = {};
         if (polygonModeStatus.enabled) {
           // Polygon zones - get labels from polygonZones state and deviceZoneLabels
-          for (const zone of polygonZones) {
+          for (const zone of zonesToWrite) {
             const label = deviceZoneLabels[zone.id] || zone.label;
             if (label) {
               labelsToSave[zone.id] = label;
@@ -1172,9 +1331,10 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
               handleZonesChange(newDisplayZones.filter(z => z.enabled));
             }}
             // Polygon zones support
-            polygonZones={polygonZones}
+            polygonZones={activePolygonZones}
             onPolygonZonesChange={handlePolygonZonesChange}
             polygonMode={polygonModeStatus.enabled}
+            polygonLateralOnlyAxis={isCeilingSliceMode ? ceilingSliceConfig.axis : undefined}
             selectedId={selectedZoneId}
             onSelect={(id) => setSelectedZoneId(id)}
             rangeMm={rangeMm}
@@ -1196,13 +1356,14 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
             maxRangeMeters={trackingMaxRangeMeters}
             deviceIconUrl={deviceIconUrl}
             clipRadarToWalls={clipRadarToWalls}
+            heightCoverage={heightCoverageConfig ?? undefined}
             showRadar
             showWalls={showWalls}
             showFurniture={showFurniture}
             showDoors={showDoors}
             showZones={showZones}
             showDevice={showDeviceIcon}
-            onDragStateChange={setIsDraggingZone}
+            onDragStateChange={handleZoneCanvasDragStateChange}
             renderOverlay={({ toCanvas }) => {
               // Define colors for each target (up to 3 targets)
               const targetColors = [
@@ -1212,41 +1373,118 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
               ];
 
               // Render live target positions (pointer-events: none so they don't block zone interaction)
-              if (showTargets && targetPositions.length > 0) {
+              if (showTargets && isCeilingSliceMode && liveState?.targets && liveState.targets.length > 0) {
                 return (
                   <g style={{ pointerEvents: 'none' }}>
-                    {targetPositions.map((target) => {
-                      const canvasPos = toCanvas({ x: target.x, y: target.y });
-                      const cx = canvasPos.x;
-                      const cy = canvasPos.y;
+                    {liveState.targets.map((target) => {
+                      if (target.active === false) return null;
+                      const lateral = getCeilingSlicePosition(target, ceilingSliceConfig);
+                      if (lateral === null) return null;
+                      const endpoints = ceilingSliceConfig.axis === 'x'
+                        ? (() => {
+                            const depth = getCeilingSliceLineDepth(lateral, ceilingSliceConfig, heightCoverageConfig, trackingMaxRangeMm);
+                            return depth ? [
+                              deviceToRoom(lateral, depth.min),
+                              deviceToRoom(lateral, depth.max),
+                            ] : null;
+                          })()
+                        : (() => {
+                            const depth = getCeilingSliceLineDepth(lateral, ceilingSliceConfig, heightCoverageConfig, trackingMaxRangeMm);
+                            return depth ? [
+                              deviceToRoom(depth.min, lateral),
+                              deviceToRoom(depth.max, lateral),
+                            ] : null;
+                          })();
+                      if (!endpoints) return null;
+                      const start = toCanvas(endpoints[0]);
+                      const end = toCanvas(endpoints[1]);
+                      const labelPoint = toCanvas(deviceToRoom(
+                        ceilingSliceConfig.axis === 'x' ? lateral : 0,
+                        ceilingSliceConfig.axis === 'x' ? 0 : lateral,
+                      ));
                       const colorIndex = (target.id - 1) % targetColors.length;
                       const color = targetColors[colorIndex];
 
                       return (
                         <g key={target.id}>
-                          {/* Outer pulsing circle */}
-                          <circle
-                            cx={cx}
-                            cy={cy}
-                            r={25}
-                            fill={color.fillOpacity}
-                            stroke={color.fill}
-                            strokeWidth={2}
-                            className="animate-pulse"
+                          <line
+                            x1={start.x}
+                            y1={start.y}
+                            x2={end.x}
+                            y2={end.y}
+                            stroke="rgba(15, 23, 42, 0.85)"
+                            strokeWidth={8}
+                            strokeLinecap="round"
+                            opacity={0.9}
                           />
-                          {/* Inner solid dot */}
+                          <line
+                            x1={start.x}
+                            y1={start.y}
+                            x2={end.x}
+                            y2={end.y}
+                            stroke={color.fill}
+                            strokeWidth={4}
+                            strokeLinecap="round"
+                            opacity={0.95}
+                            strokeDasharray="10 7"
+                          />
                           <circle
-                            cx={cx}
-                            cy={cy}
-                            r={10}
+                            cx={labelPoint.x}
+                            cy={labelPoint.y}
+                            r={8}
                             fill={color.fill}
                             stroke="white"
                             strokeWidth={2}
                           />
-                          {/* Target ID label */}
                           <text
-                            x={cx}
-                            y={cy - 35}
+                            x={labelPoint.x}
+                            y={labelPoint.y - 14}
+                            textAnchor="middle"
+                            fill="white"
+                            fontSize="12"
+                            fontWeight="bold"
+                            className="pointer-events-none"
+                            style={{ filter: 'drop-shadow(0 1px 2px rgb(0 0 0 / 0.9))' }}
+                          >
+                            T{target.id}
+                          </text>
+                        </g>
+                      );
+                    })}
+                  </g>
+                );
+              }
+
+              if (showTargets && targetPositions.length > 0) {
+                return (
+                  <g style={{ pointerEvents: 'none' }}>
+                    {targetPositions.map((target) => {
+                      const colorIndex = (target.id - 1) % targetColors.length;
+                      const color = targetColors[colorIndex];
+                      const canvasPos = toCanvas({ x: target.x, y: target.y });
+
+                      return (
+                        <g key={target.id}>
+                          <circle
+                            cx={canvasPos.x}
+                            cy={canvasPos.y}
+                            r={12}
+                            fill={color.fill}
+                            fillOpacity={0.3}
+                            stroke={color.fill}
+                            strokeWidth={2}
+                          />
+                          <circle
+                            cx={canvasPos.x}
+                            cy={canvasPos.y}
+                            r={5}
+                            fill={color.fill}
+                            stroke="white"
+                            strokeWidth={2}
+                          />
+                          <text
+                            x={canvasPos.x}
+                            y={canvasPos.y - 18}
                             textAnchor="middle"
                             fill="white"
                             fontSize="12"
@@ -1294,7 +1532,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
               className="rounded-xl border border-aqua-600/50 bg-aqua-600/10 backdrop-blur px-6 py-3 text-sm font-semibold text-aqua-100 shadow-lg transition-all hover:bg-aqua-600/20 hover:shadow-xl active:scale-95"
               onClick={() => setShowZoneList(!showZoneList)}
             >
-              {showZoneList ? '✕ Hide' : '☰ Show'} Zone Slots ({polygonModeStatus.enabled ? polygonZones.length : enabledZones.length}/{displayZones.length})
+              {showZoneList ? '✕ Hide' : '☰ Show'} Zone Slots ({polygonModeStatus.enabled ? activePolygonZones.length : enabledZones.length}/{displayZones.length})
             </button>
 
             {/* Polygon Mode Toggle (only show if supported by profile AND device has the entities) */}
@@ -1319,7 +1557,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
               >
                 {togglingPolygonMode ? 'Switching...' : (
                   <>
-                    {polygonModeStatus.enabled ? '⬡ Polygon Mode' : '▢ Rectangle Mode'}
+                    {polygonModeStatus.enabled ? (isCeilingSliceMode ? 'Ceiling Slice Mode' : '⬡ Polygon Mode') : '▢ Rectangle Mode'}
                     {!polygonModeStatus.enabled && polygonZonesAvailable === false && ' ⚠️'}
                   </>
                 )}
@@ -1489,7 +1727,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
               <div className="sticky top-0 z-10 border-b border-slate-700 bg-slate-900/90 backdrop-blur p-4">
                 <div className="flex items-center justify-between">
                   <h3 className="text-lg font-bold text-white">
-                    {polygonModeStatus.enabled ? '⬡ Polygon Zones' : 'Zone Slots'}
+                    {polygonModeStatus.enabled ? (isCeilingSliceMode ? 'Ceiling Slices' : '⬡ Polygon Zones') : 'Zone Slots'}
                   </h3>
                   <button
                     onClick={() => setShowZoneList(false)}
@@ -1500,7 +1738,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
                 </div>
                 <div className="mt-2 text-xs text-slate-400">
                   {polygonModeStatus.enabled
-                    ? `${polygonZones.length} of ${displayZones.length} slots configured`
+                    ? `${activePolygonZones.length} of ${displayZones.length} slots configured`
                     : `${enabledZones.length} of ${displayZones.length} slots active`
                   }
                 </div>
@@ -1509,8 +1747,96 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
               {/* Polygon Mode Zone List */}
               {polygonModeStatus.enabled ? (
                 <div className="p-4 space-y-3">
+                  {isCeilingSliceMode && (
+                    <div className="rounded-lg border border-cyan-500/40 bg-cyan-600/10 p-3 text-sm text-cyan-100">
+                      <div className="mb-2 font-semibold">Ceiling Slice Mode</div>
+                      <div className="mb-3 text-xs text-cyan-100/80">
+                        Targets are shown as clipped lateral lines. Drag slice edges to adjust left/right boundaries.
+                      </div>
+                      <div className="grid grid-cols-2 gap-2">
+                        <label className="text-xs">
+                          <span className="mb-1 block text-cyan-100/80">Reliable axis</span>
+                          <select
+                            className="w-full rounded-md border border-cyan-700 bg-slate-900 px-2 py-1 text-cyan-50"
+                            value={ceilingSliceConfig.axis}
+                            onChange={(e) => {
+                              void updateCeilingSliceConfig({ axis: e.target.value === 'y' ? 'y' : 'x' });
+                            }}
+                          >
+                            <option value="x">X axis</option>
+                            <option value="y">Y axis</option>
+                          </select>
+                        </label>
+                        <label className="text-xs">
+                          <span className="mb-1 block text-cyan-100/80">Slices</span>
+                          <select
+                            className="w-full rounded-md border border-cyan-700 bg-slate-900 px-2 py-1 text-cyan-50"
+                            value={ceilingSliceConfig.sliceCount}
+                            onChange={(e) => {
+                              void updateCeilingSliceConfig({
+                                sliceCount: Number(e.target.value) || 3,
+                                lateralBreakpointsMm: undefined,
+                                lateralRangesMm: undefined,
+                              });
+                            }}
+                          >
+                            <option value={2}>2</option>
+                            <option value={3}>3</option>
+                            <option value={4}>4</option>
+                          </select>
+                        </label>
+                        <label className="text-xs">
+                          <span className="mb-1 block text-cyan-100/80">Min</span>
+                          <input
+                            type="number"
+                            step={100}
+                            className="w-full rounded-md border border-cyan-700 bg-slate-900 px-2 py-1 text-cyan-50"
+                            value={ceilingSliceConfig.lateralMinMm}
+                            onChange={(e) => {
+                              void updateCeilingSliceConfig({ lateralMinMm: Number(e.target.value) || 0 });
+                            }}
+                          />
+                        </label>
+                        <label className="text-xs">
+                          <span className="mb-1 block text-cyan-100/80">Max</span>
+                          <input
+                            type="number"
+                            step={100}
+                            className="w-full rounded-md border border-cyan-700 bg-slate-900 px-2 py-1 text-cyan-50"
+                            value={ceilingSliceConfig.lateralMaxMm}
+                            onChange={(e) => {
+                              void updateCeilingSliceConfig({ lateralMaxMm: Number(e.target.value) || 0 });
+                            }}
+                          />
+                        </label>
+                      </div>
+                      <div className="mt-2 text-xs text-cyan-100/80">
+                        Ceiling mount left/right mirroring is applied automatically.
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const existing = ceilingSliceConfig.exclusionRangesMm ?? [];
+                          const maxExclusions = selectedProfile?.limits.maxExclusionZones ?? 2;
+                          if (existing.length >= maxExclusions) return;
+                          const width = Math.max(300, (ceilingSliceConfig.lateralMaxMm - ceilingSliceConfig.lateralMinMm) / 8);
+                          const center = 0;
+                          void updateCeilingSliceConfig({
+                            exclusionRangesMm: [
+                              ...existing,
+                              { min: center - width / 2, max: center + width / 2 },
+                            ],
+                          });
+                        }}
+                        disabled={(ceilingSliceConfig.exclusionRangesMm?.length ?? 0) >= (selectedProfile?.limits.maxExclusionZones ?? 2)}
+                        className="mt-3 w-full rounded-md border border-rose-500/50 bg-rose-600/20 px-3 py-2 text-xs font-semibold text-rose-100 transition-all hover:bg-rose-600/30 disabled:opacity-40 disabled:cursor-not-allowed"
+                      >
+                        + Exclusion ({ceilingSliceConfig.exclusionRangesMm?.length ?? 0}/{selectedProfile?.limits.maxExclusionZones ?? 2})
+                      </button>
+                    </div>
+                  )}
                   {/* Add Zone Buttons */}
-                  <div className="flex flex-wrap gap-2 pb-3 border-b border-slate-700/50">
+                  {!isCeilingSliceMode && <div className="flex flex-wrap gap-2 pb-3 border-b border-slate-700/50">
                     <button
                       onClick={() => {
                         const regularCount = polygonZones.filter(z => z.type === 'regular').length;
@@ -1565,16 +1891,16 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
                     >
                       + Entry ({polygonZones.filter(z => z.type === 'entry').length}/{selectedProfile?.limits.maxEntryZones ?? 2})
                     </button>
-                  </div>
+                  </div>}
 
                   {/* Polygon Zone List */}
-                  {polygonZones.length === 0 ? (
+                  {activePolygonZones.length === 0 ? (
                     <div className="text-center py-8 text-slate-400 text-sm">
                       No polygon zones configured.<br />
                       Use the buttons above to add zones.
                     </div>
                   ) : (
-                    polygonZones.map((polygon) => {
+                    activePolygonZones.map((polygon) => {
                       const isSelected = selectedZoneId === polygon.id;
                       const polygonStatus = getPolygonStatus(polygon.id);
                       return (
@@ -1620,6 +1946,14 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
                             <button
                               onClick={(e) => {
                                 e.stopPropagation();
+                                if (isCeilingSliceMode && polygon.type === 'exclusion') {
+                                  const index = Number(polygon.id.replace(/\D/g, '')) - 1;
+                                  const nextExclusions = (ceilingSliceConfig.exclusionRangesMm ?? [])
+                                    .filter((_, exclusionIndex) => exclusionIndex !== index);
+                                  void updateCeilingSliceConfig({ exclusionRangesMm: nextExclusions });
+                                  setSelectedZoneId(activePolygonZones[0]?.id ?? null);
+                                  return;
+                                }
                                 const newZones = polygonZones.filter(z => z.id !== polygon.id);
                                 // Renumber zones of the same type
                                 let regularIdx = 1, exclusionIdx = 1, entryIdx = 1;
@@ -1634,6 +1968,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
                                 }
                               }}
                               className="rounded-lg border border-slate-600 bg-slate-700/50 px-2 py-1 text-xs text-slate-300 transition-all hover:bg-rose-600/30 hover:border-rose-500 hover:text-rose-200"
+                              style={{ display: isCeilingSliceMode && polygon.type !== 'exclusion' ? 'none' : undefined }}
                             >
                               Delete
                             </button>

--- a/everything-presence-mmwave-configurator/frontend/src/utils/ceilingSlices.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/ceilingSlices.ts
@@ -1,0 +1,334 @@
+import type { ZonePolygon } from '../api/types';
+
+export type CeilingSliceAxis = 'x' | 'y';
+
+export interface CeilingSliceConfig {
+  enabled: boolean;
+  axis: CeilingSliceAxis;
+  mirrorLateralAxis: boolean;
+  sliceCount: number;
+  lateralMinMm: number;
+  lateralMaxMm: number;
+  lateralBreakpointsMm?: number[];
+  lateralRangesMm?: Array<{ min: number; max: number }>;
+  exclusionRangesMm?: Array<{ min: number; max: number }>;
+  depthMinMm: number;
+  depthMaxMm: number;
+}
+
+export interface CeilingSliceBand {
+  id: string;
+  label: string;
+  min: number;
+  max: number;
+}
+
+export type CeilingSliceCoordinateSpace = 'display' | 'device';
+
+export interface CeilingSliceCoverage {
+  heightMm?: number;
+  horizontalFovDeg?: number;
+  verticalFovDeg?: number;
+  maxRangeMeters?: number;
+}
+
+export const DEFAULT_CEILING_SLICE_CONFIG: CeilingSliceConfig = {
+  enabled: true,
+  axis: 'x',
+  mirrorLateralAxis: true,
+  sliceCount: 3,
+  lateralMinMm: -2000,
+  lateralMaxMm: 2000,
+  depthMinMm: -6000,
+  depthMaxMm: 6000,
+};
+
+export const normalizeCeilingSliceConfig = (
+  value: unknown,
+  maxRangeMm: number,
+  forceMirrorLateralAxis = false,
+): CeilingSliceConfig => {
+  const raw = value && typeof value === 'object' ? value as Record<string, unknown> : {};
+  const sliceCountRaw = Number(raw.sliceCount ?? DEFAULT_CEILING_SLICE_CONFIG.sliceCount);
+  const lateralMinRaw = Number(raw.lateralMinMm ?? DEFAULT_CEILING_SLICE_CONFIG.lateralMinMm);
+  const lateralMaxRaw = Number(raw.lateralMaxMm ?? DEFAULT_CEILING_SLICE_CONFIG.lateralMaxMm);
+  const depthMinRaw = Number(raw.depthMinMm ?? -maxRangeMm);
+  const depthMaxRaw = Number(raw.depthMaxMm ?? maxRangeMm);
+
+  const lateralMinMm = Number.isFinite(lateralMinRaw) ? lateralMinRaw : DEFAULT_CEILING_SLICE_CONFIG.lateralMinMm;
+  const lateralMaxMm = Number.isFinite(lateralMaxRaw) ? lateralMaxRaw : DEFAULT_CEILING_SLICE_CONFIG.lateralMaxMm;
+  const depthMinMm = Number.isFinite(depthMinRaw) ? depthMinRaw : -maxRangeMm;
+  const depthMaxMm = Number.isFinite(depthMaxRaw) ? depthMaxRaw : maxRangeMm;
+
+  const normalizedMin = Math.min(lateralMinMm, lateralMaxMm - 100);
+  const normalizedMax = Math.max(lateralMaxMm, lateralMinMm + 100);
+  const sliceCount = Math.min(4, Math.max(2, Number.isFinite(sliceCountRaw) ? Math.round(sliceCountRaw) : 3));
+  const lateralBreakpointsMm = Array.isArray(raw.lateralBreakpointsMm)
+    ? raw.lateralBreakpointsMm
+        .map((value) => Number(value))
+        .filter((value) => Number.isFinite(value) && value > normalizedMin && value < normalizedMax)
+        .sort((a, b) => a - b)
+        .filter((value, index, values) => index === 0 || Math.abs(value - values[index - 1]) >= 50)
+        .slice(0, sliceCount - 1)
+    : undefined;
+  const lateralRangesMm = Array.isArray(raw.lateralRangesMm)
+    ? raw.lateralRangesMm
+        .map((range) => {
+          const candidate = range && typeof range === 'object' ? range as Record<string, unknown> : {};
+          const min = Number(candidate.min);
+          const max = Number(candidate.max);
+          if (!Number.isFinite(min) || !Number.isFinite(max)) return null;
+          return {
+            min: Math.min(min, max - 100),
+            max: Math.max(max, min + 100),
+          };
+        })
+        .filter((range): range is { min: number; max: number } => range !== null)
+        .slice(0, sliceCount)
+    : undefined;
+  const exclusionRangesMm = Array.isArray(raw.exclusionRangesMm)
+    ? raw.exclusionRangesMm
+        .map((range) => {
+          const candidate = range && typeof range === 'object' ? range as Record<string, unknown> : {};
+          const min = Number(candidate.min);
+          const max = Number(candidate.max);
+          if (!Number.isFinite(min) || !Number.isFinite(max)) return null;
+          return {
+            min: Math.min(min, max - 100),
+            max: Math.max(max, min + 100),
+          };
+        })
+        .filter((range): range is { min: number; max: number } => range !== null)
+        .slice(0, 2)
+    : undefined;
+
+  return {
+    enabled: raw.enabled !== false,
+    axis: raw.axis === 'y' ? 'y' : 'x',
+    mirrorLateralAxis: forceMirrorLateralAxis
+      ? true
+      : raw.mirrorLateralAxis !== undefined
+        ? Boolean(raw.mirrorLateralAxis)
+        : raw.inverted !== undefined
+          ? Boolean(raw.inverted)
+          : DEFAULT_CEILING_SLICE_CONFIG.mirrorLateralAxis,
+    sliceCount,
+    lateralMinMm: normalizedMin,
+    lateralMaxMm: normalizedMax,
+    lateralBreakpointsMm: lateralBreakpointsMm && lateralBreakpointsMm.length === sliceCount - 1
+      ? lateralBreakpointsMm
+      : undefined,
+    lateralRangesMm: lateralRangesMm && lateralRangesMm.length === sliceCount
+      ? lateralRangesMm
+      : undefined,
+    exclusionRangesMm,
+    depthMinMm: Math.min(depthMinMm, depthMaxMm - 100),
+    depthMaxMm: Math.max(depthMaxMm, depthMinMm + 100),
+  };
+};
+
+export const getCeilingCoverageHalfExtents = (
+  coverage: CeilingSliceCoverage | null | undefined,
+  fallbackMaxRangeMm: number,
+): { halfWidthMm: number; halfDepthMm: number } => {
+  const heightMm = Number(coverage?.heightMm);
+  const horizontalFovDeg = Number(coverage?.horizontalFovDeg);
+  const verticalFovDeg = Number(coverage?.verticalFovDeg);
+  const maxRangeMm = Number.isFinite(Number(coverage?.maxRangeMeters))
+    ? Number(coverage?.maxRangeMeters) * 1000
+    : fallbackMaxRangeMm;
+
+  if (!Number.isFinite(heightMm) || heightMm <= 0 ||
+      !Number.isFinite(horizontalFovDeg) || horizontalFovDeg <= 0 ||
+      !Number.isFinite(verticalFovDeg) || verticalFovDeg <= 0) {
+    return { halfWidthMm: fallbackMaxRangeMm, halfDepthMm: fallbackMaxRangeMm };
+  }
+
+  return {
+    halfWidthMm: Math.min(heightMm * Math.tan((horizontalFovDeg / 2) * Math.PI / 180), maxRangeMm),
+    halfDepthMm: Math.min(heightMm * Math.tan((verticalFovDeg / 2) * Math.PI / 180), maxRangeMm),
+  };
+};
+
+export const getCeilingSliceLineDepth = (
+  lateral: number,
+  config: CeilingSliceConfig,
+  coverage: CeilingSliceCoverage | null | undefined,
+  fallbackMaxRangeMm: number,
+): { min: number; max: number } | null => {
+  const { halfWidthMm, halfDepthMm } = getCeilingCoverageHalfExtents(coverage, fallbackMaxRangeMm);
+  const lateralRadius = config.axis === 'x' ? halfWidthMm : halfDepthMm;
+  const depthRadius = config.axis === 'x' ? halfDepthMm : halfWidthMm;
+  if (!Number.isFinite(lateralRadius) || !Number.isFinite(depthRadius) || lateralRadius <= 0 || depthRadius <= 0) {
+    return { min: config.depthMinMm, max: config.depthMaxMm };
+  }
+
+  const normalized = Math.abs(lateral) / lateralRadius;
+  if (normalized > 1) return null;
+  const halfDepth = depthRadius * Math.sqrt(Math.max(0, 1 - normalized * normalized));
+  return {
+    min: Math.max(config.depthMinMm, -halfDepth),
+    max: Math.min(config.depthMaxMm, halfDepth),
+  };
+};
+
+export const getCeilingSliceBands = (config: CeilingSliceConfig): CeilingSliceBand[] => {
+  const count = Math.min(4, Math.max(2, config.sliceCount));
+  const equalWidth = (config.lateralMaxMm - config.lateralMinMm) / count;
+  const boundaries = config.lateralBreakpointsMm && config.lateralBreakpointsMm.length === count - 1
+    ? [config.lateralMinMm, ...config.lateralBreakpointsMm, config.lateralMaxMm]
+    : Array.from({ length: count + 1 }, (_, index) => (
+        index === count ? config.lateralMaxMm : config.lateralMinMm + equalWidth * index
+      ));
+  const labels = count === 2
+    ? ['Left', 'Right']
+    : count === 3
+      ? ['Left', 'Center', 'Right']
+      : ['Far Left', 'Left Center', 'Right Center', 'Far Right'];
+
+  return Array.from({ length: count }, (_, index) => {
+    const customRange = config.lateralRangesMm?.[index];
+    return {
+      id: `Zone ${index + 1}`,
+      label: labels[index] ?? `Slice ${index + 1}`,
+      min: customRange?.min ?? boundaries[index],
+      max: customRange?.max ?? boundaries[index + 1],
+    };
+  });
+};
+
+const toDeviceLateral = (value: number, config: CeilingSliceConfig): number => (
+  config.mirrorLateralAxis ? -value : value
+);
+
+export const buildCeilingSliceZones = (
+  config: CeilingSliceConfig,
+  existingLabels: Record<string, string> = {},
+  coordinateSpace: CeilingSliceCoordinateSpace = 'device',
+  useExistingLabels = true,
+  coverage?: CeilingSliceCoverage | null,
+  fallbackMaxRangeMm = Math.max(Math.abs(config.depthMinMm), Math.abs(config.depthMaxMm)),
+): ZonePolygon[] => {
+  const bands = getCeilingSliceBands(config);
+  return buildCeilingRangeZones(
+    config,
+    bands.map((band) => ({ ...band, type: 'regular' as const })),
+    existingLabels,
+    coordinateSpace,
+    useExistingLabels,
+    coverage,
+    fallbackMaxRangeMm,
+  );
+};
+
+export const buildCeilingExclusionZones = (
+  config: CeilingSliceConfig,
+  existingLabels: Record<string, string> = {},
+  coordinateSpace: CeilingSliceCoordinateSpace = 'device',
+  useExistingLabels = true,
+  coverage?: CeilingSliceCoverage | null,
+  fallbackMaxRangeMm = Math.max(Math.abs(config.depthMinMm), Math.abs(config.depthMaxMm)),
+): ZonePolygon[] => {
+  const ranges = config.exclusionRangesMm ?? [];
+  return buildCeilingRangeZones(
+    config,
+    ranges.map((range, index) => ({
+      id: `Exclusion ${index + 1}`,
+      label: `Exclusion ${index + 1}`,
+      min: range.min,
+      max: range.max,
+      type: 'exclusion' as const,
+    })),
+    existingLabels,
+    coordinateSpace,
+    useExistingLabels,
+    coverage,
+    fallbackMaxRangeMm,
+  );
+};
+
+const buildCeilingRangeZones = (
+  config: CeilingSliceConfig,
+  bands: Array<CeilingSliceBand & { type: 'regular' | 'exclusion' }>,
+  existingLabels: Record<string, string>,
+  coordinateSpace: CeilingSliceCoordinateSpace,
+  useExistingLabels: boolean,
+  coverage: CeilingSliceCoverage | null | undefined,
+  fallbackMaxRangeMm: number,
+): ZonePolygon[] => {
+  return bands.map((band) => {
+    const lateralA = coordinateSpace === 'device' ? toDeviceLateral(band.min, config) : band.min;
+    const lateralB = coordinateSpace === 'device' ? toDeviceLateral(band.max, config) : band.max;
+    let displayLateralA = lateralA;
+    let displayLateralB = lateralB;
+
+    if (coordinateSpace === 'display' && coverage) {
+      const { halfWidthMm, halfDepthMm } = getCeilingCoverageHalfExtents(coverage, fallbackMaxRangeMm);
+      const lateralRadius = config.axis === 'x' ? halfWidthMm : halfDepthMm;
+      if (Number.isFinite(lateralRadius) && lateralRadius > 0) {
+        const rangeMin = Math.min(lateralA, lateralB);
+        const rangeMax = Math.max(lateralA, lateralB);
+        const clippedMin = Math.max(rangeMin, -lateralRadius);
+        const clippedMax = Math.min(rangeMax, lateralRadius);
+
+        if (clippedMax - clippedMin < 1) {
+          return null;
+        }
+
+        if (lateralA <= lateralB) {
+          displayLateralA = clippedMin;
+          displayLateralB = clippedMax;
+        } else {
+          displayLateralA = clippedMax;
+          displayLateralB = clippedMin;
+        }
+      }
+    }
+
+    const lateralMin = coordinateSpace === 'display' ? displayLateralA : Math.min(lateralA, lateralB);
+    const lateralMax = coordinateSpace === 'display' ? displayLateralB : Math.max(lateralA, lateralB);
+    const boundaryA = Math.min(displayLateralA, displayLateralB);
+    const boundaryB = Math.max(displayLateralA, displayLateralB);
+    const depthAtMin = coordinateSpace === 'display' && coverage
+      ? getCeilingSliceLineDepth(boundaryA, config, coverage, fallbackMaxRangeMm)
+      : null;
+    const depthAtMax = coordinateSpace === 'display' && coverage
+      ? getCeilingSliceLineDepth(boundaryB, config, coverage, fallbackMaxRangeMm)
+      : null;
+    const minDepthMin = depthAtMin?.min ?? config.depthMinMm;
+    const minDepthMax = depthAtMin?.max ?? config.depthMaxMm;
+    const maxDepthMin = depthAtMax?.min ?? config.depthMinMm;
+    const maxDepthMax = depthAtMax?.max ?? config.depthMaxMm;
+
+    const vertices = config.axis === 'x'
+      ? [
+          { x: lateralMin, y: minDepthMin },
+          { x: lateralMax, y: maxDepthMin },
+          { x: lateralMax, y: maxDepthMax },
+          { x: lateralMin, y: minDepthMax },
+        ]
+      : [
+          { x: minDepthMin, y: lateralMin },
+          { x: maxDepthMin, y: lateralMax },
+          { x: maxDepthMax, y: lateralMax },
+          { x: minDepthMax, y: lateralMin },
+        ];
+
+    return {
+      id: band.id,
+      type: band.type,
+      vertices,
+      enabled: true,
+      label: useExistingLabels ? existingLabels[band.id] || band.label : band.label,
+    };
+  }).filter((zone): zone is ZonePolygon => zone !== null);
+};
+
+export const getCeilingSlicePosition = (
+  target: { x: number | null; y: number | null },
+  config: CeilingSliceConfig,
+): number | null => {
+  const value = config.axis === 'x' ? target.x : target.y;
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return config.mirrorLateralAxis ? -value : value;
+};


### PR DESCRIPTION
Adds ceiling mount support for EP Pro zone editing and live visualisation using "slice" zones.

Because the LD2450 does not have full 3D positioning (2 axis only)when mounted overhead, ceiling mode now treats zones as left/right "slices" instead of trying to draw normal floor-position tracking dots like we do when mounted in the normal way.

When EP Pro is ceiling mounted, the configurator shows targets as clipped tracking lines across the sensor FoV, allowing users to understand which lateral slice a target occupies without implying inaccurate forward/backward precision. Users can resize and move slice zones left/right, leave gaps between zones, and add exclusion slices. These slices are then converted into polygon zones when saved to the device, so the firmware-side zone occupancy logic continues to work with the existing coordinate model.