### PR TITLE
Reduce startup load from device discovery

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/domain/deviceDiscovery.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/deviceDiscovery.ts
@@ -1,8 +1,6 @@
 import type { IHaReadTransport } from '../ha/readTransport';
 import { logger } from '../logger';
 import {
-  deriveEntityPrefixFromRegistryEntries,
-  extractEsphomeNodeName,
   filterEverythingPresenceDevices,
   normalizeManufacturer,
 } from './everythingPresenceDevices';
@@ -22,29 +20,6 @@ export class DeviceDiscoveryService {
 
   constructor(readTransport: IHaReadTransport) {
     this.readTransport = readTransport;
-  }
-
-  private async getEntityNamePrefixForDevice(deviceId: string): Promise<string | undefined> {
-    try {
-      const devices = await this.readTransport.listDevices();
-      const device = filterEverythingPresenceDevices(devices).find((entry) => entry.id === deviceId);
-      if (device) {
-        const esphomePrefix = extractEsphomeNodeName(device);
-        if (esphomePrefix) {
-          return esphomePrefix;
-        }
-      }
-
-      const entityRegistry = await this.readTransport.listEntityRegistry();
-      const deviceEntities = entityRegistry.filter((entry) => entry.device_id === deviceId);
-      const registryPrefix = deriveEntityPrefixFromRegistryEntries(deviceEntities);
-      if (registryPrefix) {
-        return registryPrefix;
-      }
-    } catch (error) {
-      logger.warn({ error: (error as Error).message, deviceId }, 'Failed to get entity prefix for device');
-    }
-    return undefined;
   }
 
   async discover(): Promise<DiscoveredDevice[]> {
@@ -82,18 +57,12 @@ export class DeviceDiscoveryService {
       }))
     );
 
-    // Enrich with entity name prefix and area name
-    const enrichedDevices = await Promise.all(
-      filteredDevices.map(async (device) => {
-        const { areaId, ...rest } = device;
-        return {
-          ...rest,
-          entityNamePrefix: await this.getEntityNamePrefixForDevice(device.id),
-          areaName: areaId ? areaMap.get(areaId) : undefined,
-        };
-      })
-    );
-
-    return enrichedDevices;
+    return filteredDevices.map((device) => {
+      const { areaId, ...rest } = device;
+      return {
+        ...rest,
+        areaName: areaId ? areaMap.get(areaId) : undefined,
+      };
+    });
   }
 }


### PR DESCRIPTION
This reduces the amount of work the add-on does when loading the device list.

  Previously, startup discovery was eagerly trying to populate entityNamePrefix for every Everything Presence device. On larger Home Assistant installs, that could trigger repeated registry lookups during app
  load and cause WebSocket timeouts, REST fallback churn, and in some cases HA frontend instability.

  This change keeps device discovery lightweight by returning the filtered device list without doing per-device prefix enrichment up front.

  ## What changed

  - removed eager entityNamePrefix resolution from DeviceDiscoveryService.discover()
  - stopped the startup path from calling extra listDevices() / listEntityRegistry() work per device
  - kept entityNamePrefix optional so existing mapped-device flows continue to work
  - left legacy prefix fallback in place for runtime flows that still need it

Hopefully fixes #360