### PR TITLE
Make Dockerfile build layer atomic to fix #306

### DIFF
--- a/everything-presence-mmwave-configurator/Dockerfile
+++ b/everything-presence-mmwave-configurator/Dockerfile
@@ -4,17 +4,14 @@ FROM node:20-alpine AS build
 WORKDIR /app
 ENV NODE_ENV=development
 
-# Install dependencies for workspace build
+# Source copied before install so install+build+prune is one atomic layer
+# invalidated by source changes — fixes stale-install failure (#306).
 COPY package.json package-lock.json ./
-COPY backend/package.json backend/package.json
-COPY frontend/package.json frontend/package.json
-RUN npm ci --include=dev
-
-# Copy sources and build
 COPY backend backend
 COPY frontend frontend
-RUN npm run build --workspaces
-RUN npm prune --omit=dev --workspaces
+RUN npm ci --include=dev \
+ && npm run build --workspaces \
+ && npm prune --omit=dev --workspaces
 
 FROM ${BUILD_FROM} AS addon
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
## Summary
Collapses install + build + prune into one atomic RUN and copies source before install, so the build layer is invalidated by source changes too.

## Why

The build log on the failing host shows:

```
#14 [build 7/10] COPY backend backend    CACHED
#16 [build 8/10] COPY frontend frontend  CACHED
```

backend/ and frontend/ changed by ~5000 lines between v2.0.12 and v2.1.0, so those shouldn't be cache hits. The whole pre-build prefix is being served from the 2.0.12 cache, and `npm run build` only re-runs because its result entry got evicted. That's also why `docker builder prune -af` fixes it.

The reason it gets into this state: `npm ci` and `npm run build` are separate layers keyed only on the package manifests, which didn't change in 2.1.0. The install layer never gets re-validated, and the later `npm prune --omit=dev` strips tsc/vite, so any drift between the cached install and a re-run of the build step lands here. x86 / HA Green pull the published addon image and skip the build path entirely, which is probably why it didn't repro on those.

The two-step merge suggested in the OP helps but its cache key is still just the manifests. Since the prune still matters for image size, this PR keeps all three atomic and copies source first.

Fixes #306. Closes #307.