### PR TITLE
Use native arm64 runners and build all arches on PR

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -15,7 +15,23 @@ jobs:
   build-pr:
     name: Build Docker Images (PR)
     if: github.event_name != 'push'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+            build_from: ghcr.io/hassio-addons/base:19.0.0
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+            build_from: ghcr.io/hassio-addons/base:19.0.0
+          - platform: linux/arm/v7
+            arch: armv7
+            runner: ubuntu-latest
+            build_from: ghcr.io/home-assistant/armv7-base:latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -26,13 +42,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract version from config.yaml
         run: |
           VERSION=$(grep '^version:' everything-presence-mmwave-configurator/config.yaml | awk '{print $2}' | tr -d '"')
@@ -41,55 +50,50 @@ jobs:
 
       - name: Set Image Tags
         run: |
-          echo "STANDALONE_IMAGE_TAG=test/everything-presence-mmwave-configurator:${{ env.VERSION }}" >> $GITHUB_ENV
-          echo "ADDON_IMAGE_TAG=test/everything-presence-mmwave-configurator:addon-${{ env.VERSION }}" >> $GITHUB_ENV
+          echo "STANDALONE_IMAGE_TAG=test/everything-presence-mmwave-configurator:${{ env.VERSION }}-${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "ADDON_IMAGE_TAG=test/everything-presence-mmwave-configurator:addon-${{ env.VERSION }}-${{ matrix.arch }}" >> $GITHUB_ENV
 
-      - name: Build standalone image (amd64)
+      - name: Build standalone image
         uses: docker/build-push-action@v4
         with:
           context: ./everything-presence-mmwave-configurator
           target: standalone
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: false
-          load: true
+          load: false
           tags: |
             ${{ env.STANDALONE_IMAGE_TAG }}
 
-      - name: Build add-on image (amd64)
+      - name: Build add-on image
         uses: docker/build-push-action@v4
         with:
           context: ./everything-presence-mmwave-configurator
           target: addon
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: false
-          load: true
+          load: false
           build-args: |
-            BUILD_FROM=ghcr.io/hassio-addons/base:19.0.0
+            BUILD_FROM=${{ matrix.build_from }}
           tags: |
             ${{ env.ADDON_IMAGE_TAG }}
-
-      - name: Test standalone image
-        run: |
-          docker run --rm --entrypoint /bin/echo ${{ env.STANDALONE_IMAGE_TAG }} "Image built successfully"
-
-      - name: Test add-on image
-        run: |
-          docker run --rm --entrypoint /bin/echo ${{ env.ADDON_IMAGE_TAG }} "Image built successfully"
 
   build-push-standalone:
     name: Build and Push Standalone Image
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux/amd64
             arch: amd64
+            runner: ubuntu-latest
           - platform: linux/arm64
             arch: arm64
+            runner: ubuntu-24.04-arm
           - platform: linux/arm/v7
             arch: armv7
+            runner: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -136,19 +140,22 @@ jobs:
   build-push-addon:
     name: Build and Push Add-on Image
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux/amd64
             arch: amd64
+            runner: ubuntu-latest
             build_from: ghcr.io/hassio-addons/base:19.0.0
           - platform: linux/arm64
             arch: arm64
+            runner: ubuntu-24.04-arm
             build_from: ghcr.io/hassio-addons/base:19.0.0
           - platform: linux/arm/v7
             arch: armv7
+            runner: ubuntu-latest
             build_from: ghcr.io/home-assistant/armv7-base:latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -12,8 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-pr:
-    name: Build Docker Images (PR)
+  build-pr-matrix:
+    name: "Build Docker Image (PR) (${{ matrix.arch }})"
     if: github.event_name != 'push'
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -76,6 +76,20 @@ jobs:
             BUILD_FROM=${{ matrix.build_from }}
           tags: |
             ${{ env.ADDON_IMAGE_TAG }}
+
+  build-pr:
+    name: Build Docker Images (PR)
+    if: ${{ always() && github.event_name != 'push' }}
+    needs: build-pr-matrix
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check matrix result
+        run: |
+          if [ "${{ needs.build-pr-matrix.result }}" != "success" ]; then
+            echo "One or more matrix builds failed: ${{ needs.build-pr-matrix.result }}"
+            exit 1
+          fi
+          echo "All matrix builds passed"
 
   build-push-standalone:
     name: Build and Push Standalone Image


### PR DESCRIPTION
## Summary
- Switch the arm64 build matrix to GitHub's native `ubuntu-24.04-arm` runners so arm64 builds natively rather than under QEMU emulation on an amd64 host.
- Expand the PR smoke build from amd64-only to the full amd64 / arm64 / armv7 matrix (push and load both off).

## Why

The arm64 QEMU build on the #311 merge hit `qemu: uncaught target signal 4 (Illegal instruction)` mid-`npm ci` and only passed on rerun. Same Dockerfile, same `node:20-alpine` builder, identical RUN — only arm64 standalone flaked, arm64 addon passed. That's the well-known QEMU + node arm64 emulation instability. GitHub now offers `ubuntu-24.04-arm` free for public repos, so arm64 can build natively. armv7 stays on QEMU since GitHub doesn't offer a native armv7 runner, and that emulation has been stable for this repo.

Expected side effect: arm64 build time drops roughly 3x (3m -> ~1m).

The previous PR check only built `linux/amd64` with `load: true` plus a trivial `echo` test, so an arm-only build break could merge without CI catching it. That gap is exactly how the issue behind #306 surfaced on update rather than on PR. Matching the PR matrix to the push matrix closes that.