### PR TITLE
Align EPL assumed presence timeout range

### DIFF
--- a/everything-presence-mmwave-configurator/config/device-profiles/everything_presence_lite.json
+++ b/everything-presence-mmwave-configurator/config/device-profiles/everything_presence_lite.json
@@ -150,7 +150,7 @@
       "label": "Assume Present Timeout",
       "controlType": "number",
       "min": 0,
-      "max": 600,
+      "max": 43200,
       "step": 1,
       "unit": "s",
       "required": false


### PR DESCRIPTION
Aligns the EPL device profile range with the current firmware timeout change from EverythingSmartHome/everything-presence-lite#438.