### PR TITLE
Reduce broad Home Assistant entity discovery devices

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/domain/deviceDiscovery.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/deviceDiscovery.ts
@@ -1,5 +1,11 @@
 import type { IHaReadTransport } from '../ha/readTransport';
 import { logger } from '../logger';
+import {
+  deriveEntityPrefixFromRegistryEntries,
+  extractEsphomeNodeName,
+  filterEverythingPresenceDevices,
+  normalizeManufacturer,
+} from './everythingPresenceDevices';
 
 export interface DiscoveredDevice {
   id: string;
@@ -11,25 +17,8 @@ export interface DiscoveredDevice {
   areaName?: string; // Home Assistant area name (e.g., "Living Room")
 }
 
-const normalizeManufacturer = (value: unknown): string => {
-  if (typeof value === 'string') {
-    return value.trim();
-  }
-  if (Array.isArray(value)) {
-    return value.map(item => String(item ?? '')).join(', ').trim();
-  }
-  if (value == null) {
-    return '';
-  }
-  return String(value).trim();
-};
-
 export class DeviceDiscoveryService {
   private readonly readTransport: IHaReadTransport;
-  private readonly manufacturerFilters = [
-    'EverythingSmartTechnology',        // EP Lite format (no spaces)
-    'Everything Smart Technology',      // EP1 format (with spaces)
-  ];
 
   constructor(readTransport: IHaReadTransport) {
     this.readTransport = readTransport;
@@ -37,151 +26,20 @@ export class DeviceDiscoveryService {
 
   private async getEntityNamePrefixForDevice(deviceId: string): Promise<string | undefined> {
     try {
-      // Get entity registry to find entities for this device
+      const devices = await this.readTransport.listDevices();
+      const device = filterEverythingPresenceDevices(devices).find((entry) => entry.id === deviceId);
+      if (device) {
+        const esphomePrefix = extractEsphomeNodeName(device);
+        if (esphomePrefix) {
+          return esphomePrefix;
+        }
+      }
+
       const entityRegistry = await this.readTransport.listEntityRegistry();
-
-      // Filter entities belonging to this device
-      const deviceEntities = entityRegistry.filter((e) => e.device_id === deviceId);
-
-      // Prefer finding occupancy or presence sensor first, as it's most reliable
-      let deviceEntity = deviceEntities.find((e) =>
-        e.entity_id?.includes('_occupancy') || e.entity_id?.includes('_presence')
-      );
-
-      // Fallback to any binary_sensor or sensor
-      if (!deviceEntity) {
-        deviceEntity = deviceEntities.find((e) =>
-          e.entity_id?.startsWith('binary_sensor.') || e.entity_id?.startsWith('sensor.')
-        );
-      }
-
-      // Last resort: use first entity
-      if (!deviceEntity) {
-        deviceEntity = deviceEntities[0];
-      }
-
-      if (deviceEntity?.entity_id) {
-        // Extract prefix from entity_id like "binary_sensor.everything_presence_lite_f1c114_occupancy"
-        // Result should be: "everything_presence_lite_f1c114"
-        const entityId = deviceEntity.entity_id as string;
-
-        // Remove domain prefix (everything before the first dot)
-        const withoutDomain = entityId.replace(/^[^.]+\./, '');
-
-        // Remove common suffixes to get the base device name
-        // This handles ESPHome entity naming patterns
-        // Note: Order matters - more specific patterns should come first
-        const prefix = withoutDomain.replace(
-          new RegExp([
-            // EPP-specific suffixes (must come first - more specific patterns)
-            '_exclusion_zone_\\d+_start_[xy]$',
-            '_exclusion_zone_\\d+_end_[xy]$',
-            '_exclusion_zone_\\d+_target_count$',
-            '_zone_\\d+_start_[xy]$',
-            '_zone_\\d+_timeout$',
-            '_zone_\\d+_presence$',
-            '_tracking_detection_range$',
-            '_tracking_presence_timeout$',
-            '_tracking_sensor_angle$',
-            '_tracking_update_rate$',
-            '_target_tracking_detail$',
-            '_target_update_rate$',
-            '_auto_clear_stuck_targets$',
-            '_stuck_target_timeout$',
-            '_tracking_presence$',
-            '_mmwave_presence$',
-            '_tracking_sensor_firmware$',
-            '_tracking_configuration_mode$',
-            '_ld2450_bluetooth$',
-            // EPP environmental/control suffixes
-            '_relay_output$',
-            '_relay_trigger_mode$',
-            '_led_mode$',
-            '_led_brightness$',
-            '_occupancy_timeout$',
-            '_motion_timeout$',
-            '_temperature_calibration$',
-            '_humidity_calibration$',
-            '_illuminance_calibration$',
-            // Zone-related suffixes (more specific first)
-            '_zone_\\d+_occupancy_off_delay$',
-            '_zone_\\d+_target_count$',
-            '_zone_\\d+_occupancy$',
-            '_zone_\\d+_begin_[xy]$',
-            '_zone_\\d+_end_[xy]$',
-            '_zone_\\d+_off_delay$',
-            '_entry_zone_\\d+_begin_[xy]$',
-            '_entry_zone_\\d+_end_[xy]$',
-            '_occupancy_mask_\\d+_begin_[xy]$',
-            '_occupancy_mask_\\d+_end_[xy]$',
-            '_polygon_zone_\\d+$',
-            '_polygon_exclusion_\\d+$',
-            '_polygon_entry_\\d+$',
-            // Target tracking suffixes
-            '_target_\\d+_[a-z]+$',
-            '_target_\\d+.*$',
-            '_target_count$',
-            // Settings entity suffixes (EPL)
-            '_max_distance$',
-            '_occupancy_off_delay$',
-            '_installation_angle$',
-            '_upside_down_mounting$',
-            '_update_speed$',
-            '_tracking_behaviour$',
-            '_entry_exit_enabled$',
-            '_exit_threshold_pct$',
-            '_assume_present_timeout$',
-            '_stale_target_reset_timeout$',
-            '_stale_target_reset$',
-            '_polygon_zones$',
-            // Settings entity suffixes (EP1)
-            '_mmwave_mode$',
-            '_mmwave_minimum_distance$',
-            '_mmwave_max_distance$',
-            '_mmwave_trigger_distance$',
-            '_mmwave_sustain_sensitivity$',
-            '_mmwave_trigger_sensitivity$',
-            '_mmwave_threshold_factor$',
-            '_mmwave_on_latency$',
-            '_mmwave_off_latency$',
-            '_occupancy_off_latency$',
-            '_pir_off_latency$',
-            '_pir_on_latency$',
-            '_temperature_offset$',
-            '_humidity_offset$',
-            '_illuminance_offset$',
-            '_micro_motion_detection$',
-            '_mmwave_led$',
-            '_distance_speed_update_rate$',
-            // General sensor/entity suffixes
-            '_occupancy$',
-            '_presence$',
-            '_mmwave.*$',
-            '_pir.*$',
-            '_light.*$',
-            '_illuminance.*$',
-            '_temperature.*$',
-            '_humidity.*$',
-            '_co2$',
-            '_firmware.*$',
-            '_esp32_status_led$',
-            '_esp32_led$',
-            '_status_led$',
-            '_led$',
-            '_wifi_signal$',
-            '_uptime$',
-            '_restart$',
-            '_safe_mode$',
-            '_ip_address$',
-            '_connected_ssid$',
-            '_mac_address$',
-            '_dns_address$',
-            '_bluetooth_proxy.*$',
-          ].join('|')),
-          ''
-        );
-
-        return prefix;
+      const deviceEntities = entityRegistry.filter((entry) => entry.device_id === deviceId);
+      const registryPrefix = deriveEntityPrefixFromRegistryEntries(deviceEntities);
+      if (registryPrefix) {
+        return registryPrefix;
       }
     } catch (error) {
       logger.warn({ error: (error as Error).message, deviceId }, 'Failed to get entity prefix for device');
@@ -212,7 +70,8 @@ export class DeviceDiscoveryService {
       }
     }
 
-    const filteredDevices = devices
+    const filteredDevices = filterEverythingPresenceDevices(
+      devices
       .map((d: any) => ({
         id: d.id as string,
         name: (d.name_by_user as string) || (d.name as string) || 'Unnamed device',
@@ -221,10 +80,7 @@ export class DeviceDiscoveryService {
         firmwareVersion: d.sw_version as string | undefined,
         areaId: d.area_id as string | undefined,
       }))
-      .filter((d) => {
-        const manufacturer = normalizeManufacturer(d.manufacturer).toLowerCase();
-        return this.manufacturerFilters.some(filter => manufacturer === filter.toLowerCase());
-      });
+    );
 
     // Enrich with entity name prefix and area name
     const enrichedDevices = await Promise.all(

--- a/everything-presence-mmwave-configurator/backend/src/domain/entityDiscovery.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/entityDiscovery.ts
@@ -1,12 +1,18 @@
 import type { IHaReadTransport } from '../ha/readTransport';
 import type { EntityRegistryEntry } from '../ha/types';
 import type { DeviceRegistryEntry } from '../ha/readTransport';
-import type { DeviceProfileLoader } from './deviceProfiles';
+import type { DeviceProfile, DeviceProfileLoader } from './deviceProfiles';
 import type { EntityMappings, ZoneEntitySet, TargetEntitySet } from './types';
 import { deviceMappingStorage, DeviceMapping, parseFirmwareVersion } from '../config/deviceMappingStorage';
 import { logger } from '../logger';
 import { telemetry } from '../logger/telemetry';
 import { normalizeMappingKeys } from './mappingUtils';
+import {
+  deriveEntityPrefixFromRegistryEntries,
+  extractEsphomeNodeName,
+  filterEverythingPresenceDevices,
+  isEverythingPresenceManufacturer,
+} from './everythingPresenceDevices';
 
 /**
  * Entity definition from profile.entities with template for discovery.
@@ -79,9 +85,40 @@ export class EntityDiscoveryService {
   /**
    * Get all entities belonging to a specific device.
    */
-  async getDeviceEntities(deviceId: string): Promise<EntityRegistryEntry[]> {
-    const entityRegistry = await this.readTransport.listEntityRegistry();
-    return entityRegistry.filter((e) => e.device_id === deviceId);
+  async getDeviceEntities(deviceId: string, profileId?: string): Promise<EntityRegistryEntry[]> {
+    const device = await this.getEverythingPresenceDevice(deviceId);
+    if (!device) {
+      logger.warn({ deviceId }, 'Refusing entity discovery for non-Everything Presence device');
+      return [];
+    }
+
+    const profiles = this.getCandidateProfiles(profileId);
+    const prefixes = await this.getCandidateNamePrefixes(device);
+    const candidateEntityIds = this.buildCandidateEntityIds(prefixes, profiles);
+
+    if (candidateEntityIds.size === 0) {
+      logger.warn({ deviceId, profileId }, 'No candidate entity IDs generated for device discovery');
+      return [];
+    }
+
+    const allStates = await this.readTransport.getAllStates();
+    const matchedEntities = allStates
+      .filter((state) => candidateEntityIds.has(state.entity_id))
+      .map((state) => ({
+        entity_id: state.entity_id,
+        name: typeof state.attributes.friendly_name === 'string' ? state.attributes.friendly_name : null,
+        platform: '',
+        device_id: deviceId,
+        disabled_by: null,
+        hidden_by: null,
+      }));
+
+    logger.info(
+      { deviceId, candidateCount: candidateEntityIds.size, matchedCount: matchedEntities.length },
+      'Resolved targeted Everything Presence entity candidates'
+    );
+
+    return matchedEntities;
   }
 
   /**
@@ -97,7 +134,7 @@ export class EntityDiscoveryService {
     }
 
     // Get all entities for this device
-    const deviceEntities = await this.getDeviceEntities(deviceId);
+    const deviceEntities = await this.getDeviceEntities(deviceId, profileId);
     logger.info({ deviceId, entityCount: deviceEntities.length }, 'Found device entities');
 
     // Attempt ESPHome service discovery in parallel with entity discovery.
@@ -266,6 +303,95 @@ export class EntityDiscoveryService {
     }
 
     return byDomain;
+  }
+
+  private async getEverythingPresenceDevice(deviceId: string): Promise<DeviceRegistryEntry | null> {
+    const devices = await this.readTransport.listDevices();
+    return filterEverythingPresenceDevices(devices).find((device) => device.id === deviceId) ?? null;
+  }
+
+  private getCandidateProfiles(profileId?: string): DeviceProfile[] {
+    if (profileId) {
+      const profile = this.profileLoader.getProfileById(profileId);
+      return profile ? [profile] : [];
+    }
+
+    return this.profileLoader
+      .listProfiles()
+      .filter((profile) => isEverythingPresenceManufacturer(profile.manufacturer));
+  }
+
+  private async getCandidateNamePrefixes(device: DeviceRegistryEntry): Promise<string[]> {
+    const prefixes = new Set<string>();
+    const esphomeNodeName = extractEsphomeNodeName(device);
+    if (esphomeNodeName) {
+      prefixes.add(esphomeNodeName);
+    }
+
+    if (prefixes.size === 0) {
+      try {
+        const entityRegistry = await this.readTransport.listEntityRegistry();
+        const deviceEntities = entityRegistry.filter((entry) => entry.device_id === device.id);
+        const registryPrefix = deriveEntityPrefixFromRegistryEntries(deviceEntities);
+        if (registryPrefix) {
+          prefixes.add(registryPrefix);
+        }
+      } catch (err) {
+        logger.warn({ err, deviceId: device.id }, 'Failed to derive entity prefix from registry fallback');
+      }
+    }
+
+    return Array.from(prefixes);
+  }
+
+  private buildCandidateEntityIds(prefixes: string[], profiles: DeviceProfile[]): Set<string> {
+    const candidateEntityIds = new Set<string>();
+
+    for (const prefix of prefixes) {
+      for (const profile of profiles) {
+        const profileEntities = profile.entities as Record<string, EntityDefinitionWithTemplate> | undefined;
+        if (profileEntities) {
+          for (const definition of Object.values(profileEntities)) {
+            if (typeof definition.template === 'string') {
+              candidateEntityIds.add(definition.template.replace('${name}', prefix));
+            }
+          }
+        }
+
+        const entityMap = profile.entityMap as Record<string, unknown> | undefined;
+        if (entityMap) {
+          this.collectTemplatesFromLegacyMap(entityMap, candidateEntityIds, prefix);
+        }
+      }
+    }
+
+    return candidateEntityIds;
+  }
+
+  private collectTemplatesFromLegacyMap(
+    value: unknown,
+    candidateEntityIds: Set<string>,
+    prefix: string
+  ): void {
+    if (typeof value === 'string') {
+      if (value.includes('${name}')) {
+        candidateEntityIds.add(value.replace('${name}', prefix));
+      }
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        this.collectTemplatesFromLegacyMap(item, candidateEntityIds, prefix);
+      }
+      return;
+    }
+
+    if (value && typeof value === 'object') {
+      for (const nested of Object.values(value as Record<string, unknown>)) {
+        this.collectTemplatesFromLegacyMap(nested, candidateEntityIds, prefix);
+      }
+    }
   }
 
   /**
@@ -1139,21 +1265,7 @@ export class EntityDiscoveryService {
   }
 
   private extractEsphomeNodeName(device: DeviceRegistryEntry): string | undefined {
-    for (const [domain, identifier] of device.identifiers ?? []) {
-      if (typeof domain === 'string' && typeof identifier === 'string' && domain.toLowerCase() === 'esphome') {
-        return identifier;
-      }
-    }
-    return this.slugifyDeviceName(device.name);
-  }
-
-  private slugifyDeviceName(name: string | null | undefined): string | undefined {
-    if (!name) return undefined;
-    const slug = name
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '_')
-      .replace(/^_+|_+$/g, '');
-    return slug || undefined;
+    return extractEsphomeNodeName(device);
   }
 
   /**

--- a/everything-presence-mmwave-configurator/backend/src/domain/everythingPresenceDevices.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/everythingPresenceDevices.ts
@@ -1,0 +1,178 @@
+import type { DeviceRegistryEntry } from '../ha/readTransport';
+import type { EntityRegistryEntry } from '../ha/types';
+
+const MANUFACTURER_FILTERS = [
+  'EverythingSmartTechnology',
+  'Everything Smart Technology',
+];
+
+export const normalizeManufacturer = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item ?? '')).join(', ').trim();
+  }
+  if (value == null) {
+    return '';
+  }
+  return String(value).trim();
+};
+
+export const isEverythingPresenceManufacturer = (manufacturer: unknown): boolean => {
+  const normalized = normalizeManufacturer(manufacturer).toLowerCase();
+  return MANUFACTURER_FILTERS.some((filter) => normalized === filter.toLowerCase());
+};
+
+export const filterEverythingPresenceDevices = <T extends { manufacturer?: unknown }>(devices: T[]): T[] =>
+  devices.filter((device) => isEverythingPresenceManufacturer(device.manufacturer));
+
+export const slugifyDeviceName = (name: string | null | undefined): string | undefined => {
+  if (!name) return undefined;
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return slug || undefined;
+};
+
+export const extractEsphomeNodeName = (device: DeviceRegistryEntry): string | undefined => {
+  for (const [domain, identifier] of device.identifiers ?? []) {
+    if (typeof domain === 'string' && typeof identifier === 'string' && domain.toLowerCase() === 'esphome') {
+      return identifier;
+    }
+  }
+  return undefined;
+};
+
+const ENTITY_SUFFIX_REGEX = new RegExp(
+  [
+    '_exclusion_zone_\\d+_start_[xy]$',
+    '_exclusion_zone_\\d+_end_[xy]$',
+    '_exclusion_zone_\\d+_target_count$',
+    '_zone_\\d+_start_[xy]$',
+    '_zone_\\d+_timeout$',
+    '_zone_\\d+_presence$',
+    '_tracking_detection_range$',
+    '_tracking_presence_timeout$',
+    '_tracking_sensor_angle$',
+    '_tracking_update_rate$',
+    '_target_tracking_detail$',
+    '_target_update_rate$',
+    '_auto_clear_stuck_targets$',
+    '_stuck_target_timeout$',
+    '_tracking_presence$',
+    '_mmwave_presence$',
+    '_tracking_sensor_firmware$',
+    '_tracking_configuration_mode$',
+    '_ld2450_bluetooth$',
+    '_relay_output$',
+    '_relay_trigger_mode$',
+    '_led_mode$',
+    '_led_brightness$',
+    '_occupancy_timeout$',
+    '_motion_timeout$',
+    '_temperature_calibration$',
+    '_humidity_calibration$',
+    '_illuminance_calibration$',
+    '_zone_\\d+_occupancy_off_delay$',
+    '_zone_\\d+_target_count$',
+    '_zone_\\d+_occupancy$',
+    '_zone_\\d+_begin_[xy]$',
+    '_zone_\\d+_end_[xy]$',
+    '_zone_\\d+_off_delay$',
+    '_entry_zone_\\d+_begin_[xy]$',
+    '_entry_zone_\\d+_end_[xy]$',
+    '_occupancy_mask_\\d+_begin_[xy]$',
+    '_occupancy_mask_\\d+_end_[xy]$',
+    '_polygon_zone_\\d+$',
+    '_polygon_exclusion_\\d+$',
+    '_polygon_entry_\\d+$',
+    '_target_\\d+_[a-z]+$',
+    '_target_\\d+.*$',
+    '_target_count$',
+    '_max_distance$',
+    '_occupancy_off_delay$',
+    '_installation_angle$',
+    '_upside_down_mounting$',
+    '_update_speed$',
+    '_tracking_behaviour$',
+    '_entry_exit_enabled$',
+    '_exit_threshold_pct$',
+    '_assume_present_timeout$',
+    '_stale_target_reset_timeout$',
+    '_stale_target_reset$',
+    '_polygon_zones$',
+    '_mmwave_mode$',
+    '_mmwave_minimum_distance$',
+    '_mmwave_max_distance$',
+    '_mmwave_trigger_distance$',
+    '_mmwave_sustain_sensitivity$',
+    '_mmwave_trigger_sensitivity$',
+    '_mmwave_threshold_factor$',
+    '_mmwave_on_latency$',
+    '_mmwave_off_latency$',
+    '_occupancy_off_latency$',
+    '_pir_off_latency$',
+    '_pir_on_latency$',
+    '_temperature_offset$',
+    '_humidity_offset$',
+    '_illuminance_offset$',
+    '_micro_motion_detection$',
+    '_mmwave_led$',
+    '_distance_speed_update_rate$',
+    '_occupancy$',
+    '_presence$',
+    '_mmwave.*$',
+    '_pir.*$',
+    '_light.*$',
+    '_illuminance.*$',
+    '_temperature.*$',
+    '_humidity.*$',
+    '_co2$',
+    '_firmware.*$',
+    '_esp32_status_led$',
+    '_esp32_led$',
+    '_status_led$',
+    '_led$',
+    '_wifi_signal$',
+    '_uptime$',
+    '_restart$',
+    '_safe_mode$',
+    '_ip_address$',
+    '_connected_ssid$',
+    '_mac_address$',
+    '_dns_address$',
+    '_bluetooth_proxy.*$',
+  ].join('|')
+);
+
+export const extractEntityPrefixFromEntityId = (entityId: string): string | undefined => {
+  const withoutDomain = entityId.replace(/^[^.]+\./, '');
+  const prefix = withoutDomain.replace(ENTITY_SUFFIX_REGEX, '');
+  return prefix || undefined;
+};
+
+export const deriveEntityPrefixFromRegistryEntries = (
+  deviceEntities: EntityRegistryEntry[]
+): string | undefined => {
+  let deviceEntity = deviceEntities.find(
+    (entry) => entry.entity_id?.includes('_occupancy') || entry.entity_id?.includes('_presence')
+  );
+
+  if (!deviceEntity) {
+    deviceEntity = deviceEntities.find(
+      (entry) => entry.entity_id?.startsWith('binary_sensor.') || entry.entity_id?.startsWith('sensor.')
+    );
+  }
+
+  if (!deviceEntity) {
+    deviceEntity = deviceEntities[0];
+  }
+
+  if (!deviceEntity?.entity_id) {
+    return undefined;
+  }
+
+  return extractEntityPrefixFromEntityId(deviceEntity.entity_id);
+};

--- a/everything-presence-mmwave-configurator/backend/src/ha/restReadTransport.ts
+++ b/everything-presence-mmwave-configurator/backend/src/ha/restReadTransport.ts
@@ -27,6 +27,7 @@ interface Subscription {
  */
 export class RestReadTransport implements IHaReadTransport {
   readonly activeTransport = 'rest' as const;
+  private static readonly TEMPLATE_ENTITY_BATCH_SIZE = 200;
 
   private readonly config: ReadTransportConfig;
   private readonly baseUrl: string;
@@ -63,6 +64,36 @@ export class RestReadTransport implements IHaReadTransport {
   private buildUrl(path: string): string {
     const normalized = path.startsWith('/') ? path : `/${path}`;
     return `${this.baseUrl}${normalized}`;
+  }
+
+  private async renderTemplate(template: string): Promise<string | null> {
+    try {
+      const url = this.buildUrl('/template');
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: this.headers,
+        body: JSON.stringify({ template }),
+      });
+
+      if (!res.ok) {
+        const text = await res.text();
+        logger.warn({ status: res.status, text }, 'RestReadTransport: Template API request failed');
+        return null;
+      }
+
+      return await res.text();
+    } catch (err) {
+      logger.error({ err }, 'RestReadTransport: Template API request failed');
+      return null;
+    }
+  }
+
+  private chunkArray<T>(items: T[], size: number): T[][] {
+    const chunks: T[][] = [];
+    for (let index = 0; index < items.length; index += size) {
+      chunks.push(items.slice(index, index + size));
+    }
+    return chunks;
   }
 
   // ─────────────────────────────────────────────────────────────────
@@ -159,20 +190,10 @@ export class RestReadTransport implements IHaReadTransport {
 {{ devices.list | tojson }}`.trim();
 
     try {
-      const url = this.buildUrl('/template');
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: this.headers,
-        body: JSON.stringify({ template }),
-      });
-
-      if (!res.ok) {
-        const text = await res.text();
-        logger.warn({ status: res.status, text }, 'RestReadTransport: Template API failed');
+      const resultText = await this.renderTemplate(template);
+      if (!resultText) {
         return [];
       }
-
-      const resultText = await res.text();
       const devices = JSON.parse(resultText) as DeviceRegistryEntry[];
       logger.info({ count: devices.length }, 'RestReadTransport: Discovered devices via template');
       return devices;
@@ -206,39 +227,56 @@ export class RestReadTransport implements IHaReadTransport {
    * It focuses on the fields needed for zone availability checking.
    */
   private async listEntityRegistryViaTemplate(): Promise<EntityRegistryEntry[]> {
-    // Jinja2 template that collects entity info from states
-    // Note: disabled_by isn't directly available via template, but we can infer
-    // unavailable entities from state
-    const template = `
-{% set entities = namespace(list=[]) %}
-{% for state in states %}
-  {% set entities.list = entities.list + [{
-    'entity_id': state.entity_id,
-    'disabled_by': none,
-    'hidden_by': none,
-    'platform': state.attributes.get('platform', ''),
-    'device_id': device_id(state.entity_id)
-  }] %}
-{% endfor %}
-{{ entities.list | tojson }}`.trim();
-
     try {
-      const url = this.buildUrl('/template');
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: this.headers,
-        body: JSON.stringify({ template }),
-      });
-
-      if (!res.ok) {
-        const text = await res.text();
-        logger.warn({ status: res.status, text }, 'RestReadTransport: Template API failed for entity registry');
+      const states = await this.getAllStates();
+      if (states.length === 0) {
         return [];
       }
 
-      const resultText = await res.text();
-      const entities = JSON.parse(resultText) as EntityRegistryEntry[];
-      logger.info({ count: entities.length }, 'RestReadTransport: Got entity registry via template');
+      const entityIds = states.map((state) => state.entity_id);
+      const stateMap = new Map(states.map((state) => [state.entity_id, state]));
+      const chunks = this.chunkArray(entityIds, RestReadTransport.TEMPLATE_ENTITY_BATCH_SIZE);
+      const entities: EntityRegistryEntry[] = [];
+
+      for (const chunk of chunks) {
+        const quotedEntityIds = JSON.stringify(chunk);
+        const template = `
+{% set ns = namespace(list=[]) %}
+{% set entity_ids = ${quotedEntityIds} %}
+{% for entity_id in entity_ids %}
+  {% set ns.list = ns.list + [{
+    'entity_id': entity_id,
+    'disabled_by': none,
+    'hidden_by': none,
+    'platform': '',
+    'device_id': device_id(entity_id)
+  }] %}
+{% endfor %}
+{{ ns.list | tojson }}`.trim();
+
+        const resultText = await this.renderTemplate(template);
+        if (!resultText) {
+          logger.warn(
+            { chunkSize: chunk.length },
+            'RestReadTransport: Skipping entity registry template chunk after API failure'
+          );
+          continue;
+        }
+
+        const chunkEntities = JSON.parse(resultText) as EntityRegistryEntry[];
+        for (const entity of chunkEntities) {
+          const state = stateMap.get(entity.entity_id);
+          entities.push({
+            ...entity,
+            platform: state?.attributes?.platform ? String(state.attributes.platform) : '',
+          });
+        }
+      }
+
+      logger.info(
+        { count: entities.length, chunkCount: chunks.length },
+        'RestReadTransport: Got entity registry via chunked template fallback'
+      );
       return entities;
     } catch (err) {
       logger.error({ err }, 'RestReadTransport: Template-based entity registry failed');
@@ -294,20 +332,10 @@ export class RestReadTransport implements IHaReadTransport {
 {{ areas.list | tojson }}`.trim();
 
     try {
-      const url = this.buildUrl('/template');
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: this.headers,
-        body: JSON.stringify({ template }),
-      });
-
-      if (!res.ok) {
-        const text = await res.text();
-        logger.warn({ status: res.status, text }, 'RestReadTransport: Template API failed for area registry');
+      const resultText = await this.renderTemplate(template);
+      if (!resultText) {
         return [];
       }
-
-      const resultText = await res.text();
       const areas = JSON.parse(resultText) as AreaRegistryEntry[];
       logger.info({ count: areas.length }, 'RestReadTransport: Got area registry via template');
       return areas;


### PR DESCRIPTION
This changes the Zone Configurator discovery flow so it no longer depends on fetching the full Home Assistant entity registry during discovery. This can cause issues on larger installs where it attempts to fetch large amounts of entities, in some cases too many entities to fit

Hopefully help with: https://github.com/EverythingSmartHome/everything-presence-addons/issues/279