### PR TITLE
Use migration metadata for auto-prepare

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/domain/firmwareService.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/firmwareService.ts
@@ -765,7 +765,7 @@ export class FirmwareService {
   /**
    * Check if a version satisfies a simple comparator range (e.g., "<1.5.0", ">=1.2.0").
    */
-  private matchesVersionRange(version: string, range: string): boolean {
+  matchesVersionRange(version: string, range: string): boolean {
     if (!version || !range) return false;
     const trimmed = range.trim();
     const match = trimmed.match(/^(<=|>=|<|>|=)?\s*v?(\d+(?:\.\d+){0,2})/);

--- a/everything-presence-mmwave-configurator/backend/src/routes/firmware.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/firmware.ts
@@ -656,6 +656,12 @@ export const createFirmwareRouter = (deps: FirmwareRouterDependencies): Router =
         });
       }
 
+      const migration = productIndex.migrations.find((m) => {
+        if (m.id !== 'rectangular-to-polygon-zones') return false;
+        return firmwareService.matchesVersionRange(currentVersion, m.fromVersion) &&
+          firmwareService.matchesVersionRange(productIndex.product.latestVersion, m.toVersion);
+      });
+
       // Prepare the firmware
       const prepared = await firmwareService.prepareFirmwareForDevice(deviceId, fullManifestUrl);
 
@@ -666,6 +672,7 @@ export const createFirmwareRouter = (deps: FirmwareRouterDependencies): Router =
         validation,
         prepared,
         newVersion: productIndex.product.latestVersion,
+        migration,
       });
     } catch (error) {
       logger.error({ error }, 'Failed to auto-prepare firmware');

--- a/everything-presence-mmwave-configurator/frontend/src/api/types.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/api/types.ts
@@ -749,4 +749,5 @@ export interface AutoPrepareResponse {
   validation: FirmwareValidation;
   prepared: PreparedFirmwareResponse;
   newVersion: string;
+  migration?: FirmwareMigration;
 }

--- a/everything-presence-mmwave-configurator/frontend/src/components/FirmwareUpdateSection.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/FirmwareUpdateSection.tsx
@@ -155,6 +155,7 @@ export const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({
   const [updateStatus, setUpdateStatus] = useState<FirmwareUpdateStatus>('idle');
   const [preparedToken, setPreparedToken] = useState<string | null>(null);
   const [preparedVersion, setPreparedVersion] = useState<string | null>(null);
+  const [preparedMigrationMeta, setPreparedMigrationMeta] = useState<AvailableUpdate['migration'] | null>(null);
   const [updateEntityStatus, setUpdateEntityStatus] = useState<FirmwareUpdateEntityStatus | null>(null);
   const [updateProgress, setUpdateProgress] = useState<number | null>(null);
   const [updateMonitorMessage, setUpdateMonitorMessage] = useState<string | null>(null);
@@ -354,6 +355,7 @@ export const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({
     setUpdateStatus('idle');
     setPreparedToken(null);
     setPreparedVersion(null);
+    setPreparedMigrationMeta(null);
     setUpdateEntityStatus(null);
     setUpdateProgress(null);
     setUpdateMonitorMessage(null);
@@ -602,6 +604,7 @@ export const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({
       setUpdateStatus('preparing');
       setPreparedToken(null);
       setPreparedVersion(null);
+      setPreparedMigrationMeta(null);
 
       setUpdateStatus('downloading');
       const prepareRes = await prepareFirmware(selectedDeviceId, manifestUrl, {
@@ -725,6 +728,7 @@ export const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({
       setUpdateStatus('preparing');
       setPreparedToken(null);
       setPreparedVersion(null);
+      setPreparedMigrationMeta(null);
       setValidation(null);
 
       setUpdateStatus('downloading');
@@ -736,6 +740,7 @@ export const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({
 
       setPreparedToken(res.prepared.token);
       setPreparedVersion(res.newVersion);
+      setPreparedMigrationMeta(res.migration ?? null);
       setValidation(res.validation);
       setUpdateStatus('ready');
 
@@ -746,7 +751,7 @@ export const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({
         resolved.firmwareVersion,
         res.newVersion,
         resolved.model,
-        null
+        res.migration ?? null
       );
       if (migrationInfo?.required) {
         promptMigration();
@@ -829,6 +834,7 @@ export const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({
     if (migrationGate?.required) {
       setPreparedToken(entry.token);
       setPreparedVersion(entry.version);
+      setPreparedMigrationMeta(null);
       setUpdateStatus('ready');
       setUpdateModalOpen(true);
       promptMigration();
@@ -838,6 +844,7 @@ export const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({
     try {
       setPreparedToken(entry.token);
       setPreparedVersion(entry.version);
+      setPreparedMigrationMeta(null);
       setUpdateModalOpen(true);
       await triggerUpdateOnDevice(entry.token);
     } catch (err) {
@@ -1246,7 +1253,7 @@ export const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({
         currentFirmwareVersion,
         preparedVersion,
         deviceConfig?.model ?? selectedDevice?.model ?? undefined,
-        selectedUpdate?.migration ?? null
+        preparedMigrationMeta
       )
     : null;
   const restoreBackupId = migrationBackupId ?? lastBackupId ?? latestBackup?.id ?? null;


### PR DESCRIPTION
Use firmware migration metadata in the auto-prepare update path so polygon migration prompting follows the firmware index instead of relying on the frontend fallback threshold.
