### PR TITLE
Preserve zone timeouts when saving zones

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/domain/types.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/types.ts
@@ -5,6 +5,7 @@ export interface ZoneRect {
   y: number;
   width: number;
   height: number;
+  timeout?: number;
   enabled?: boolean; // Whether this zone slot is active/configured
   label?: string; // Custom display label (e.g., "Bed", "Chair")
 }

--- a/everything-presence-mmwave-configurator/backend/src/ha/zoneReader.ts
+++ b/everything-presence-mmwave-configurator/backend/src/ha/zoneReader.ts
@@ -216,13 +216,14 @@ export class ZoneReader {
         }
 
         if (!zoneEntitySet) continue;
-        const { beginX: beginXEntity, endX: endXEntity, beginY: beginYEntity, endY: endYEntity } = zoneEntitySet;
+        const { beginX: beginXEntity, endX: endXEntity, beginY: beginYEntity, endY: endYEntity, offDelay: offDelayEntity } = zoneEntitySet;
 
-        const [beginXState, endXState, beginYState, endYState] = await Promise.all([
+        const [beginXState, endXState, beginYState, endYState, offDelayState] = await Promise.all([
           this.readTransport.getState(beginXEntity),
           this.readTransport.getState(endXEntity),
           this.readTransport.getState(beginYEntity),
           this.readTransport.getState(endYEntity),
+          offDelayEntity ? this.readTransport.getState(offDelayEntity) : Promise.resolve(null),
         ]);
 
         if (!beginXState || !endXState || !beginYState || !endYState) continue;
@@ -245,6 +246,8 @@ export class ZoneReader {
         // Skip zones with no area
         if (width === 0 || height === 0) continue;
 
+        const timeout = this.parseStateNumber(offDelayState);
+
         zones.push({
           id: `Zone ${i}`,
           type: 'regular',
@@ -252,6 +255,7 @@ export class ZoneReader {
           y,
           width,
           height,
+          ...(timeout !== null ? { timeout } : {}),
         });
       } catch (error) {
         logger.warn({ key, error }, 'Failed to read zone');

--- a/everything-presence-mmwave-configurator/backend/src/ha/zoneWriter.ts
+++ b/everything-presence-mmwave-configurator/backend/src/ha/zoneWriter.ts
@@ -330,7 +330,9 @@ export class ZoneWriter {
           if (zoneEntitySet.endX) updates.push({ entity: zoneEntitySet.endX, value: zone.x + zone.width });
           if (zoneEntitySet.beginY) updates.push({ entity: zoneEntitySet.beginY, value: zone.y });
           if (zoneEntitySet.endY) updates.push({ entity: zoneEntitySet.endY, value: zone.y + zone.height });
-          if (zoneEntitySet.offDelay) updates.push({ entity: zoneEntitySet.offDelay, value: 15 });
+          if (zoneEntitySet.offDelay && typeof zone.timeout === 'number') {
+            updates.push({ entity: zoneEntitySet.offDelay, value: zone.timeout });
+          }
         } else {
           // Clear unused zone slot by setting all coordinates to 0
           if (zoneEntitySet.beginX) updates.push({ entity: zoneEntitySet.beginX, value: 0 });

--- a/everything-presence-mmwave-configurator/frontend/src/api/types.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/api/types.ts
@@ -96,6 +96,7 @@ export interface ZoneRect {
   y: number;
   width: number;
   height: number;
+  timeout?: number;
   enabled?: boolean; // Whether this zone slot is active/configured
   label?: string; // Custom display label (e.g., "Bed", "Chair")
 }


### PR DESCRIPTION
Read each zone timeout from Home Assistant when loading rectangular zones and write that value back instead of forcing `15` on save.

This keeps zone editor saves from overwriting the device's configured zone timeout.

Fixes #257