### PR TITLE
fix: entity discovery matches 0 entities when device has no esphome identifier

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/domain/everythingPresenceDevices.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/everythingPresenceDevices.ts
@@ -150,15 +150,49 @@ const ENTITY_SUFFIX_REGEX = new RegExp(
 export const extractEntityPrefixFromEntityId = (entityId: string): string | undefined => {
   const withoutDomain = entityId.replace(/^[^.]+\./, '');
   const prefix = withoutDomain.replace(ENTITY_SUFFIX_REGEX, '');
-  return prefix || undefined;
+  // Only trust the result when a known suffix was actually stripped. Otherwise the
+  // entity is not a recognised one (e.g. a button like `_apply_update`) and its full
+  // object_id must not be returned as a prefix.
+  if (prefix && prefix !== withoutDomain) {
+    return prefix;
+  }
+  return undefined;
+};
+
+const deriveEntityPrefixFromCommonPrefix = (
+  deviceEntities: EntityRegistryEntry[]
+): string | undefined => {
+  const objectIds = deviceEntities
+    .map((entry) => entry.entity_id)
+    .filter((id): id is string => Boolean(id))
+    .map((id) => id.replace(/^[^.]+\./, ''));
+  if (objectIds.length === 0) {
+    return undefined;
+  }
+  let common = objectIds[0];
+  for (const id of objectIds.slice(1)) {
+    let i = 0;
+    while (i < common.length && i < id.length && common[i] === id[i]) {
+      i++;
+    }
+    common = common.slice(0, i);
+    if (!common) {
+      break;
+    }
+  }
+  const trimmed = common.replace(/_+$/, '');
+  return trimmed || undefined;
 };
 
 export const deriveEntityPrefixFromRegistryEntries = (
   deviceEntities: EntityRegistryEntry[]
 ): string | undefined => {
-  let deviceEntity = deviceEntities.find(
-    (entry) => entry.entity_id?.includes('_occupancy') || entry.entity_id?.includes('_presence')
-  );
+  // Prefer the presence/occupancy sensor, matched on an END-ANCHORED suffix.
+  // The product name "everything_presence_lite" contains the substring "_presence",
+  // so a loose includes() check spuriously matches every entity (including buttons)
+  // and derives a garbage prefix from whichever entity happens to be first.
+  const objectId = (entityId: string | undefined): string => (entityId ?? '').replace(/^[^.]+\./, '');
+  let deviceEntity = deviceEntities.find((entry) => /_(occupancy|presence)$/.test(objectId(entry.entity_id)));
 
   if (!deviceEntity) {
     deviceEntity = deviceEntities.find(
@@ -166,13 +200,14 @@ export const deriveEntityPrefixFromRegistryEntries = (
     );
   }
 
-  if (!deviceEntity) {
-    deviceEntity = deviceEntities[0];
+  if (deviceEntity?.entity_id) {
+    const prefix = extractEntityPrefixFromEntityId(deviceEntity.entity_id);
+    if (prefix) {
+      return prefix;
+    }
   }
 
-  if (!deviceEntity?.entity_id) {
-    return undefined;
-  }
-
-  return extractEntityPrefixFromEntityId(deviceEntity.entity_id);
+  // Robust fallback: the longest common object_id prefix across all device entities.
+  // Immune to unknown/new entity suffixes that ENTITY_SUFFIX_REGEX does not cover.
+  return deriveEntityPrefixFromCommonPrefix(deviceEntities);
 };


### PR DESCRIPTION
## Problem

The Zone Configurator matches **0 entities** ("Found 0 of 0") for some Everything Presence Lite devices, even after a clean reinstall. Affected devices show `candidateCount: N, matchedCount: 0` in the logs and the derived entity prefix ends up as a button object_id like `..._esp_reboot` / `..._apply_update`.

This is the same symptom as EverythingSmartHome/everything-presence-lite#429.

## Root cause

It only happens when the device's HA device-registry entry has **no `esphome` identifier** (only a MAC connection). In that case `extractEsphomeNodeName()` returns `undefined`, so `deriveEntityPrefixFromRegistryEntries()` runs as the fallback.

That fallback picks the prefix anchor with:

```ts
deviceEntities.find(e => e.entity_id?.includes('_occupancy') || e.entity_id?.includes('_presence'))
```

Because the node/product name itself contains `_presence` (`everything_presence_lite_*`), `includes('_presence')` matches **every** entity. It therefore anchors on whichever entity is first (commonly a `*_esp_reboot` / `*_apply_update` button). `extractEntityPrefixFromEntityId()` can't strip an unknown suffix from that object_id, and returned the **full object_id** as the prefix — so every generated candidate entity_id is wrong and nothing matches.

(Most devices have an `esphome` identifier, so the primary path succeeds and this fallback never runs — which is why it only affects some installs.)

## Fix

`backend/src/domain/everythingPresenceDevices.ts`:

- Match the presence/occupancy sensor on an **end-anchored** suffix (`/_(occupancy|presence)$/`) instead of a loose substring, so the product name no longer self-matches.
- `extractEntityPrefixFromEntityId()` returns `undefined` when no known suffix was actually stripped, so a button object_id can never be returned as a prefix.
- Add a **longest-common-object_id-prefix** fallback, which is robust to new/unknown entity suffixes that `ENTITY_SUFFIX_REGEX` doesn't cover.

## Verification

Reproduced against a live affected device (empty `esphome` identifier, firmware 1.5.0), then ran the patched build as a local add-on and called `/api/devices/:id/discover-entities` directly:

- Before: `matchedCount: 0`
- After: **`matchedCount: 52, unmatchedCount: 0, allMatched: true`**

`npm run build` (tsc) passes.

Fixes EverythingSmartHome/everything-presence-lite#429