### PR TITLE
Improve mobile canvas touch interactions

### DIFF
--- a/everything-presence-mmwave-configurator/frontend/src/components/RoomCanvas.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/RoomCanvas.tsx
@@ -52,6 +52,8 @@ interface RoomCanvasProps {
   };
   panOffsetMm?: { x: number; y: number };
   onPanChange?: (offset: { x: number; y: number }) => void;
+  onZoomChange?: (zoom: number) => void;
+  touchPanEnabled?: boolean;
   onDragStateChange?: (isDragging: boolean) => void;
   previewFrom?: Point | null;
   previewTo?: Point | null;
@@ -65,12 +67,14 @@ interface RoomCanvasProps {
   renderOverlay?: (ctx: {
     toCanvas: (p: Point) => { x: number; y: number };
     fromCanvas: (x: number, y: number) => Point;
-    toWorldFromEvent: (e: React.MouseEvent<SVGSVGElement | SVGElement, MouseEvent>) => Point | null;
+    toWorldFromEvent: (e: { clientX: number; clientY: number }) => Point | null;
     svgRef: React.RefObject<SVGSVGElement>;
     rangeMm: number;
     roomShellPoints: Point[];
     devicePlacement: DevicePlacement | undefined;
     fieldOfViewDeg: number;
+    onCanvasPointerMove: (e: React.PointerEvent<SVGElement>) => void;
+    onCanvasPointerRelease: (e: React.PointerEvent<SVGElement>) => void;
     /** Device element to render (when deviceInteractive is false) - render at desired z-order */
     deviceElement?: React.ReactNode;
   }) => React.ReactNode;
@@ -278,7 +282,7 @@ const buildHeightCoveragePolygon = (params: {
 };
 
 const getSvgPoint = (
-  e: React.MouseEvent<SVGSVGElement, MouseEvent>,
+  e: { clientX: number; clientY: number },
   svgEl: SVGSVGElement | null,
 ): { x: number; y: number } | null => {
   if (!svgEl) return null;
@@ -514,6 +518,8 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
   heightCoverage,
   panOffsetMm = { x: 0, y: 0 },
   onPanChange,
+  onZoomChange,
+  touchPanEnabled = false,
   onDragStateChange,
   previewFrom = null,
   previewTo = null,
@@ -590,6 +596,8 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
     currentRotation?: number;
   } | null>(null);
   const suppressClickRef = useRef<boolean>(false);
+  const activePointersRef = useRef<Map<number, { x: number; y: number }>>(new Map());
+  const pinchRef = useRef<{ distance: number; zoom: number } | null>(null);
 
   const effectiveRangeMm = Number.isFinite(rangeMm) && rangeMm > 0 ? rangeMm : 6000;
   const effectiveGrid = Number.isFinite(gridSpacingMm) && gridSpacingMm > 0 ? gridSpacingMm : 1000;
@@ -634,7 +642,7 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
     return pathPoints.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ') + ' Z';
   };
 
-  const toWorldFromEvent = (e: React.MouseEvent<SVGSVGElement | SVGElement, MouseEvent>) => {
+  const toWorldFromEvent = (e: { clientX: number; clientY: number }) => {
     const svgPoint = getSvgPoint(e as any, svgRef.current);
     if (!svgPoint) return null;
     const cx = svgPoint.x - HALF;
@@ -674,14 +682,56 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
     onCanvasClick?.(point);
   };
 
-  const handleDragStart = (idx: number) => (e: React.MouseEvent<SVGCircleElement, MouseEvent>) => {
+  const capturePointer = (e: React.PointerEvent<SVGElement>) => {
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    } catch {
+      // Some SVG elements in older webviews can reject capture; dragging still works through bubbling.
+    }
+  };
+
+  const updatePointer = (e: React.PointerEvent<SVGElement>) => {
+    activePointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+  };
+
+  const getPinchDistance = () => {
+    const pointers = Array.from(activePointersRef.current.values());
+    if (pointers.length < 2) return null;
+    return Math.hypot(pointers[0].x - pointers[1].x, pointers[0].y - pointers[1].y);
+  };
+
+  const beginPan = (e: React.PointerEvent<SVGElement>) => {
+    const svgPoint = getSvgPoint(e as any, svgRef.current);
+    if (!svgPoint || !onPanChange) return false;
+    e.preventDefault();
+    capturePointer(e);
+    const world = fromCanvasWithOffset(svgPoint.x - HALF, svgPoint.y - HALF, panOffsetMm);
+    setPanDrag({ start: world, base: panOffsetMm });
+    onDragStateChange?.(true);
+    suppressClickRef.current = true;
+    return true;
+  };
+
+  const handleDragStart = (idx: number) => (e: React.PointerEvent<SVGCircleElement>) => {
+    if (e.button !== 0) return;
     e.stopPropagation();
     if (e.cancelable) e.preventDefault();
+    capturePointer(e);
     suppressClickRef.current = true;
     setDragIdx(idx);
     onDragStateChange?.(true);
   };
-  const handleMouseUp = () => {
+  const handlePointerUp = (e?: React.PointerEvent<SVGElement>) => {
+    if (e) {
+      activePointersRef.current.delete(e.pointerId);
+      if (activePointersRef.current.size < 2) {
+        pinchRef.current = null;
+      }
+    } else {
+      activePointersRef.current.clear();
+      pinchRef.current = null;
+    }
+
     // Finalize furniture drag
     if (furnitureDrag && onFurnitureChange) {
       const furnitureItem = furniture.find((f) => f.id === furnitureDrag.id);
@@ -746,7 +796,18 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
     onCanvasRelease?.();
   };
 
-  const handleMouseMove = (e: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
+  const handlePointerMove = (e: React.PointerEvent<SVGElement>) => {
+    updatePointer(e);
+    if (pinchRef.current && onZoomChange) {
+      const distance = getPinchDistance();
+      if (distance && pinchRef.current.distance > 0) {
+        e.preventDefault();
+        const nextZoom = Math.min(5, Math.max(0.1, pinchRef.current.zoom * (distance / pinchRef.current.distance)));
+        onZoomChange(nextZoom);
+      }
+      return;
+    }
+
     const svgPoint = getSvgPoint(e, svgRef.current);
         if (!svgPoint) return;
         const cx = svgPoint.x - HALF;
@@ -901,6 +962,71 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
     }
   };
 
+  const handlePointerDown = (e: React.PointerEvent<SVGSVGElement>) => {
+    updatePointer(e);
+
+    if (activePointersRef.current.size === 2 && onZoomChange) {
+      const distance = getPinchDistance();
+      if (distance) {
+        e.preventDefault();
+        capturePointer(e);
+        pinchRef.current = { distance, zoom: effectiveZoom };
+        setPanDrag(null);
+        onDragStateChange?.(true);
+      }
+      return;
+    }
+
+    if (e.button === 2) {
+      beginPan(e);
+      return;
+    }
+
+    if (e.pointerType !== 'mouse' && touchPanEnabled && onPanChange) {
+      beginPan(e);
+      return;
+    }
+
+    if (e.button !== 0 || !safePoints.length) return;
+    if (lockShell) return;
+    const svgPoint = getSvgPoint(e as any, svgRef.current);
+    if (!svgPoint) return;
+    const cx = svgPoint.x - HALF;
+    const cy = svgPoint.y - HALF;
+    const world = fromCanvasCoord(cx, cy);
+    let best: number | null = null;
+    let bestDist = 250;
+    let bestProj: Point | null = null;
+    safePoints.forEach((p, idx) => {
+      const next = safePoints[(idx + 1) % safePoints.length];
+      const dx = next.x - p.x;
+      const dy = next.y - p.y;
+      const len2 = dx * dx + dy * dy || 1;
+      const t = Math.max(0, Math.min(1, ((world.x - p.x) * dx + (world.y - p.y) * dy) / len2));
+      const projX = p.x + t * dx;
+      const projY = p.y + t * dy;
+      const dist = Math.hypot(world.x - projX, world.y - projY);
+      if (dist < bestDist) {
+        bestDist = dist;
+        best = idx;
+        bestProj = { x: projX, y: projY };
+      }
+    });
+    if (!isDoorPlacementMode && e.shiftKey && onSegmentInsert && best !== null && bestProj) {
+      e.preventDefault();
+      e.stopPropagation();
+      onSegmentInsert(best, bestProj);
+      suppressClickRef.current = true;
+      return;
+    }
+    onSegmentSelect?.(best);
+    if (best !== null && onSegmentDragStart) {
+      onSegmentDragStart(best, world);
+      suppressClickRef.current = true;
+      onDragStateChange?.(true);
+    }
+  };
+
   return (
     <div className="w-full h-full">
       <svg
@@ -909,11 +1035,15 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
         viewBox={`${viewMin} ${viewMin} ${viewSize} ${viewSize}`}
         height={height}
         className="bg-slate-900"
+        style={{ touchAction: 'none' }}
         onClick={handleSvgClick}
-        onMouseMove={handleMouseMove}
-        onMouseUp={handleMouseUp}
-        onMouseLeave={handleMouseUp}
-        onMouseOver={(e) => {
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onPointerLeave={(e) => {
+          if (e.pointerType === 'mouse') handlePointerUp(e);
+        }}
+        onPointerOver={(e) => {
         if (!safePoints.length || lockShell) return;
         const svgPoint = getSvgPoint(e as any, svgRef.current);
         if (!svgPoint) return;
@@ -938,58 +1068,8 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
           });
           onSegmentHover?.(best);
         }}
-        onMouseOut={() => onSegmentHover?.(null)}
-        onMouseDown={(e) => {
-          if ((e as any).button === 2) {
-            // right-drag to pan
-            const svgPoint = getSvgPoint(e as any, svgRef.current);
-            if (!svgPoint || !onPanChange) return;
-            e.preventDefault();
-            const world = fromCanvasWithOffset(svgPoint.x - HALF, svgPoint.y - HALF, panOffsetMm);
-            setPanDrag({ start: world, base: panOffsetMm });
-            onDragStateChange?.(true);
-            suppressClickRef.current = true;
-            return;
-          }
-          if ((e as any).button !== 0 || !safePoints.length) return;
-          if (lockShell) return;
-          const svgPoint = getSvgPoint(e as any, svgRef.current);
-          if (!svgPoint) return;
-          const cx = svgPoint.x - HALF;
-          const cy = svgPoint.y - HALF;
-          const world = fromCanvasCoord(cx, cy);
-          let best: number | null = null;
-          let bestDist = 250;
-          let bestProj: Point | null = null;
-          safePoints.forEach((p, idx) => {
-            const next = safePoints[(idx + 1) % safePoints.length];
-            const dx = next.x - p.x;
-            const dy = next.y - p.y;
-            const len2 = dx * dx + dy * dy || 1;
-            const t = Math.max(0, Math.min(1, ((world.x - p.x) * dx + (world.y - p.y) * dy) / len2));
-            const projX = p.x + t * dx;
-            const projY = p.y + t * dy;
-            const dist = Math.hypot(world.x - projX, world.y - projY);
-            if (dist < bestDist) {
-              bestDist = dist;
-              best = idx;
-              bestProj = { x: projX, y: projY };
-            }
-          });
-          if (!isDoorPlacementMode && (e as any).shiftKey && onSegmentInsert && best !== null && bestProj) {
-            e.preventDefault();
-            e.stopPropagation();
-            onSegmentInsert(best, bestProj);
-            suppressClickRef.current = true;
-            return;
-          }
-          onSegmentSelect?.(best);
-          if (best !== null && onSegmentDragStart) {
-            onSegmentDragStart(best, world);
-            suppressClickRef.current = true;
-            onDragStateChange?.(true);
-          }
-        }}
+        onPointerOut={() => onSegmentHover?.(null)}
+        onPointerDown={handlePointerDown}
         onContextMenu={(e) => e.preventDefault()}
       >
         <defs>
@@ -1059,11 +1139,11 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                     <circle
                       cx={cx}
                       cy={cy}
-                      r={8}
+                      r={11}
                       fill="#0ea5e9"
                       stroke="#e0f2fe"
                       strokeWidth={2}
-                      onMouseDown={handleDragStart(idx)}
+                      onPointerDown={handleDragStart(idx)}
                     />
                   </g>
                 );
@@ -1157,17 +1237,18 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                 return (
                   <>
                     <rect
-                      x={x1 - 6}
-                      y={y1 - 6}
-                      width={12}
-                      height={12}
+                      x={x1 - 9}
+                      y={y1 - 9}
+                      width={18}
+                      height={18}
                       fill="#0ea5e9"
                       stroke="#e0f2fe"
                       strokeWidth={2}
                       rx={2}
-                      onMouseDown={(e) => {
+                      onPointerDown={(e) => {
                         e.stopPropagation();
                         if (e.cancelable) e.preventDefault();
+                        capturePointer(e);
                         if (onEndpointDragStart) {
                           const world = toWorldFromEvent(e as any) ?? { x: p.x, y: p.y };
                           onEndpointDragStart(selectedSegment, 'start', world);
@@ -1177,17 +1258,18 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                       }}
                     />
                     <rect
-                      x={x2 - 6}
-                      y={y2 - 6}
-                      width={12}
-                      height={12}
+                      x={x2 - 9}
+                      y={y2 - 9}
+                      width={18}
+                      height={18}
                       fill="#0ea5e9"
                       stroke="#e0f2fe"
                       strokeWidth={2}
                       rx={2}
-                      onMouseDown={(e) => {
+                      onPointerDown={(e) => {
                         e.stopPropagation();
                         if (e.cancelable) e.preventDefault();
+                        capturePointer(e);
                         if (onEndpointDragStart) {
                           const world = toWorldFromEvent(e as any) ?? { x: next.x, y: next.y };
                           onEndpointDragStart(selectedSegment, 'end', world);
@@ -1319,9 +1401,12 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                   height={Math.abs(arcEndY) + 30}
                   fill="transparent"
                   style={{ cursor: isSelected ? 'grab' : 'pointer' }}
-                  onMouseDown={(e) => {
+                  onPointerDown={(e) => {
+                    if (e.button !== 0) return;
                     e.stopPropagation();
-                    suppressClickRef.current = false;
+                    if (e.cancelable) e.preventDefault();
+                    capturePointer(e);
+                    suppressClickRef.current = true;
 
                     // Select the door
                     onDoorSelect?.(door.id);
@@ -1450,11 +1535,12 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                   strokeDasharray={isSelected ? '4 2' : undefined}
                   rx={3}
                   style={{ cursor: isDragging ? 'grabbing' : 'grab' }}
-                  onMouseDown={(e) => {
+                  onPointerDown={(e) => {
                     e.stopPropagation();
+                    capturePointer(e);
                     const worldPos = toWorldFromEvent(e as any);
                     if (!worldPos) return;
-                    suppressClickRef.current = false;
+                    suppressClickRef.current = true;
                     setFurnitureDrag({ id: item.id, start: worldPos, basePos: { x: item.x, y: item.y } });
                     onDragStateChange?.(true);
                     onFurnitureSelect?.(item.id);
@@ -1464,7 +1550,7 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
 
               {/* Resize handles (only when selected and not dragging/rotating) */}
               {isSelected && !isDragging && !isResizing && !isRotating && (() => {
-                const handleSize = 8;
+                const handleSize = 14;
                 const handles: Array<{ corner: 'nw' | 'ne' | 'sw' | 'se'; x: number; y: number; cursor: string }> = [
                   { corner: 'nw', x: -canvasWidth / 2, y: -canvasHeight / 2, cursor: 'nwse-resize' },
                   { corner: 'ne', x: canvasWidth / 2, y: -canvasHeight / 2, cursor: 'nesw-resize' },
@@ -1487,11 +1573,12 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                         rx={1}
                         transform={`translate(${canvasPos.x}, ${canvasPos.y}) rotate(${displayRotation})`}
                         style={{ transformOrigin: '0 0', cursor: handle.cursor }}
-                        onMouseDown={(e) => {
+                        onPointerDown={(e) => {
                           e.stopPropagation();
+                          capturePointer(e);
                           const worldPos = toWorldFromEvent(e as any);
                           if (!worldPos) return;
-                          suppressClickRef.current = false;
+                          suppressClickRef.current = true;
                           setFurnitureResize({
                             id: item.id,
                             corner: handle.corner,
@@ -1519,16 +1606,17 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                       <circle
                         cx={0}
                         cy={-canvasHeight / 2 - 20}
-                        r={6}
+                        r={10}
                         fill="#a855f7"
                         stroke="#ffffff"
                         strokeWidth={1.5}
                         style={{ cursor: 'grab' }}
-                        onMouseDown={(e) => {
+                        onPointerDown={(e) => {
                           e.stopPropagation();
+                          capturePointer(e);
                           const worldPos = toWorldFromEvent(e as any);
                           if (!worldPos) return;
-                          suppressClickRef.current = false;
+                          suppressClickRef.current = true;
                           setFurnitureRotate({
                             id: item.id,
                             start: worldPos,
@@ -1556,6 +1644,8 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
           roomShellPoints: safePoints,
           devicePlacement: safePlacement,
           fieldOfViewDeg: effectiveFov,
+          onCanvasPointerMove: handlePointerMove,
+          onCanvasPointerRelease: handlePointerUp,
           deviceElement: (!deviceInteractive && showDevice && devicePlacement && safePlacement) ? (() => {
             const { x: px, y: py } = toCanvasCoord(safePlacement);
             // Add 90 degrees so that 0 degrees points down (Y+) instead of right (X+)
@@ -1885,7 +1975,12 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                       width={iconSize}
                       height={iconSize}
                       style={{ cursor: 'grab', pointerEvents: 'all' }}
-                      onMouseDown={() => {
+                      onPointerDown={(e) => {
+                        if (e.button !== 0) return;
+                        e.stopPropagation();
+                        if (e.cancelable) e.preventDefault();
+                        capturePointer(e);
+                        suppressClickRef.current = true;
                         setDragDevice(true);
                         onDragStateChange?.(true);
                       }}
@@ -1900,7 +1995,12 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                       fill="#3b82f6"
                       stroke="#1d4ed8"
                       strokeWidth={2}
-                      onMouseDown={() => {
+                      onPointerDown={(e) => {
+                        if (e.button !== 0) return;
+                        e.stopPropagation();
+                        if (e.cancelable) e.preventDefault();
+                        capturePointer(e);
+                        suppressClickRef.current = true;
                         setDragDevice(true);
                         onDragStateChange?.(true);
                       }}

--- a/everything-presence-mmwave-configurator/frontend/src/components/ZoneCanvas.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/ZoneCanvas.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { ZoneRect, ZonePolygon, Point, FurnitureInstance, Door, isZonePolygon } from '../api/types';
 import { RoomCanvas } from './RoomCanvas';
 import { DevicePlacement, Point as RoomPoint } from './RoomCanvas';
@@ -22,6 +22,8 @@ interface ZoneCanvasProps {
   zoom?: number;
   panOffsetMm?: { x: number; y: number };
   onPanChange?: (offset: { x: number; y: number }) => void;
+  onZoomChange?: (zoom: number) => void;
+  touchPanEnabled?: boolean;
   onCanvasMove?: (point: { x: number; y: number }) => void;
   roomShell?: { points: RoomPoint[] };
   roomShellFillMode?: 'overlay' | 'material';
@@ -57,7 +59,7 @@ interface ZoneCanvasProps {
   renderOverlay?: (params: {
     toCanvas: (point: { x: number; y: number }) => { x: number; y: number };
     fromCanvas: (point: { x: number; y: number }) => { x: number; y: number };
-    toWorldFromEvent: (e: React.MouseEvent<SVGElement>) => { x: number; y: number } | null;
+    toWorldFromEvent: (e: { clientX: number; clientY: number }) => { x: number; y: number } | null;
     svgRef: React.RefObject<SVGSVGElement>;
     rangeMm: number;
   }) => React.ReactNode;
@@ -79,6 +81,8 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
   zoom = 1,
   panOffsetMm = { x: 0, y: 0 },
   onPanChange,
+  onZoomChange,
+  touchPanEnabled = true,
   onCanvasMove,
   roomShell,
   roomShellFillMode,
@@ -114,6 +118,19 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
   const [draggingPolygonId, setDraggingPolygonId] = useState<string | null>(null);
   const [polygonDragOffset, setPolygonDragOffset] = useState<{ dx: number; dy: number }>({ dx: 0, dy: 0 });
   const [draggingVertex, setDraggingVertex] = useState<{ zoneId: string; vertexIndex: number } | null>(null);
+  const polygonPointerDragRef = useRef<
+    | { type: 'polygon'; zoneId: string; offset: { dx: number; dy: number } }
+    | { type: 'vertex'; zoneId: string; vertexIndex: number }
+    | null
+  >(null);
+
+  const capturePointer = (e: React.PointerEvent<SVGElement>) => {
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    } catch {
+      // Older embedded webviews can reject capture on SVG nodes.
+    }
+  };
 
   const effectiveRotationDeg =
     devicePlacement ? (devicePlacement.rotationDeg ?? 0) + (installationAngle ?? 0) : 0;
@@ -159,6 +176,114 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
       x: translatedX * cos - translatedY * sin,
       y: translatedX * sin + translatedY * cos,
     };
+  };
+
+  const applyPolygonPointerDrag = (pt: { x: number; y: number }) => {
+    const active = polygonPointerDragRef.current;
+    if (!active || polygonReadOnly || !onPolygonZonesChange) return false;
+
+    if (active.type === 'vertex') {
+      const idx = polygonZones.findIndex((z) => z.id === active.zoneId);
+      if (idx === -1) return false;
+
+      const polygon = { ...polygonZones[idx] };
+      const vertices = [...polygon.vertices];
+      if (!vertices[active.vertexIndex]) return false;
+
+      const deviceCoords = roomToDevice(pt.x, pt.y);
+      let newX = deviceCoords.x;
+      let newY = deviceCoords.y;
+
+      if (snapGridMm && snapGridMm > 0) {
+        const step = snapGridMm;
+        newX = Math.round(newX / step) * step;
+        newY = Math.round(newY / step) * step;
+      }
+
+      if (polygonLateralOnlyAxis) {
+        const axis = polygonLateralOnlyAxis;
+        const previousValue = vertices[active.vertexIndex][axis];
+        const nextValue = axis === 'x' ? newX : newY;
+        onPolygonZonesChange(polygonZones.map((candidate) => (
+          candidate.id === polygon.id
+            ? {
+                ...candidate,
+                vertices: candidate.vertices.map((vertex) => (
+                  Math.abs(vertex[axis] - previousValue) < 1
+                    ? { ...vertex, [axis]: nextValue }
+                    : vertex
+                )),
+              }
+            : candidate
+        )));
+        return true;
+      }
+
+      vertices[active.vertexIndex] = { x: newX, y: newY };
+      polygon.vertices = vertices;
+      const next = [...polygonZones];
+      next[idx] = polygon;
+      onPolygonZonesChange(next);
+      return true;
+    }
+
+    const idx = polygonZones.findIndex((z) => z.id === active.zoneId);
+    if (idx === -1) return false;
+
+    const polygon = { ...polygonZones[idx] };
+    const deviceCoords = roomToDevice(pt.x - active.offset.dx, pt.y - active.offset.dy);
+    const centroid = polygon.vertices.reduce(
+      (acc, v) => ({ x: acc.x + v.x / polygon.vertices.length, y: acc.y + v.y / polygon.vertices.length }),
+      { x: 0, y: 0 }
+    );
+
+    let deltaX = deviceCoords.x - centroid.x;
+    let deltaY = deviceCoords.y - centroid.y;
+
+    if (snapGridMm && snapGridMm > 0) {
+      const step = snapGridMm;
+      deltaX = Math.round(deltaX / step) * step;
+      deltaY = Math.round(deltaY / step) * step;
+    }
+
+    if (polygonLateralOnlyAxis === 'x') {
+      deltaY = 0;
+    } else if (polygonLateralOnlyAxis === 'y') {
+      deltaX = 0;
+    }
+
+    if (polygonLateralOnlyAxis) {
+      const axis = polygonLateralOnlyAxis;
+      const delta = axis === 'x' ? deltaX : deltaY;
+      if (Math.abs(delta) < 0.5) return true;
+
+      onPolygonZonesChange(polygonZones.map((candidate) => ({
+        ...candidate,
+        vertices: candidate.id === polygon.id
+          ? candidate.vertices.map((vertex) => ({ ...vertex, [axis]: vertex[axis] + delta }))
+          : candidate.vertices,
+      })));
+      return true;
+    }
+
+    polygon.vertices = polygon.vertices.map((v) => ({
+      x: v.x + deltaX,
+      y: v.y + deltaY,
+    }));
+
+    const next = [...polygonZones];
+    next[idx] = polygon;
+    onPolygonZonesChange(next);
+    return true;
+  };
+
+  const finishPolygonPointerDrag = () => {
+    if (!polygonPointerDragRef.current) return false;
+    polygonPointerDragRef.current = null;
+    setDraggingVertex(null);
+    setDraggingPolygonId(null);
+    onDragStateChange?.(false);
+    return true;
   };
 
   return (
@@ -367,6 +492,8 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
       zoom={zoom}
       panOffsetMm={panOffsetMm}
       onPanChange={onPanChange}
+      onZoomChange={onZoomChange}
+      touchPanEnabled={touchPanEnabled}
       devicePlacement={devicePlacement}
       fieldOfViewDeg={fieldOfViewDeg}
       maxRangeMeters={maxRangeMeters}
@@ -382,7 +509,68 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
       deviceInteractive={false}
       lockShell
       renderOverlay={(params) => {
-        const { toCanvas, toWorldFromEvent } = params;
+        const { toCanvas, toWorldFromEvent, onCanvasPointerMove, onCanvasPointerRelease } = params;
+        const forwardCanvasPointerMove = (e: React.PointerEvent<SVGElement>) => {
+          onCanvasPointerMove(e);
+          e.stopPropagation();
+        };
+        const forwardCanvasPointerRelease = (e: React.PointerEvent<SVGElement>) => {
+          onCanvasPointerRelease(e);
+          e.stopPropagation();
+        };
+        const handlePolygonPointerMove = (e: React.PointerEvent<SVGElement>) => {
+          const world = toWorldFromEvent(e);
+          if (world && applyPolygonPointerDrag(world)) {
+            e.stopPropagation();
+            if (e.cancelable) e.preventDefault();
+            return;
+          }
+          forwardCanvasPointerMove(e);
+        };
+        const handlePolygonPointerRelease = (e: React.PointerEvent<SVGElement>) => {
+          if (finishPolygonPointerDrag()) {
+            e.stopPropagation();
+            if (e.cancelable) e.preventDefault();
+            return;
+          }
+          forwardCanvasPointerRelease(e);
+        };
+        const startPolygonDrag = (
+          e: React.PointerEvent<SVGElement>,
+          polygon: ZonePolygon,
+          roomCentroid: { x: number; y: number },
+        ) => {
+          if (e.button !== 0) return;
+          e.stopPropagation();
+          if (e.cancelable) e.preventDefault();
+          capturePointer(e);
+          if (polygonReadOnly) {
+            onSelect?.(polygon.id);
+            return;
+          }
+          const world = toWorldFromEvent(e);
+          if (!world) return;
+          const offset = { dx: world.x - roomCentroid.x, dy: world.y - roomCentroid.y };
+          polygonPointerDragRef.current = { type: 'polygon', zoneId: polygon.id, offset };
+          setDraggingPolygonId(polygon.id);
+          setPolygonDragOffset(offset);
+          onDragStateChange?.(true);
+          onSelect?.(polygon.id);
+        };
+        const startPolygonVertexDrag = (
+          e: React.PointerEvent<SVGElement>,
+          polygon: ZonePolygon,
+          vertexIndex: number,
+        ) => {
+          if (e.button !== 0) return;
+          e.stopPropagation();
+          if (e.cancelable) e.preventDefault();
+          capturePointer(e);
+          polygonPointerDragRef.current = { type: 'vertex', zoneId: polygon.id, vertexIndex };
+          setDraggingVertex({ zoneId: polygon.id, vertexIndex });
+          onDragStateChange?.(true);
+          onSelect?.(polygon.id);
+        };
 
         // Render furniture (before zones, so zones appear on top)
         const furnitureElements = showFurniture ? furniture.map((item) => {
@@ -492,9 +680,10 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
                 onClick={(e) => {
                   e.stopPropagation(); // Prevent canvas click from deselecting
                 }}
-                onMouseDown={(e) => {
-                  if ((e as any).button !== 0) return; // only left click selects/drags
+                onPointerDown={(e) => {
+                  if (e.button !== 0) return; // only primary click/touch selects/drags
                   e.stopPropagation();
+                  capturePointer(e);
                   const world = toWorldFromEvent(e);
                   if (!world) return;
                   setDraggingId(zone.id);
@@ -503,6 +692,9 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
                   setDragOffset({ dx: world.x - roomTopLeft.x, dy: world.y - roomTopLeft.y });
                   onSelect?.(zone.id);
                 }}
+                onPointerMove={forwardCanvasPointerMove}
+                onPointerUp={forwardCanvasPointerRelease}
+                onPointerCancel={forwardCanvasPointerRelease}
               />
               {/* Zone label with better visibility */}
               <text
@@ -527,7 +719,7 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
                   key={handle.name}
                   cx={handle.x}
                   cy={handle.y}
-                  r={6}
+                  r={11}
                   fill="white"
                   stroke={color}
                   strokeWidth={2}
@@ -539,9 +731,10 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
                   onClick={(e) => {
                     e.stopPropagation(); // Prevent canvas click from deselecting
                   }}
-                  onMouseDown={(e) => {
-                    if ((e as any).button !== 0) return;
+                  onPointerDown={(e) => {
+                    if (e.button !== 0) return;
                     e.stopPropagation();
+                    capturePointer(e);
                     const world = toWorldFromEvent(e);
                     if (!world) return;
                     setResizingHandle({ zoneId: zone.id, handle: handle.name });
@@ -549,6 +742,9 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
                     onDragStateChange?.(true);
                     onSelect?.(zone.id);
                   }}
+                  onPointerMove={forwardCanvasPointerMove}
+                  onPointerUp={forwardCanvasPointerRelease}
+                  onPointerCancel={forwardCanvasPointerRelease}
                 />
               ))}
             </g>
@@ -596,6 +792,15 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
             { x: 0, y: 0 }
           );
           const roomCentroid = deviceToRoom(deviceCentroid.x, deviceCentroid.y);
+          const lateralDragEdges = polygonLateralOnlyAxis
+            ? canvasVertices
+                .map((v, idx) => ({ start: v, end: canvasVertices[(idx + 1) % canvasVertices.length], idx }))
+                .filter(({ start, end }) => (
+                  polygonLateralOnlyAxis === 'x'
+                    ? Math.abs(start.x - end.x) < 1
+                    : Math.abs(start.y - end.y) < 1
+                ))
+            : [];
 
           return (
             <g key={polygon.id}>
@@ -608,22 +813,33 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
                 style={{ cursor: polygonReadOnly ? 'pointer' : polygonLateralOnlyAxis ? (polygonLateralOnlyAxis === 'x' ? 'ew-resize' : 'ns-resize') : draggingPolygonId === polygon.id ? 'move' : 'pointer' }}
                 onClick={(e) => {
                   e.stopPropagation();
-                }}
-                onMouseDown={(e) => {
-                  if ((e as any).button !== 0) return;
-                  e.stopPropagation();
-                  if (polygonReadOnly) {
-                    onSelect?.(polygon.id);
-                    return;
-                  }
-                  const world = toWorldFromEvent(e);
-                  if (!world) return;
-                  setDraggingPolygonId(polygon.id);
-                  onDragStateChange?.(true);
-                  setPolygonDragOffset({ dx: world.x - roomCentroid.x, dy: world.y - roomCentroid.y });
                   onSelect?.(polygon.id);
                 }}
+                pointerEvents="all"
+                onPointerDown={(e) => startPolygonDrag(e, polygon, roomCentroid)}
+                onPointerMove={handlePolygonPointerMove}
+                onPointerUp={handlePolygonPointerRelease}
+                onPointerCancel={handlePolygonPointerRelease}
               />
+              {polygonLateralOnlyAxis && (
+                <polygon
+                  points={pointsStr}
+                  fill="transparent"
+                  stroke="transparent"
+                  strokeWidth={24}
+                  vectorEffect="non-scaling-stroke"
+                  pointerEvents="all"
+                  style={{ cursor: polygonLateralOnlyAxis === 'x' ? 'ew-resize' : 'ns-resize' }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onSelect?.(polygon.id);
+                  }}
+                  onPointerDown={(e) => startPolygonDrag(e, polygon, roomCentroid)}
+                  onPointerMove={handlePolygonPointerMove}
+                  onPointerUp={handlePolygonPointerRelease}
+                  onPointerCancel={handlePolygonPointerRelease}
+                />
+              )}
               {/* Zone label */}
               <text
                 x={centroid.x}
@@ -647,21 +863,38 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
                   key={`vertex-${idx}`}
                   cx={v.x}
                   cy={v.y}
-                  r={7}
+                  r={11}
                   fill="white"
                   stroke={color}
                   strokeWidth={2}
                   style={{ cursor: polygonLateralOnlyAxis === 'x' ? 'ew-resize' : polygonLateralOnlyAxis === 'y' ? 'ns-resize' : 'move' }}
                   onClick={(e) => {
                     e.stopPropagation();
-                  }}
-                  onMouseDown={(e) => {
-                    if ((e as any).button !== 0) return;
-                    e.stopPropagation();
-                    setDraggingVertex({ zoneId: polygon.id, vertexIndex: idx });
-                    onDragStateChange?.(true);
                     onSelect?.(polygon.id);
                   }}
+                  pointerEvents="all"
+                  onPointerDown={(e) => startPolygonVertexDrag(e, polygon, idx)}
+                  onPointerMove={handlePolygonPointerMove}
+                  onPointerUp={handlePolygonPointerRelease}
+                  onPointerCancel={handlePolygonPointerRelease}
+                />
+              ))}
+              {isSelected && !polygonReadOnly && polygonLateralOnlyAxis && lateralDragEdges.map(({ start, end, idx }) => (
+                <line
+                  key={`lateral-edge-${idx}`}
+                  x1={start.x}
+                  y1={start.y}
+                  x2={end.x}
+                  y2={end.y}
+                  stroke="transparent"
+                  strokeWidth={28}
+                  vectorEffect="non-scaling-stroke"
+                  pointerEvents="stroke"
+                  style={{ cursor: polygonLateralOnlyAxis === 'x' ? 'ew-resize' : 'ns-resize' }}
+                  onPointerDown={(e) => startPolygonVertexDrag(e, polygon, idx)}
+                  onPointerMove={handlePolygonPointerMove}
+                  onPointerUp={handlePolygonPointerRelease}
+                  onPointerCancel={handlePolygonPointerRelease}
                 />
               ))}
               {/* Edge midpoints for adding vertices (only when selected) */}
@@ -676,7 +909,7 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
                     key={`midpoint-${idx}`}
                     cx={midX}
                     cy={midY}
-                    r={5}
+                    r={8}
                     fill={color}
                     fillOpacity={0.5}
                     stroke="white"
@@ -702,8 +935,9 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
                       const next = polygonZones.map(p => p.id === polygon.id ? updatedPolygon : p);
                       onPolygonZonesChange(next);
                     }}
-                    onMouseDown={(e) => {
+                    onPointerDown={(e) => {
                       e.stopPropagation();
+                      capturePointer(e);
                     }}
                   />
                 );

--- a/everything-presence-mmwave-configurator/frontend/src/pages/LiveTrackingPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/LiveTrackingPage.tsx
@@ -1074,6 +1074,8 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
             zoom={zoom}
             panOffsetMm={panOffsetMm}
             onPanChange={(next) => setPanOffsetMm(next)}
+            onZoomChange={setZoom}
+            touchPanEnabled
             onCanvasMove={(pt) => setCursorPos(pt)}
             roomShell={selectedRoom.roomShell}
             roomShellFillMode={selectedRoom.roomShellFillMode}

--- a/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
@@ -1232,6 +1232,8 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                   zoom={zoom}
                   panOffsetMm={panOffsetMm}
                   onPanChange={(next) => setPanOffsetMm(next)}
+                  onZoomChange={setZoom}
+                  touchPanEnabled={!isDrawingWall && !isDoorPlacementMode}
                   displayUnits={displayUnits}
                   devicePlacement={
                     selectedRoom.devicePlacement ?? {

--- a/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
@@ -29,6 +29,7 @@ import {
   buildCeilingExclusionZones,
   buildCeilingSliceZones,
   CeilingSliceConfig,
+  getCeilingSliceBands,
   getCeilingSliceLineDepth,
   getCeilingSlicePosition,
   normalizeCeilingSliceConfig,
@@ -680,37 +681,46 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
 
   const handlePolygonZonesChange = (nextZones: ZonePolygon[]) => {
     if (isCeilingSliceMode) {
-      const regularZones = nextZones
-        .filter((zone) => zone.type === 'regular')
-        .slice(0, ceilingSliceConfig.sliceCount);
-      const lateralRangesMm = regularZones.map((zone) => {
+      const getPolygonLateralRange = (zone: ZonePolygon) => {
         const values = zone.vertices
           .map((vertex) => ceilingSliceConfig.axis === 'x' ? vertex.x : vertex.y)
           .filter((value) => Number.isFinite(value));
+        if (!values.length) return null;
         const min = Math.min(...values);
         const max = Math.max(...values);
         return { min: Math.min(min, max - 100), max: Math.max(max, min + 100) };
-      });
+      };
 
-      if (lateralRangesMm.length === ceilingSliceConfig.sliceCount) {
-        const exclusionRangesMm = nextZones
-          .filter((zone) => zone.type === 'exclusion')
-          .map((zone) => {
-            const values = zone.vertices
-              .map((vertex) => ceilingSliceConfig.axis === 'x' ? vertex.x : vertex.y)
-              .filter((value) => Number.isFinite(value));
-            const min = Math.min(...values);
-            const max = Math.max(...values);
-            return { min: Math.min(min, max - 100), max: Math.max(max, min + 100) };
-          });
-        updateCeilingSliceConfig({
-          lateralMinMm: Math.min(...lateralRangesMm.map((range) => range.min)),
-          lateralMaxMm: Math.max(...lateralRangesMm.map((range) => range.max)),
-          lateralBreakpointsMm: undefined,
-          lateralRangesMm,
-          exclusionRangesMm,
-        }, { persist: false });
+      const existingRanges = getCeilingSliceBands(ceilingSliceConfig)
+        .slice(0, ceilingSliceConfig.sliceCount)
+        .map((band) => ({ min: band.min, max: band.max }));
+      const lateralRangesMm = [...existingRanges];
+
+      for (const zone of nextZones.filter((zone) => zone.type === 'regular')) {
+        const index = Number(zone.id.match(/\d+/)?.[0] ?? '0') - 1;
+        const range = getPolygonLateralRange(zone);
+        if (index >= 0 && index < lateralRangesMm.length && range) {
+          lateralRangesMm[index] = range;
+        }
       }
+
+      const existingExclusions = ceilingSliceConfig.exclusionRangesMm ?? [];
+      const exclusionRangesMm = [...existingExclusions];
+      for (const zone of nextZones.filter((zone) => zone.type === 'exclusion')) {
+        const index = Number(zone.id.match(/\d+/)?.[0] ?? '0') - 1;
+        const range = getPolygonLateralRange(zone);
+        if (index >= 0 && range) {
+          exclusionRangesMm[index] = range;
+        }
+      }
+
+      updateCeilingSliceConfig({
+        lateralMinMm: Math.min(...lateralRangesMm.map((range) => range.min)),
+        lateralMaxMm: Math.max(...lateralRangesMm.map((range) => range.max)),
+        lateralBreakpointsMm: undefined,
+        lateralRangesMm,
+        exclusionRangesMm: exclusionRangesMm.slice(0, selectedProfile?.limits.maxExclusionZones ?? 2),
+      }, { persist: false });
       return;
     }
     setPolygonZones(nextZones);
@@ -1432,6 +1442,8 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
             zoom={zoom}
             panOffsetMm={panOffsetMm}
             onPanChange={(next) => setPanOffsetMm(next)}
+            onZoomChange={setZoom}
+            touchPanEnabled={!isDraggingZone}
             onCanvasMove={(pt) => setCursorPos(pt)}
             roomShell={selectedRoom.roomShell}
             roomShellFillMode={selectedRoom.roomShellFillMode}


### PR DESCRIPTION
Improves canvas interaction across Live Dashboard, Zone Editor, and Room Builder for mobile and touch devices.

This moves the shared canvas interaction model toward pointer events, adds touch-friendly drag handles, enables one-finger canvas panning where appropriate, and wires pinch zoom into the existing page zoom state. Desktop mouse interaction is preserved, including mouse wheel zoom and right-drag panning.