### PR TITLE
Back up polygon zones

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/routes/zoneBackups.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/zoneBackups.ts
@@ -9,7 +9,7 @@ import { zoneBackupStorage } from '../config/zoneBackupStorage';
 import { deviceMappingStorage } from '../config/deviceMappingStorage';
 import { deviceEntityService } from '../domain/deviceEntityService';
 import { rectToPolygon, isValidPolygon } from '../domain/polygonUtils';
-import type { ZoneRect, ZonePolygon, EntityMappings } from '../domain/types';
+import type { Zone, ZoneRect, ZonePolygon, EntityMappings } from '../domain/types';
 import type { ZoneBackup } from '../types/zoneBackup';
 import { logger } from '../logger';
 
@@ -49,8 +49,17 @@ const parseZoneIndex = (id: string): number => {
 const sortZonesByIndex = (zones: ZoneRect[]): ZoneRect[] =>
   [...zones].sort((a, b) => parseZoneIndex(a.id) - parseZoneIndex(b.id));
 
+const sortPolygonZonesByIndex = (zones: ZonePolygon[]): ZonePolygon[] =>
+  [...zones].sort((a, b) => parseZoneIndex(a.id) - parseZoneIndex(b.id));
+
 const isValidRect = (zone: ZoneRect): boolean =>
   Number.isFinite(zone.width) && Number.isFinite(zone.height) && zone.width > 0 && zone.height > 0;
+
+const isZoneRect = (zone: Zone): zone is ZoneRect =>
+  typeof zone === 'object' && zone !== null && 'width' in zone && 'height' in zone;
+
+const isZonePolygon = (zone: Zone): zone is ZonePolygon =>
+  typeof zone === 'object' && zone !== null && 'vertices' in zone;
 
 export const createZoneBackupsRouter = (deps: ZoneBackupsRouterDependencies): Router => {
   const router = Router();
@@ -97,7 +106,7 @@ export const createZoneBackupsRouter = (deps: ZoneBackupsRouterDependencies): Ro
 
   /**
    * POST /api/zone-backups
-   * Create a backup from device rectangular zones.
+   * Create a backup from device zones.
    * Body: { deviceId, profileId, entityNamePrefix?, entityMappings? }
    */
   router.post('/', async (req, res) => {
@@ -127,7 +136,10 @@ export const createZoneBackupsRouter = (deps: ZoneBackupsRouterDependencies): Ro
     }
 
     try {
-      const zones = await zoneReader.readZones(profile.entityMap as any, prefix, entityMappings, deviceId);
+      const polygonZones = await zoneReader.readPolygonZones(profile.entityMap as any, prefix, entityMappings, deviceId);
+      const zones = polygonZones.length > 0
+        ? polygonZones
+        : await zoneReader.readZones(profile.entityMap as any, prefix, entityMappings, deviceId);
       const mapping = deviceMappingStorage.getMapping(deviceId);
       const backup: ZoneBackup = {
         id: generateId(),
@@ -142,6 +154,7 @@ export const createZoneBackupsRouter = (deps: ZoneBackupsRouterDependencies): Ro
         zoneLabels: mapping?.zoneLabels ?? undefined,
         metadata: {
           entityNamePrefix: prefix,
+          notes: polygonZones.length > 0 ? 'polygon' : 'rectangular',
         },
       };
 
@@ -169,7 +182,7 @@ export const createZoneBackupsRouter = (deps: ZoneBackupsRouterDependencies): Ro
       }
       const deviceId = typeof entry.deviceId === 'string' ? entry.deviceId : undefined;
       const profileId = typeof entry.profileId === 'string' ? entry.profileId : undefined;
-      const zones = Array.isArray(entry.zones) ? (entry.zones as ZoneRect[]) : undefined;
+      const zones = Array.isArray(entry.zones) ? (entry.zones as Zone[]) : undefined;
       if (!deviceId || !profileId || !zones) {
         continue;
       }
@@ -200,7 +213,7 @@ export const createZoneBackupsRouter = (deps: ZoneBackupsRouterDependencies): Ro
 
   /**
    * POST /api/zone-backups/:backupId/restore
-   * Restore a backup by converting rectangular zones to polygons.
+   * Restore a backup by applying polygon zones directly or converting rectangular zones.
    * Body: { deviceId?, profileId?, entityNamePrefix?, entityMappings? }
    */
   router.post('/:backupId/restore', async (req, res) => {
@@ -245,14 +258,24 @@ export const createZoneBackupsRouter = (deps: ZoneBackupsRouterDependencies): Ro
     const maxExclusion = limits.maxExclusionZones ?? 2;
     const maxEntry = limits.maxEntryZones ?? 2;
 
-    const regularZones = sortZonesByIndex(
-      backup.zones.filter((zone) => zone.type === 'regular' && isValidRect(zone))
+    const regularPolygonZones = sortPolygonZonesByIndex(
+      backup.zones.filter((zone): zone is ZonePolygon => zone.type === 'regular' && isZonePolygon(zone) && isValidPolygon(zone.vertices))
     ).slice(0, maxZones);
-    const exclusionZones = sortZonesByIndex(
-      backup.zones.filter((zone) => zone.type === 'exclusion' && isValidRect(zone))
+    const exclusionPolygonZones = sortPolygonZonesByIndex(
+      backup.zones.filter((zone): zone is ZonePolygon => zone.type === 'exclusion' && isZonePolygon(zone) && isValidPolygon(zone.vertices))
     ).slice(0, maxExclusion);
-    const entryZones = sortZonesByIndex(
-      backup.zones.filter((zone) => zone.type === 'entry' && isValidRect(zone))
+    const entryPolygonZones = sortPolygonZonesByIndex(
+      backup.zones.filter((zone): zone is ZonePolygon => zone.type === 'entry' && isZonePolygon(zone) && isValidPolygon(zone.vertices))
+    ).slice(0, maxEntry);
+
+    const regularRectZones = sortZonesByIndex(
+      backup.zones.filter((zone): zone is ZoneRect => zone.type === 'regular' && isZoneRect(zone) && isValidRect(zone))
+    ).slice(0, maxZones);
+    const exclusionRectZones = sortZonesByIndex(
+      backup.zones.filter((zone): zone is ZoneRect => zone.type === 'exclusion' && isZoneRect(zone) && isValidRect(zone))
+    ).slice(0, maxExclusion);
+    const entryRectZones = sortZonesByIndex(
+      backup.zones.filter((zone): zone is ZoneRect => zone.type === 'entry' && isZoneRect(zone) && isValidRect(zone))
     ).slice(0, maxEntry);
 
     // Restore writes zones sequentially into slot 1..N regardless of original slot index.
@@ -263,18 +286,33 @@ export const createZoneBackupsRouter = (deps: ZoneBackupsRouterDependencies): Ro
     const entryIdMap = new Map<string, string>();
 
     const polygons: ZonePolygon[] = [
-      ...regularZones.map((zone, idx) => {
+      ...regularPolygonZones.map((zone, idx) => {
         const newId = `Zone ${idx + 1}`;
+        regularIdMap.set(zone.id, newId);
+        return { ...zone, id: newId };
+      }),
+      ...exclusionPolygonZones.map((zone, idx) => {
+        const newId = `Exclusion ${idx + 1}`;
+        exclusionIdMap.set(zone.id, newId);
+        return { ...zone, id: newId };
+      }),
+      ...entryPolygonZones.map((zone, idx) => {
+        const newId = `Entry ${idx + 1}`;
+        entryIdMap.set(zone.id, newId);
+        return { ...zone, id: newId };
+      }),
+      ...regularRectZones.map((zone, idx) => {
+        const newId = `Zone ${regularPolygonZones.length + idx + 1}`;
         regularIdMap.set(zone.id, newId);
         return { ...rectToPolygon(zone), id: newId };
       }),
-      ...exclusionZones.map((zone, idx) => {
-        const newId = `Exclusion ${idx + 1}`;
+      ...exclusionRectZones.map((zone, idx) => {
+        const newId = `Exclusion ${exclusionPolygonZones.length + idx + 1}`;
         exclusionIdMap.set(zone.id, newId);
         return { ...rectToPolygon(zone), id: newId };
       }),
-      ...entryZones.map((zone, idx) => {
-        const newId = `Entry ${idx + 1}`;
+      ...entryRectZones.map((zone, idx) => {
+        const newId = `Entry ${entryPolygonZones.length + idx + 1}`;
         entryIdMap.set(zone.id, newId);
         return { ...rectToPolygon(zone), id: newId };
       }),
@@ -315,9 +353,9 @@ export const createZoneBackupsRouter = (deps: ZoneBackupsRouterDependencies): Ro
         warnings,
         backupId,
         applied: {
-          regular: regularZones.length,
-          exclusion: exclusionZones.length,
-          entry: entryZones.length,
+          regular: regularPolygonZones.length + regularRectZones.length,
+          exclusion: exclusionPolygonZones.length + exclusionRectZones.length,
+          entry: entryPolygonZones.length + entryRectZones.length,
         },
       });
     } catch (error) {

--- a/everything-presence-mmwave-configurator/backend/src/types/zoneBackup.ts
+++ b/everything-presence-mmwave-configurator/backend/src/types/zoneBackup.ts
@@ -1,4 +1,4 @@
-import type { ZoneRect } from '../domain/types';
+import type { Zone } from '../domain/types';
 
 export type ZoneBackupSource = 'device' | 'import';
 
@@ -11,7 +11,7 @@ export interface ZoneBackup {
   deviceName?: string;
   profileId: string;
   firmwareVersion?: string;
-  zones: ZoneRect[];
+  zones: Zone[];
   zoneLabels?: Record<string, string>;
   metadata?: {
     model?: string;

--- a/everything-presence-mmwave-configurator/frontend/src/api/types.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/api/types.ts
@@ -131,7 +131,7 @@ export interface ZoneBackup {
   deviceName?: string;
   profileId: string;
   firmwareVersion?: string;
-  zones: ZoneRect[];
+  zones: Zone[];
   zoneLabels?: Record<string, string>;
   metadata?: {
     model?: string;

--- a/everything-presence-mmwave-configurator/frontend/src/components/FirmwareUpdateSection.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/FirmwareUpdateSection.tsx
@@ -31,6 +31,7 @@ import {
   FirmwareUpdateEntityStatus,
   DeviceProfile,
   ZoneBackup,
+  Zone,
   ZoneRect,
   ZonePolygon,
 } from '../api/types';
@@ -1021,28 +1022,47 @@ export const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({
     return true;
   };
 
+  const isBackupRect = (zone: Zone): zone is ZoneRect =>
+    typeof zone === 'object' && zone !== null && 'width' in zone && 'height' in zone;
+
+  const isBackupPolygon = (zone: Zone): zone is ZonePolygon =>
+    typeof zone === 'object' && zone !== null && 'vertices' in zone;
+
   const buildExpectedPolygons = (backup: ZoneBackup, limits: DeviceProfile['limits'] | undefined): ZonePolygon[] => {
     const maxZones = limits?.maxZones ?? 4;
     const maxExclusion = limits?.maxExclusionZones ?? 2;
     const maxEntry = limits?.maxEntryZones ?? 2;
 
-    const regularZones = sortZonesByIndex(
-      backup.zones.filter((zone) => zone.type === 'regular' && isValidRect(zone))
+    const regularPolygonZones = sortZonesByIndex(
+      backup.zones.filter((zone): zone is ZonePolygon => zone.type === 'regular' && isBackupPolygon(zone))
     ).slice(0, maxZones);
-    const exclusionZones = sortZonesByIndex(
-      backup.zones.filter((zone) => zone.type === 'exclusion' && isValidRect(zone))
+    const exclusionPolygonZones = sortZonesByIndex(
+      backup.zones.filter((zone): zone is ZonePolygon => zone.type === 'exclusion' && isBackupPolygon(zone))
     ).slice(0, maxExclusion);
-    const entryZones = sortZonesByIndex(
-      backup.zones.filter((zone) => zone.type === 'entry' && isValidRect(zone))
+    const entryPolygonZones = sortZonesByIndex(
+      backup.zones.filter((zone): zone is ZonePolygon => zone.type === 'entry' && isBackupPolygon(zone))
+    ).slice(0, maxEntry);
+
+    const regularRectZones = sortZonesByIndex(
+      backup.zones.filter((zone): zone is ZoneRect => zone.type === 'regular' && isBackupRect(zone) && isValidRect(zone))
+    ).slice(0, maxZones);
+    const exclusionRectZones = sortZonesByIndex(
+      backup.zones.filter((zone): zone is ZoneRect => zone.type === 'exclusion' && isBackupRect(zone) && isValidRect(zone))
+    ).slice(0, maxExclusion);
+    const entryRectZones = sortZonesByIndex(
+      backup.zones.filter((zone): zone is ZoneRect => zone.type === 'entry' && isBackupRect(zone) && isValidRect(zone))
     ).slice(0, maxEntry);
 
     return [
       // IMPORTANT: restore writes zones sequentially into slot 1..N regardless of original slot index.
       // If a backup has gaps (e.g. Exclusion 2 only), it will be restored into Exclusion 1.
       // Verification must mirror that behavior to avoid false warnings.
-      ...regularZones.map((zone, idx) => ({ ...rectToPolygon(zone), id: `Zone ${idx + 1}` })),
-      ...exclusionZones.map((zone, idx) => ({ ...rectToPolygon(zone), id: `Exclusion ${idx + 1}` })),
-      ...entryZones.map((zone, idx) => ({ ...rectToPolygon(zone), id: `Entry ${idx + 1}` })),
+      ...regularPolygonZones.map((zone, idx) => ({ ...zone, id: `Zone ${idx + 1}` })),
+      ...exclusionPolygonZones.map((zone, idx) => ({ ...zone, id: `Exclusion ${idx + 1}` })),
+      ...entryPolygonZones.map((zone, idx) => ({ ...zone, id: `Entry ${idx + 1}` })),
+      ...regularRectZones.map((zone, idx) => ({ ...rectToPolygon(zone), id: `Zone ${regularPolygonZones.length + idx + 1}` })),
+      ...exclusionRectZones.map((zone, idx) => ({ ...rectToPolygon(zone), id: `Exclusion ${exclusionPolygonZones.length + idx + 1}` })),
+      ...entryRectZones.map((zone, idx) => ({ ...rectToPolygon(zone), id: `Entry ${entryPolygonZones.length + idx + 1}` })),
     ];
   };
 


### PR DESCRIPTION
## Summary
- back up polygon zones for polygon-only devices instead of saving empty rectangular backups
- keep restore and verification working for both polygon and rectangular backup formats
