### PR TITLE
Update all user facing docs to use apps termionology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Everything Presence Add-ons
+# Everything Presence Apps
 
 [![Stars][stars-shield]][repo]  [![Release][release-shield]][release] [![Discord][discord-shield]][discord]
 
 ## About
 
-Home Assistant add-ons for Everything Presence One/Lite/Pro mmWave presence sensors.
+Home Assistant apps for Everything Presence One/Lite/Pro mmWave presence sensors.
 
 ## Install Repository
 
@@ -24,17 +24,17 @@ Use this installation method **ONLY** if you have a [Home Assistant OS Installat
 
         1. Click **`+ Add`** then **`Close`**.
 
-1. Scroll to the section **`"Everything Presence Add-ons"`**.
+1. Scroll to the section **`"Everything Presence Apps"`**.
 
-1. Install any of the **`Add-ons`** in this repository.
+1. Install any of the **`Apps`** in this repository.
 
-## Add-ons provided by this repository
+## Apps provided by this repository
 
 ### Everything Presence Zone Configurator
 
 A visual configuration tool for Everything Presence devices in Home Assistant.
 
-**[📚 Zone Configurator Add-on documentation:][zc-repo-addon-docs]** Use for Home Assistant OS Installations
+**[📚 Zone Configurator App documentation:][zc-repo-addon-docs]** Use for Home Assistant OS Installations
 
 **[📚 Zone Configurator Standalone Docker Documentation][zc-repo-standalone-docs]** Use for Home Assistant Installations that **DO NOT** support add-ons.
 

--- a/everything-presence-mmwave-configurator/DOCS.md
+++ b/everything-presence-mmwave-configurator/DOCS.md
@@ -1,4 +1,4 @@
-# Everything Presence Add-on: Zone Configurator
+# Everything Presence App: Zone Configurator
 
 [![Stars][stars-shield]][repo]  [![Release][release-shield]][release] [![Discord][discord-shield]][discord]
 
@@ -23,13 +23,13 @@ Use this installation method **ONLY** if you have a [Home Assistant OS Installat
 
         1. Click **`+ Add`** then **`Close`**.
 
-1. Scroll to the section **"Everything Presence Add-ons"**
+1. Scroll to the section **"Everything Presence Apps"**
 
 1. Click **"Everything Presence Zone Configurator"** and then Install.
 
-1. Start the **Everything Presence Zone Configurator** add-on.
+1. Start the **Everything Presence Zone Configurator** app.
 
-1. Check the logs of the **Everything Presence Zone Configurator** add-on to see if everything started correctly.
+1. Check the logs of the **Everything Presence Zone Configurator** app to see if everything started correctly.
 
 1. Click the **OPEN WEB UI** button to open **Everything Presence Zone Configurator**.
 
@@ -47,14 +47,14 @@ Use this installation method **ONLY** if you have a [Home Assistant OS Installat
 
 ## Quick Links
 
-| I want to...              | Go to...
-| :-------------------------| :-
-| Install the add-on        | [Installation][installation]
-| Set up my first device    | [Setup Wizard][setup-wizard]
-| Create detection zones    | [Zone Editor][zone-editor]
-| Draw my room layout       | [Room Builder][room-builder]
-| Fix a problem             | [Troubleshooting][troubleshooting]
-| Update device firmware    | [Firmware Updates][firmware-updates]
+| I want to...           | Go to...                             |
+| :--------------------- | :----------------------------------- |
+| Install the app        | [Installation][installation]         |
+| Set up my first device | [Setup Wizard][setup-wizard]         |
+| Create detection zones | [Zone Editor][zone-editor]           |
+| Draw my room layout    | [Room Builder][room-builder]         |
+| Fix a problem          | [Troubleshooting][troubleshooting]   |
+| Update device firmware | [Firmware Updates][firmware-updates] |
 
 <!--
 ###########################

--- a/everything-presence-mmwave-configurator/DOCS.md
+++ b/everything-presence-mmwave-configurator/DOCS.md
@@ -11,7 +11,7 @@ Use this installation method **ONLY** if you have a [Home Assistant OS Installat
 1. Click the Home Assistant My button below to open the add-on on your Home
    Assistant instance.
 
-    [![Open your Home Assistant instance and show the dashboard of an add-on.][ha-addon-svg]][ha-addon-url]
+    [![Open your Home Assistant instance and show the dashboard of an app.][ha-addon-svg]][ha-addon-url]
 
    - If that link doesn't work, then...
 

--- a/everything-presence-mmwave-configurator/README.md
+++ b/everything-presence-mmwave-configurator/README.md
@@ -1,10 +1,10 @@
-# Everything Presence Add-on: Zone Configurator
+# Everything Presence App: Zone Configurator
 
 [![Stars][stars-shield]][repo]  [![Release][release-shield]][release] [![Discord][discord-shield]][discord]
 
 ---
 
-[Zone Configurator][zone-configurator] is a Home Assistant add-on that provides a visual interface for configuring Everything Presence devices. Draw room layouts, create detection zones, and watch real-time target tracking - all from your browser.
+[Zone Configurator][zone-configurator] is a Home Assistant app that provides a visual interface for configuring Everything Presence devices. Draw room layouts, create detection zones, and watch real-time target tracking - all from your browser.
 
 ![Zone Configurator Frontend][screenshot]
 
@@ -33,7 +33,7 @@
 
 ## Requirements
 
-- Home Assistant (with Supervisor for add-on, or Docker for standalone)
+- Home Assistant (with Supervisor for app, or Docker for standalone)
 - Everything Presence Pro, Lite, or One device
 - Device already configured and connected to Home Assistant
 

--- a/everything-presence-mmwave-configurator/config.yaml
+++ b/everything-presence-mmwave-configurator/config.yaml
@@ -18,8 +18,8 @@ ports:
   42069/tcp: null
   38080/tcp: 38080
 ports_description:
-  42069/tcp: Optional direct access (ingress preferred, configurable in add-on settings)
-  38080/tcp: LAN firmware server for device OTA updates (configurable in add-on settings)
+  42069/tcp: Optional direct access (ingress preferred, configurable in app settings)
+  38080/tcp: LAN firmware server for device OTA updates (configurable in app settings)
 homeassistant_api: true
 auth_api: true
 hassio_api: true

--- a/everything-presence-mmwave-configurator/frontend/src/components/FirmwareUpdateSection.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/FirmwareUpdateSection.tsx
@@ -2503,7 +2503,7 @@ export const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({
                         To avoid installing incompatible firmware, updates are disabled.
                       </p>
                       <p className="mb-3 text-xs text-amber-200">
-                        Flash the latest firmware via USB to enable over-the-air updates in this add-on.
+                        Flash the latest firmware via USB to enable over-the-air updates in this app.
                       </p>
                       <a
                         href="https://docs.everythingsmart.io"

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,3 @@
-name: Everything Presence Add-ons
+name: Everything Presence Apps
 url: 'https://github.com/everythingsmarthome/everything-presence-addons'
 maintainer: Everything Smart Home <github@everythingsmart.io>


### PR DESCRIPTION
Updates the app repository user facing strings from add-ons to apps to match new HA terminology.

Didn't touch any links etc.

The repo rename is another matter (probably not that nesassary), but this way will keep the app store page and app docs to use the updated terms