### PR TITLE
Handle EPL 1.5.0 polygon migration more cleanly

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/domain/entityDiscovery.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/entityDiscovery.ts
@@ -7,6 +7,7 @@ import { deviceMappingStorage, DeviceMapping, parseFirmwareVersion } from '../co
 import { logger } from '../logger';
 import { telemetry } from '../logger/telemetry';
 import { normalizeMappingKeys } from './mappingUtils';
+import { isEplPolygonOnlyDevice } from './firmwareVersionUtils';
 import {
   deriveEntityPrefixFromRegistryEntries,
   extractEsphomeNodeName,
@@ -137,24 +138,35 @@ export class EntityDiscoveryService {
     const deviceEntities = await this.getDeviceEntities(deviceId, profileId);
     logger.info({ deviceId, entityCount: deviceEntities.length }, 'Found device entities');
 
+    // Fetch device info early so discovery can be version-aware for breaking changes.
+    let rawSwVersion: string | undefined;
+    let firmwareVersion: string | undefined;
+    let esphomeVersion: string | undefined;
+    let esphomeNodeName: string | undefined;
+    try {
+      const devices = await this.readTransport.listDevices();
+      const device = devices.find(d => d.id === deviceId);
+      if (device?.sw_version) {
+        rawSwVersion = device.sw_version;
+        const parsed = parseFirmwareVersion(device.sw_version);
+        firmwareVersion = parsed.firmwareVersion;
+        esphomeVersion = parsed.esphomeVersion;
+        logger.debug({ deviceId, rawSwVersion, firmwareVersion, esphomeVersion }, 'Parsed firmware version');
+      }
+      if (device) {
+        esphomeNodeName = this.extractEsphomeNodeName(device);
+      }
+    } catch (err) {
+      logger.warn({ err, deviceId }, 'Failed to fetch device firmware version, continuing without it');
+    }
+
     // Attempt ESPHome service discovery in parallel with entity discovery.
     // This mirrors the entity auto-match flow: try to find services now,
     // but don't persist until the user saves.
     let serviceMappings: Record<string, string> | undefined;
     try {
       const existingMapping = deviceMappingStorage.getMapping(deviceId);
-      let esphomeNodeName = existingMapping?.esphomeNodeName;
-      if (!esphomeNodeName) {
-        try {
-          const devices = await this.readTransport.listDevices();
-          const device = devices.find(d => d.id === deviceId);
-          if (device) {
-            esphomeNodeName = this.extractEsphomeNodeName(device);
-          }
-        } catch (err) {
-          logger.warn({ err, deviceId }, 'Failed to fetch device info for service discovery, continuing without it');
-        }
-      }
+      esphomeNodeName = esphomeNodeName ?? existingMapping?.esphomeNodeName;
 
       const discoveredBuildFlags = await this.discoverServiceBySuffix(
         deviceId,
@@ -204,8 +216,17 @@ export class EntityDiscoveryService {
 
     // Check for new entities metadata format
     const profileEntities = (profile as unknown as Record<string, unknown>).entities as Record<string, EntityDefinitionWithTemplate> | undefined;
-    const entityMap = (profile as unknown as Record<string, unknown>).entityMap as Record<string, unknown>;
+    const rawEntityMap = (profile as unknown as Record<string, unknown>).entityMap as Record<string, unknown>;
     const capabilities = profile.capabilities as Record<string, unknown>;
+    const polygonOnlyEpl = isEplPolygonOnlyDevice({
+      profileId,
+      firmwareVersion,
+      model: (profile as unknown as Record<string, unknown>).model as string | undefined,
+    });
+    const profileEntitiesForDiscovery = profileEntities
+      ? this.filterProfileEntitiesForFirmware(profileEntities, polygonOnlyEpl)
+      : undefined;
+    const entityMap = this.filterLegacyEntityMapForFirmware(rawEntityMap, polygonOnlyEpl);
 
     // Match all entities
     const results: EntityMatchResult[] = [];
@@ -216,10 +237,10 @@ export class EntityDiscoveryService {
     };
 
     // Use profile.entities metadata when available (preferred)
-    if (profileEntities) {
+    if (profileEntitiesForDiscovery) {
       logger.info({ deviceId, profileId }, 'Using profile.entities metadata for discovery');
       this.discoverUsingEntitiesMetadata(
-        profileEntities,
+        profileEntitiesForDiscovery,
         deviceEntities,
         entitiesByDomain,
         results,
@@ -821,6 +842,43 @@ export class EntityDiscoveryService {
     (trackingTargets[targetKey] as unknown as Record<string, string>)[property] = entityId;
   }
 
+  private filterProfileEntitiesForFirmware(
+    profileEntities: Record<string, EntityDefinitionWithTemplate>,
+    polygonOnlyEpl: boolean
+  ): Record<string, EntityDefinitionWithTemplate> {
+    if (!polygonOnlyEpl) {
+      return profileEntities;
+    }
+
+    return Object.fromEntries(
+      Object.entries(profileEntities).filter(([entityKey, def]) => {
+        if (entityKey === 'polygonZonesEnabled') {
+          return false;
+        }
+        if (def.category !== 'zone') {
+          return true;
+        }
+        return !['regular', 'exclusion', 'entry'].includes(def.zoneType ?? '');
+      })
+    );
+  }
+
+  private filterLegacyEntityMapForFirmware(
+    entityMap: Record<string, unknown>,
+    polygonOnlyEpl: boolean
+  ): Record<string, unknown> {
+    if (!polygonOnlyEpl) {
+      return entityMap;
+    }
+
+    const filtered = { ...entityMap };
+    delete filtered.polygonZonesEnabledEntity;
+    delete filtered.zoneConfigEntities;
+    delete filtered.exclusionZoneConfigEntities;
+    delete filtered.entryZoneConfigEntities;
+    return filtered;
+  }
+
   /**
    * Discover entities using legacy entityMap format.
    * This is the fallback for profiles without the new entities metadata.
@@ -960,6 +1018,11 @@ export class EntityDiscoveryService {
     deviceId?: string
   ): Promise<{ valid: boolean; errors: Array<{ key: string; entityId: string; error: string }> }> {
     const errors: Array<{ key: string; entityId: string; error: string }> = [];
+    const existingMapping = deviceId ? deviceMappingStorage.getMapping(deviceId) : null;
+    const skipLegacyRectangles = isEplPolygonOnlyDevice({
+      profileId: existingMapping?.profileId,
+      firmwareVersion: existingMapping?.firmwareVersion,
+    });
 
     let registryById: Map<string, EntityRegistryEntry> = new Map();
     try {
@@ -1006,7 +1069,7 @@ export class EntityDiscoveryService {
       'speedEntity', 'energyEntity', 'targetCountEntity', 'modeEntity',
       'maxDistanceEntity', 'installationAngleEntity', 'upsideDownMountingEntity', 'polygonZonesEnabledEntity',
       'trackingTargetCountEntity', 'firmwareUpdateEntity', 'assumedPresentEntity', 'assumedPresentRemainingEntity',
-    ];
+    ].filter((key) => !(skipLegacyRectangles && key === 'polygonZonesEnabledEntity'));
 
     for (const key of flatKeys) {
       const entityId = (mappings as Record<string, unknown>)[key];
@@ -1016,7 +1079,9 @@ export class EntityDiscoveryService {
     }
 
     // Check zone entities
-    const zoneGroups = ['zoneConfigEntities', 'exclusionZoneConfigEntities', 'entryZoneConfigEntities'];
+    const zoneGroups = skipLegacyRectangles
+      ? []
+      : ['zoneConfigEntities', 'exclusionZoneConfigEntities', 'entryZoneConfigEntities'];
     for (const groupKey of zoneGroups) {
       const group = (mappings as Record<string, unknown>)[groupKey];
       if (group && typeof group === 'object') {
@@ -1092,7 +1157,7 @@ export class EntityDiscoveryService {
     // Fetch unit_of_measurement for tracking entities (x/y coordinates)
     const entityUnits = await this.fetchEntityUnits(flatMappings);
 
-    // Fetch device info to get firmware version
+    // Fetch device info for firmware metadata and ESPHome node name.
     let rawSwVersion: string | undefined;
     let firmwareVersion: string | undefined;
     let esphomeVersion: string | undefined;
@@ -1105,7 +1170,6 @@ export class EntityDiscoveryService {
         const parsed = parseFirmwareVersion(device.sw_version);
         firmwareVersion = parsed.firmwareVersion;
         esphomeVersion = parsed.esphomeVersion;
-      logger.debug({ deviceId, rawSwVersion, firmwareVersion, esphomeVersion }, 'Parsed firmware version');
       }
       if (device) {
         esphomeNodeName = this.extractEsphomeNodeName(device);

--- a/everything-presence-mmwave-configurator/backend/src/domain/firmwareVersionUtils.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/firmwareVersionUtils.ts
@@ -1,0 +1,59 @@
+export interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+const EPL_POLYGON_ONLY_VERSION = '1.5.0';
+
+export function parseVersion(version: string | undefined | null): ParsedVersion | null {
+  if (!version) return null;
+
+  const cleaned = version.trim().replace(/^[vV](?:ersion\s*)?/, '').split('-')[0].split(' ')[0].trim();
+  const match = cleaned.match(/^(\d+)(?:\.(\d+))?(?:\.(\d+))?$/);
+  if (!match) return null;
+
+  return {
+    major: parseInt(match[1], 10),
+    minor: parseInt(match[2] ?? '0', 10),
+    patch: parseInt(match[3] ?? '0', 10),
+  };
+}
+
+export function compareVersions(
+  left: string | undefined | null,
+  right: string | undefined | null
+): number | null {
+  const a = parseVersion(left);
+  const b = parseVersion(right);
+  if (!a || !b) return null;
+
+  if (a.major !== b.major) return a.major > b.major ? 1 : -1;
+  if (a.minor !== b.minor) return a.minor > b.minor ? 1 : -1;
+  if (a.patch !== b.patch) return a.patch > b.patch ? 1 : -1;
+  return 0;
+}
+
+function normalizeModel(model?: string | null): string {
+  return model?.toLowerCase().trim() ?? '';
+}
+
+export function isEverythingPresenceLite(profileId?: string | null, model?: string | null): boolean {
+  if (profileId === 'everything_presence_lite') return true;
+  const normalized = normalizeModel(model);
+  return normalized.includes('everything presence lite') || normalized.includes('everything-presence-lite');
+}
+
+export function isEplPolygonOnlyDevice(args: {
+  profileId?: string | null;
+  firmwareVersion?: string | null;
+  model?: string | null;
+}): boolean {
+  if (!isEverythingPresenceLite(args.profileId, args.model)) {
+    return false;
+  }
+
+  const comparison = compareVersions(args.firmwareVersion, EPL_POLYGON_ONLY_VERSION);
+  return comparison !== null && comparison >= 0;
+}
+

--- a/everything-presence-mmwave-configurator/backend/src/routes/devices.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/devices.ts
@@ -8,7 +8,8 @@ import { ZoneReader } from '../ha/zoneReader';
 import { RoomConfig, ZonePolygon, EntityMappings } from '../domain/types';
 import { EntityResolver } from '../domain/entityResolver';
 import { deviceEntityService } from '../domain/deviceEntityService';
-import { deviceMappingStorage } from '../config/deviceMappingStorage';
+import { deviceMappingStorage, parseFirmwareVersion } from '../config/deviceMappingStorage';
+import { isEplPolygonOnlyDevice } from '../domain/firmwareVersionUtils';
 import { logger } from '../logger';
 
 export interface DevicesRouterDependencies {
@@ -34,6 +35,24 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
     const normalized = normalizeStateValue(state);
     // Treat "unknown" as available for readiness purposes; it's common immediately after reboot.
     return normalized === 'unavailable';
+  };
+  const getDeviceFirmwareVersion = async (deviceId: string): Promise<string | undefined> => {
+    const existingMapping = deviceMappingStorage.getMapping(deviceId);
+    if (existingMapping?.firmwareVersion) {
+      return existingMapping.firmwareVersion;
+    }
+
+    try {
+      const devices = await readTransport.listDevices();
+      const device = devices.find((candidate) => candidate.id === deviceId);
+      if (!device?.sw_version) {
+        return undefined;
+      }
+      return parseFirmwareVersion(device.sw_version).firmwareVersion;
+    } catch (error) {
+      logger.warn({ error, deviceId }, 'Failed to fetch firmware version for device route');
+      return undefined;
+    }
   };
 
   router.get('/', async (_req, res) => {
@@ -380,6 +399,12 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
 
     // Check if device has device-level mappings (preferred)
     const hasDeviceMapping = deviceMappingStorage.hasMapping(deviceId);
+    const firmwareVersion = await getDeviceFirmwareVersion(deviceId);
+    const polygonOnlyEpl = isEplPolygonOnlyDevice({
+      profileId: profile.id,
+      firmwareVersion,
+      model: (profile as unknown as { model?: string }).model,
+    });
 
     try {
       const entityRegistry = await readTransport.listEntityRegistry();
@@ -407,7 +432,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
       };
 
       // Check regular zones
-      if (zoneMap.zoneConfigEntities || hasDeviceMapping) {
+      if (!polygonOnlyEpl && (zoneMap.zoneConfigEntities || hasDeviceMapping)) {
         const zoneKeys = Object.keys(zoneMap.zoneConfigEntities || {});
         for (const zoneKey of zoneKeys) {
           const zoneEntities = (zoneMap.zoneConfigEntities?.[zoneKey] || {}) as Record<string, string>;
@@ -420,7 +445,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
       }
 
       // Check exclusion zones
-      if (zoneMap.exclusionZoneConfigEntities || hasDeviceMapping) {
+      if (!polygonOnlyEpl && (zoneMap.exclusionZoneConfigEntities || hasDeviceMapping)) {
         const zoneKeys = Object.keys(zoneMap.exclusionZoneConfigEntities || {});
         for (const zoneKey of zoneKeys) {
           const zoneEntities = (zoneMap.exclusionZoneConfigEntities?.[zoneKey] || {}) as Record<string, string>;
@@ -433,7 +458,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
       }
 
       // Check entry zones
-      if (zoneMap.entryZoneConfigEntities || hasDeviceMapping) {
+      if (!polygonOnlyEpl && (zoneMap.entryZoneConfigEntities || hasDeviceMapping)) {
         const zoneKeys = Object.keys(zoneMap.entryZoneConfigEntities || {});
         for (const zoneKey of zoneKeys) {
           const zoneEntities = (zoneMap.entryZoneConfigEntities?.[zoneKey] || {}) as Record<string, string>;
@@ -559,26 +584,46 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
         polygonZonesAvailable = !!polygonEntry;
       }
 
-      // Check entry zone 1 entity existence - try device mapping first
-      let entryZone1BeginX: string | null = null;
-      if (hasDeviceMapping) {
-        const entryZoneSet = deviceEntityService.getZoneEntitySet(deviceId, 'entry', 1);
-        entryZone1BeginX = entryZoneSet?.beginX || null;
-      }
-      if (!entryZone1BeginX && zoneMap.entryZoneConfigEntities?.entry1) {
-        const entryEntities = zoneMap.entryZoneConfigEntities.entry1 as Record<string, string>;
-        const entryZoneSet = EntityResolver.resolveZoneEntitySet(
-          entityMappings,
-          prefix,
-          'entryZoneConfigEntities',
-          'entry1',
-          entryEntities
-        );
-        entryZone1BeginX = entryZoneSet?.beginX || null;
-      }
-      if (entryZone1BeginX) {
-        const entryEntry = entityRegistry.find((e) => e.entity_id === entryZone1BeginX);
-        entryZonesAvailable = !!entryEntry;
+      if (polygonOnlyEpl) {
+        let polygonEntry1Entity: string | null = null;
+        if (hasDeviceMapping) {
+          polygonEntry1Entity = deviceEntityService.getPolygonZoneEntity(deviceId, 'polygonEntry', 1);
+        }
+        if (!polygonEntry1Entity && zoneMap.polygonEntryEntities?.entry1) {
+          polygonEntry1Entity = EntityResolver.resolvePolygonZoneEntity(
+            entityMappings,
+            prefix,
+            'polygonEntryEntities',
+            'entry1',
+            zoneMap.polygonEntryEntities.entry1
+          );
+        }
+        if (polygonEntry1Entity) {
+          const entryEntry = entityRegistry.find((e) => e.entity_id === polygonEntry1Entity);
+          entryZonesAvailable = !!entryEntry;
+        }
+      } else {
+        // Check entry zone 1 entity existence - try device mapping first
+        let entryZone1BeginX: string | null = null;
+        if (hasDeviceMapping) {
+          const entryZoneSet = deviceEntityService.getZoneEntitySet(deviceId, 'entry', 1);
+          entryZone1BeginX = entryZoneSet?.beginX || null;
+        }
+        if (!entryZone1BeginX && zoneMap.entryZoneConfigEntities?.entry1) {
+          const entryEntities = zoneMap.entryZoneConfigEntities.entry1 as Record<string, string>;
+          const entryZoneSet = EntityResolver.resolveZoneEntitySet(
+            entityMappings,
+            prefix,
+            'entryZoneConfigEntities',
+            'entry1',
+            entryEntities
+          );
+          entryZone1BeginX = entryZoneSet?.beginX || null;
+        }
+        if (entryZone1BeginX) {
+          const entryEntry = entityRegistry.find((e) => e.entity_id === entryZone1BeginX);
+          entryZonesAvailable = !!entryEntry;
+        }
       }
 
       return res.json({ availability, polygonAvailability, polygonZonesAvailable, entryZonesAvailable });

--- a/everything-presence-mmwave-configurator/frontend/src/pages/LiveTrackingPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/LiveTrackingPage.tsx
@@ -29,6 +29,7 @@ import { useIsMobileCanvas } from '../hooks/useMediaQuery';
 import { useDeviceMappings, useDeviceMapping } from '../contexts/DeviceMappingsContext';
 import { getDeviceIconUrl } from '../utils/deviceIcon';
 import { resolveCoverageFov } from '../utils/coverage';
+import { usesPolygonOnlyZones } from '../utils/firmware';
 import {
   buildCeilingExclusionZones,
   buildCeilingSliceZones,
@@ -143,6 +144,10 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
     () => profiles.find((p) => p.id === (selectedRoom?.profileId ?? selectedProfileId)) ?? null,
     [profiles, selectedRoom, selectedProfileId],
   );
+  const selectedDevice = useMemo(
+    () => (selectedRoom?.deviceId ? devices.find((d) => d.id === selectedRoom.deviceId) ?? null : null),
+    [devices, selectedRoom?.deviceId],
+  );
   const deviceTypeLabel = useMemo(() => {
     return selectedProfile?.label ?? 'Device';
   }, [selectedProfile?.label]);
@@ -248,9 +253,21 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
     [ceilingSliceConfig, heightCoverageConfig, selectedProfile?.limits?.maxRangeMeters],
   );
   const displayPolygonZones = isCeilingSliceMode ? [...ceilingSliceDisplayZones, ...ceilingExclusionDisplayZones] : polygonZones;
+  const polygonOnlyZones = useMemo(() => (
+    usesPolygonOnlyZones(
+      selectedDevice?.firmwareVersion ?? deviceMapping?.firmwareVersion ?? null,
+      selectedDevice?.model ?? selectedProfile?.label ?? null,
+    ) === true
+  ), [
+    deviceMapping?.firmwareVersion,
+    selectedDevice?.firmwareVersion,
+    selectedDevice?.model,
+    selectedProfile?.label,
+  ]);
+  const displayedRectZones = polygonOnlyZones ? [] : selectedRoom?.zones ?? [];
   const getZoneLabel = useCallback((zoneNum: number): string => {
     const candidates = [`Zone ${zoneNum}`, `zone${zoneNum}`, `zone_${zoneNum}`, `zone-${zoneNum}`];
-    const source = polygonModeStatus.enabled ? displayPolygonZones : selectedRoom?.zones ?? [];
+    const source = polygonModeStatus.enabled ? displayPolygonZones : displayedRectZones;
     const regularZones = source.filter((zone) => zone.type === 'regular');
     const matchingZone =
       source.find((zone) => candidates.includes(zone.id)) ??
@@ -273,9 +290,9 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
   }, [
     deviceMapping?.zoneLabels,
     displayPolygonZones,
+    displayedRectZones,
     isCeilingSliceMode,
     polygonModeStatus.enabled,
-    selectedRoom?.zones,
   ]);
   const zoneOccupancyNumbers = useMemo(() => {
     const configuredMax = selectedProfile?.limits?.maxZones ?? 4;
@@ -569,6 +586,10 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
       try {
         // Skip entityMappings if device has valid mappings stored
         const entityMappingsToUse = deviceHasValidMappings ? undefined : selectedRoom.entityMappings;
+        if (polygonOnlyZones) {
+          lastZonesFetchedRoomId.current = selectedRoom.id;
+          return;
+        }
         const deviceZones = await fetchZonesFromDevice(
           selectedRoom.deviceId,
           selectedRoom.profileId,
@@ -617,6 +638,7 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
     devices,
     mappingLoading,
     deviceHasValidMappings,
+    polygonOnlyZones,
   ]);
 
   useEffect(() => {
@@ -1070,7 +1092,7 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
           }}
         >
           <ZoneCanvas
-            zones={selectedRoom.zones ?? []}
+            zones={displayedRectZones}
             onZonesChange={() => {}}
             // Polygon zones support - show polygon zones when polygon mode is enabled
             polygonZones={displayPolygonZones}
@@ -1694,11 +1716,11 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
                       )
                     ) : (
                       // Rectangle zones legend
-                      selectedRoom?.zones && selectedRoom.zones.filter(z => z.type === 'regular').length > 0 && (
+                      displayedRectZones.filter(z => z.type === 'regular').length > 0 && (
                         <div className="flex flex-wrap items-center gap-2 text-[11px]">
                           {(() => {
                             const regularZoneColors = ['#3b82f6', '#8b5cf6', '#ec4899', '#f59e0b', '#06b6d4'];
-                            const regularZones = selectedRoom.zones.filter(z => z.type === 'regular');
+                            const regularZones = displayedRectZones.filter(z => z.type === 'regular');
 
                             return regularZones.map((zone, index) => (
                               <div key={zone.id} className="flex items-center gap-1.5">

--- a/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
@@ -26,6 +26,7 @@ import { useIsMobileCanvas } from '../hooks/useMediaQuery';
 import { getDeviceIconUrl } from '../utils/deviceIcon';
 import { resolveCoverageFov, resolveTrackingCoverageFov } from '../utils/coverage';
 import { formatSnapPresetLabel } from '../utils/snapLabels';
+import { usesPolygonOnlyZones } from '../utils/firmware';
 
 interface WizardPageProps {
   devices: DiscoveredDevice[];
@@ -213,6 +214,12 @@ export const WizardPage: React.FC<WizardPageProps> = ({
     () => profiles.find((p) => p.id === (selectedRoom?.profileId ?? profileId ?? undefined)) ?? null,
     [profiles, profileId, selectedRoom?.profileId],
   );
+  const polygonOnlyZones = useMemo(() => (
+    usesPolygonOnlyZones(
+      selectedDevice?.firmwareVersion ?? null,
+      selectedDevice?.model ?? currentProfile?.label ?? null,
+    ) === true
+  ), [selectedDevice?.firmwareVersion, selectedDevice?.model, currentProfile?.label]);
 
   const deviceIconUrl = useMemo(
     () => getDeviceIconUrl(currentProfile, selectedRoom?.devicePlacement),
@@ -470,7 +477,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
   const displayZones = useMemo(() => {
     if (!selectedRoom) return allPossibleZones;
 
-    const deviceZones = selectedRoom.zones ?? [];
+    const deviceZones = polygonOnlyZones ? [] : selectedRoom.zones ?? [];
     const merged = [...allPossibleZones];
 
     // Match device zones to slots by type and index
@@ -482,7 +489,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
     });
 
     return merged;
-  }, [selectedRoom, allPossibleZones]);
+  }, [selectedRoom, allPossibleZones, polygonOnlyZones]);
 
   // Only enabled zones should show on canvas
   const enabledZones = useMemo(() => {
@@ -860,6 +867,10 @@ export const WizardPage: React.FC<WizardPageProps> = ({
       zonesLoadedRef.current.add(roomKey);
 
       try {
+        if (polygonOnlyZones) {
+          setZonesLoadingComplete(roomKey);
+          return;
+        }
         // Skip entityMappings if device has valid mappings stored
         const entityMappingsToUse = deviceHasValidMappings ? undefined : selectedRoom.entityMappings;
         // fetchZonesFromDevice returns ZoneRect[] directly, not { zones: ZoneRect[] }
@@ -877,6 +888,11 @@ export const WizardPage: React.FC<WizardPageProps> = ({
           setZonesLoadingComplete(roomKey);
         }, 0);
       } catch (err) {
+        // Preserve stored rectangles for polygon-only recovery flows.
+        if (polygonOnlyZones) {
+          setZonesLoadingComplete(roomKey);
+          return;
+        }
         // Clear zones on error to prevent showing stale zones
         const updatedRoom: RoomConfig = { ...selectedRoom, zones: [] };
         await updateRoom(selectedRoom.id, updatedRoom);
@@ -889,7 +905,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
     };
 
     loadZonesFromDevice();
-  }, [currentStep, selectedRoom?.id, selectedRoom?.deviceId, selectedRoom?.profileId, selectedRoom?.entityNamePrefix, selectedRoom?.entityMappings, deviceId, devices, onRoomUpdate, deviceHasValidMappings]);
+  }, [currentStep, selectedRoom?.id, selectedRoom?.deviceId, selectedRoom?.profileId, selectedRoom?.entityNamePrefix, selectedRoom?.entityMappings, deviceId, devices, onRoomUpdate, deviceHasValidMappings, polygonOnlyZones]);
 
   // Fetch polygon mode status when entering zones step
   // This runs AFTER zones have been loaded to ensure room is fully initialized

--- a/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
@@ -1,5 +1,12 @@
 import React, { useEffect, useMemo, useState, useRef, useCallback } from 'react';
-import { fetchDevices, fetchProfiles, fetchZoneAvailability, ingressAware } from '../api/client';
+import {
+  fetchDevices,
+  fetchProfiles,
+  fetchZoneAvailability,
+  fetchZoneBackups,
+  ingressAware,
+  restoreZoneBackup,
+} from '../api/client';
 import { fetchRooms, updateRoom } from '../api/rooms';
 import { ZoneCanvas } from '../components/ZoneCanvas';
 import {
@@ -13,7 +20,16 @@ import {
 } from '../api/zones';
 import { validateZones } from '../api/validate';
 import { getZoneLabels, saveZoneLabels } from '../api/deviceMappings';
-import { DiscoveredDevice, DeviceProfile, RoomConfig, ZoneRect, ZonePolygon, LiveState, ZoneAvailability } from '../api/types';
+import {
+  DiscoveredDevice,
+  DeviceProfile,
+  RoomConfig,
+  ZoneRect,
+  ZonePolygon,
+  LiveState,
+  ZoneAvailability,
+  ZoneBackup,
+} from '../api/types';
 import {
   CanvasBottomToolbar,
   CanvasMobileSheet,
@@ -26,6 +42,7 @@ import { useIsMobileCanvas } from '../hooks/useMediaQuery';
 import { useDeviceMappings } from '../contexts/DeviceMappingsContext';
 import { getDeviceIconUrl } from '../utils/deviceIcon';
 import { resolveCoverageFov, resolveTrackingCoverageFov } from '../utils/coverage';
+import { usesPolygonOnlyZones } from '../utils/firmware';
 import {
   buildCeilingExclusionZones,
   buildCeilingSliceZones,
@@ -98,6 +115,9 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
   const [polygonZones, setPolygonZones] = useState<ZonePolygon[]>([]);
   const [togglingPolygonMode, setTogglingPolygonMode] = useState(false);
   const [showModeChangeConfirm, setShowModeChangeConfirm] = useState(false);
+  const [recoveringPolygonZones, setRecoveringPolygonZones] = useState(false);
+  const [latestZoneBackup, setLatestZoneBackup] = useState<ZoneBackup | null>(null);
+  const [loadingLatestZoneBackup, setLoadingLatestZoneBackup] = useState(false);
   // Zone labels from device mapping (stored separately from zone coordinates)
   const [deviceZoneLabels, setDeviceZoneLabels] = useState<Record<string, string>>({});
   const [roomLiveState, setRoomLiveState] = useState<LiveState | null>(null);
@@ -150,6 +170,12 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
     () => resolveTrackingCoverageFov(selectedProfile),
     [selectedProfile],
   );
+  const polygonOnlyZones = useMemo(() => (
+    usesPolygonOnlyZones(
+      selectedDevice?.firmwareVersion ?? null,
+      selectedDevice?.model ?? selectedProfile?.label ?? null,
+    ) === true
+  ), [selectedDevice?.firmwareVersion, selectedDevice?.model, selectedProfile?.label]);
   const effectiveCoverageMaxRangeMeters = coverageFov?.maxRangeMeters ?? selectedProfile?.limits?.maxRangeMeters;
   const trackingMaxRangeMeters = trackingCoverageFov?.maxRangeMeters ?? selectedProfile?.limits?.maxRangeMeters;
   const trackingFieldOfViewDeg = trackingCoverageFov?.horizontalFovDeg ?? selectedProfile?.limits?.fieldOfViewDegrees;
@@ -209,9 +235,15 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
     [ceilingSliceConfig, deviceZoneLabels],
   );
   const activePolygonZones = isCeilingSliceMode ? [...ceilingSliceDisplayZones, ...ceilingExclusionDisplayZones] : polygonZones;
+  const savedRectangularZones = useMemo(
+    () => (selectedRoom?.zones ?? []).filter((zone) => zone.enabled !== false),
+    [selectedRoom?.zones],
+  );
+  const hasSavedRectangularRecovery = savedRectangularZones.length > 0;
+  const hasBackupRecovery = latestZoneBackup !== null;
 
   // Device mappings context - used to check if device has valid entity mappings
-  const { hasValidMappings, clearCache } = useDeviceMappings();
+  const { hasValidMappings, clearCache, getMapping } = useDeviceMappings();
   const deviceHasValidMappings = selectedRoom?.deviceId ? hasValidMappings(selectedRoom.deviceId) : false;
   const hasPropLiveStateForRoom = Boolean(
     propLiveState && selectedRoom?.deviceId && propLiveState.deviceId === selectedRoom.deviceId
@@ -272,7 +304,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
   const displayZones = useMemo(() => {
     if (!selectedRoom) return allPossibleZones;
 
-    const deviceZones = selectedRoom.zones ?? [];
+    const deviceZones = polygonOnlyZones ? [] : selectedRoom.zones ?? [];
 
     // Create new objects to avoid mutating allPossibleZones
     return allPossibleZones.map(slot => {
@@ -285,7 +317,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
       // Return a fresh copy with enabled: false to ensure clean state
       return { ...slot, enabled: false };
     });
-  }, [selectedRoom, allPossibleZones, deviceZoneLabels]);
+  }, [selectedRoom, allPossibleZones, deviceZoneLabels, polygonOnlyZones]);
 
   // Only enabled zones should show on canvas
   const enabledZones = useMemo(() => {
@@ -484,6 +516,9 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
       }
 
       try {
+        if (polygonOnlyZones) {
+          return;
+        }
         // Skip entityMappings if device has valid mappings stored (device mapping is source of truth)
         const entityMappingsToUse = deviceHasValidMappings ? undefined : selectedRoom.entityMappings;
         const deviceZones = await fetchZonesFromDevice(
@@ -517,7 +552,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
     };
 
     loadZonesFromDevice();
-  }, [selectedRoom?.id, selectedRoom?.deviceId, selectedRoom?.profileId, selectedRoom?.entityNamePrefix, selectedRoom?.entityMappings, devices, deviceHasValidMappings]);
+  }, [selectedRoom?.id, selectedRoom?.deviceId, selectedRoom?.profileId, selectedRoom?.entityNamePrefix, selectedRoom?.entityMappings, devices, deviceHasValidMappings, polygonOnlyZones]);
 
   // Fetch zone availability from entity registry
   useEffect(() => {
@@ -733,6 +768,184 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
       setSelectedZoneId(nextZones[0].id);
     }
   };
+
+  const resolveZoneRestoreContext = useCallback(async () => {
+    if (!selectedRoom?.deviceId) return null;
+
+    const device = devices.find((entry) => entry.id === selectedRoom.deviceId);
+    const mapping = await getMapping(selectedRoom.deviceId);
+    const profileId = selectedRoom.profileId || mapping?.profileId || null;
+    const entityNamePrefix =
+      selectedRoom.entityNamePrefix ||
+      device?.entityNamePrefix ||
+      mapping?.esphomeNodeName ||
+      null;
+
+    if (!profileId) {
+      setError('Device profile not found. Run entity discovery to sync the device.');
+      return null;
+    }
+
+    if (!entityNamePrefix && !mapping) {
+      setError('Entity name prefix is missing. Link the device to a room or re-sync entities.');
+      return null;
+    }
+
+    return {
+      deviceId: selectedRoom.deviceId,
+      profileId,
+      entityNamePrefix,
+      entityMappings: deviceHasValidMappings ? undefined : selectedRoom.entityMappings,
+    };
+  }, [
+    deviceHasValidMappings,
+    devices,
+    getMapping,
+    selectedRoom?.deviceId,
+    selectedRoom?.entityMappings,
+    selectedRoom?.entityNamePrefix,
+    selectedRoom?.profileId,
+  ]);
+
+  const handleRecoverPolygonZones = useCallback(async () => {
+    const context = await resolveZoneRestoreContext();
+    if (!context) {
+      return;
+    }
+
+    if (savedRectangularZones.length === 0) {
+      setError('No saved rectangular zones are available to recover');
+      return;
+    }
+
+    setRecoveringPolygonZones(true);
+    setError(null);
+
+    try {
+      const convertedZones: ZonePolygon[] = savedRectangularZones.map((zone) => ({
+        id: zone.id,
+        type: zone.type,
+        vertices: [
+          { x: zone.x, y: zone.y },
+          { x: zone.x + zone.width, y: zone.y },
+          { x: zone.x + zone.width, y: zone.y + zone.height },
+          { x: zone.x, y: zone.y + zone.height },
+        ],
+        enabled: zone.enabled,
+        label: deviceZoneLabels[zone.id] ?? zone.label,
+      }));
+
+      const result = await pushPolygonZonesToDevice(
+        context.deviceId,
+        context.profileId,
+        convertedZones,
+        context.entityNamePrefix ?? undefined,
+        context.entityMappings,
+      );
+
+      if (!result.ok) {
+        const sample = result.warnings?.[0];
+        throw new Error(sample ? `Recovery partially failed: ${sample.error}` : 'Failed to recover polygon zones');
+      }
+
+      setPolygonZones(convertedZones);
+      setPolygonModeStatus((current) => ({ ...current, supported: true, enabled: true }));
+      setWarning(`Recovered ${convertedZones.length} polygon zone${convertedZones.length === 1 ? '' : 's'} from saved rectangular data.`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to recover polygon zones');
+    } finally {
+      setRecoveringPolygonZones(false);
+    }
+  }, [deviceZoneLabels, resolveZoneRestoreContext, savedRectangularZones]);
+
+  const handleRestoreLatestZoneBackup = useCallback(async () => {
+    if (!latestZoneBackup) {
+      setError('No zone backup is available to restore');
+      return;
+    }
+
+    const context = await resolveZoneRestoreContext();
+    if (!context) {
+      return;
+    }
+
+    setRecoveringPolygonZones(true);
+    setError(null);
+
+    try {
+      const result = await restoreZoneBackup(latestZoneBackup.id, {
+        deviceId: context.deviceId,
+        profileId: context.profileId,
+        entityNamePrefix: context.entityNamePrefix ?? undefined,
+        entityMappings: context.entityMappings,
+      });
+
+      if (!result.ok) {
+        throw new Error('Restore completed with errors. Check warnings and try again.');
+      }
+
+      const restoredZones = await fetchPolygonZonesFromDevice(
+        context.deviceId,
+        context.profileId,
+        context.entityNamePrefix ?? undefined,
+        context.entityMappings,
+      );
+      setPolygonZones(restoredZones);
+      setPolygonModeStatus((current) => ({ ...current, supported: true, enabled: true }));
+      clearCache(context.deviceId);
+      const labels = await getZoneLabels(context.deviceId);
+      setDeviceZoneLabels(labels);
+
+      if (result.warnings && result.warnings.length > 0) {
+        setWarning(`Restored latest backup with ${result.warnings.length} warning(s).`);
+      } else {
+        setWarning('Restored latest backup as polygon zones.');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to restore latest zone backup');
+    } finally {
+      setRecoveringPolygonZones(false);
+    }
+  }, [clearCache, latestZoneBackup, resolveZoneRestoreContext]);
+
+  useEffect(() => {
+    const shouldCheckBackups =
+      Boolean(selectedRoom?.deviceId) &&
+      polygonOnlyZones &&
+      polygonModeStatus.enabled &&
+      polygonZones.length === 0;
+
+    if (!shouldCheckBackups || !selectedRoom?.deviceId) {
+      setLatestZoneBackup(null);
+      setLoadingLatestZoneBackup(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoadingLatestZoneBackup(true);
+
+    void fetchZoneBackups(selectedRoom.deviceId)
+      .then(({ backups }) => {
+        if (cancelled) return;
+        const latest = [...(backups ?? [])]
+          .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0] ?? null;
+        setLatestZoneBackup(latest);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setLatestZoneBackup(null);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoadingLatestZoneBackup(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [polygonModeStatus.enabled, polygonOnlyZones, polygonZones.length, selectedRoom?.deviceId]);
 
   const persistCeilingSliceConfig = useCallback(async (config: CeilingSliceConfig | null = pendingCeilingSliceConfigRef.current) => {
     if (!selectedRoom || !config) return;
@@ -1179,6 +1392,44 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
       {warning && (
         <div className="absolute top-20 left-1/2 -translate-x-1/2 z-50 max-w-lg rounded-xl border border-amber-500/50 bg-amber-500/10 backdrop-blur px-6 py-3 text-amber-100 shadow-xl animate-in slide-in-from-top-4 fade-in">
           {warning}
+        </div>
+      )}
+      {polygonModeStatus.enabled && polygonZones.length === 0 && (hasSavedRectangularRecovery || hasBackupRecovery || loadingLatestZoneBackup) && (
+        <div className="absolute top-36 left-1/2 -translate-x-1/2 z-50 w-[min(42rem,calc(100vw-2rem))] rounded-2xl border border-sky-500/40 bg-slate-900/90 px-5 py-4 text-slate-100 shadow-2xl backdrop-blur">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <div className="text-sm font-semibold text-sky-300">Polygon Recovery Available</div>
+              <div className="mt-1 text-sm text-slate-300">
+                {hasSavedRectangularRecovery ? (
+                  <>This device is using polygon-only zones, but room storage still has {savedRectangularZones.length} saved rectangular zone{savedRectangularZones.length === 1 ? '' : 's'}. Recover them to the device as polygons.</>
+                ) : hasBackupRecovery ? (
+                  <>This device is using polygon-only zones and room storage no longer has the old rectangles. Restore the latest saved zone backup to repopulate polygon zones.</>
+                ) : (
+                  <>Checking for saved zone backups that can be restored to this polygon-only device.</>
+                )}
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {hasSavedRectangularRecovery && (
+                <button
+                  onClick={() => { void handleRecoverPolygonZones(); }}
+                  disabled={recoveringPolygonZones}
+                  className="rounded-xl bg-sky-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {recoveringPolygonZones ? 'Recovering...' : 'Recover Room Zones'}
+                </button>
+              )}
+              {hasBackupRecovery && (
+                <button
+                  onClick={() => { void handleRestoreLatestZoneBackup(); }}
+                  disabled={recoveringPolygonZones}
+                  className="rounded-xl border border-sky-400/50 bg-slate-800 px-4 py-2 text-sm font-semibold text-sky-100 transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {recoveringPolygonZones ? 'Restoring...' : 'Restore Latest Backup'}
+                </button>
+              )}
+            </div>
+          </div>
         </div>
       )}
 

--- a/everything-presence-mmwave-configurator/frontend/src/utils/firmware.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/firmware.ts
@@ -88,6 +88,17 @@ export function requiresZoneMigration(
   return currentCompare < 0 && targetCompare >= 0;
 }
 
+export function usesPolygonOnlyZones(
+  firmwareVersion: string | undefined | null,
+  model?: string | null
+): boolean | null {
+  const threshold = getZoneMigrationThreshold(model);
+  if (!threshold) return false;
+  const comparison = compareVersions(firmwareVersion, threshold);
+  if (comparison === null) return null;
+  return comparison >= 0;
+}
+
 /**
  * Check if a firmware version meets the minimum requirement
  * @param firmwareVersion The device's firmware version


### PR DESCRIPTION
This tightens up the Everything Presence Lite 1.5.0+ migration to polygon-only zones.

The main fixes are:
  - Fix re-sync entities from showing rectangular zones as misssing entitiees on 1.5.0+ firmware
 - stop showing stale rectangular zones in the UI before polygon state is known
 - add a recovery path for devices that were updated without going through the guided migration if one existss

Hopefully help with #353 #354 #356 and https://github.com/EverythingSmartHome/everything-presence-lite/issues/447