### PR TITLE
Fix: Use HA entity registry as the primary source for device discovery

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/domain/entityDiscovery.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/entityDiscovery.ts
@@ -93,12 +93,42 @@ export class EntityDiscoveryService {
       return [];
     }
 
+    try {
+      const entityRegistry = await this.readTransport.listEntityRegistry();
+      const registryEntities = entityRegistry.filter((entry) => entry.device_id === deviceId);
+      if (registryEntities.length > 0) {
+        logger.info(
+          { deviceId, entityCount: registryEntities.length },
+          'Loaded device entities from Home Assistant entity registry'
+        );
+        return registryEntities;
+      }
+
+      logger.warn(
+        { deviceId, profileId },
+        'No entity-registry entries linked to device; falling back to prefix-based discovery'
+      );
+    } catch (err) {
+      logger.warn(
+        { err, deviceId, profileId },
+        'Failed to read entity registry for device; falling back to prefix-based discovery'
+      );
+    }
+
+    return this.getDeviceEntitiesByPrefixFallback(device, deviceId, profileId);
+  }
+
+  private async getDeviceEntitiesByPrefixFallback(
+    device: DeviceRegistryEntry,
+    deviceId: string,
+    profileId?: string
+  ): Promise<EntityRegistryEntry[]> {
     const profiles = this.getCandidateProfiles(profileId);
     const prefixes = await this.getCandidateNamePrefixes(device);
     const candidateEntityIds = this.buildCandidateEntityIds(prefixes, profiles);
 
     if (candidateEntityIds.size === 0) {
-      logger.warn({ deviceId, profileId }, 'No candidate entity IDs generated for device discovery');
+      logger.warn({ deviceId, profileId }, 'No candidate entity IDs generated for device discovery fallback');
       return [];
     }
 
@@ -116,7 +146,7 @@ export class EntityDiscoveryService {
 
     logger.info(
       { deviceId, candidateCount: candidateEntityIds.size, matchedCount: matchedEntities.length },
-      'Resolved targeted Everything Presence entity candidates'
+      'Resolved targeted Everything Presence entity candidates via fallback discovery'
     );
 
     return matchedEntities;

--- a/everything-presence-mmwave-configurator/backend/src/domain/everythingPresenceDevices.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/everythingPresenceDevices.ts
@@ -3,6 +3,7 @@ import type { EntityRegistryEntry } from '../ha/types';
 
 const MANUFACTURER_FILTERS = [
   'EverythingSmartTechnology',
+  'Everything_Smart_Technology',
   'Everything Smart Technology',
 ];
 
@@ -150,15 +151,45 @@ const ENTITY_SUFFIX_REGEX = new RegExp(
 export const extractEntityPrefixFromEntityId = (entityId: string): string | undefined => {
   const withoutDomain = entityId.replace(/^[^.]+\./, '');
   const prefix = withoutDomain.replace(ENTITY_SUFFIX_REGEX, '');
-  return prefix || undefined;
+  if (prefix && prefix !== withoutDomain) {
+    return prefix;
+  }
+  return undefined;
+};
+
+const deriveEntityPrefixFromCommonPrefix = (
+  deviceEntities: EntityRegistryEntry[]
+): string | undefined => {
+  const objectIds = deviceEntities
+    .map((entry) => entry.entity_id)
+    .filter((id): id is string => Boolean(id))
+    .map((id) => id.replace(/^[^.]+\./, ''));
+
+  if (objectIds.length === 0) {
+    return undefined;
+  }
+
+  let common = objectIds[0];
+  for (const objectId of objectIds.slice(1)) {
+    let i = 0;
+    while (i < common.length && i < objectId.length && common[i] === objectId[i]) {
+      i += 1;
+    }
+    common = common.slice(0, i);
+    if (!common) {
+      break;
+    }
+  }
+
+  const trimmed = common.replace(/_+$/, '');
+  return trimmed || undefined;
 };
 
 export const deriveEntityPrefixFromRegistryEntries = (
   deviceEntities: EntityRegistryEntry[]
 ): string | undefined => {
-  let deviceEntity = deviceEntities.find(
-    (entry) => entry.entity_id?.includes('_occupancy') || entry.entity_id?.includes('_presence')
-  );
+  const objectId = (entityId: string | undefined): string => (entityId ?? '').replace(/^[^.]+\./, '');
+  let deviceEntity = deviceEntities.find((entry) => /_(occupancy|presence)$/.test(objectId(entry.entity_id)));
 
   if (!deviceEntity) {
     deviceEntity = deviceEntities.find(
@@ -166,13 +197,12 @@ export const deriveEntityPrefixFromRegistryEntries = (
     );
   }
 
-  if (!deviceEntity) {
-    deviceEntity = deviceEntities[0];
+  if (deviceEntity?.entity_id) {
+    const prefix = extractEntityPrefixFromEntityId(deviceEntity.entity_id);
+    if (prefix) {
+      return prefix;
+    }
   }
 
-  if (!deviceEntity?.entity_id) {
-    return undefined;
-  }
-
-  return extractEntityPrefixFromEntityId(deviceEntity.entity_id);
+  return deriveEntityPrefixFromCommonPrefix(deviceEntities);
 };


### PR DESCRIPTION
This changes entity discovery to use Home Assistant’s entity registry as the primary source of truth for a selected device.

Instead of narrowing discovery up front by guessing the ESPHome prefix, the configurator now:

  - loads all entity-registry entries linked to the selected HA device_id
  - runs matching/manual mapping against that full per-device entity set
  - only falls back to prefix-based discovery if HA returns no linked registry entities or the registry read fails

https://github.com/EverythingSmartHome/everything-presence-lite/issues/448
