### PR TITLE
Fix polygon zone editing failing after polygon only firmware updates

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/domain/entityDiscovery.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/entityDiscovery.ts
@@ -1,4 +1,4 @@
-import type { IHaReadTransport } from '../ha/readTransport';
+﻿import type { IHaReadTransport } from '../ha/readTransport';
 import type { EntityRegistryEntry } from '../ha/types';
 import type { DeviceRegistryEntry } from '../ha/readTransport';
 import type { DeviceProfile, DeviceProfileLoader } from './deviceProfiles';
@@ -7,7 +7,7 @@ import { deviceMappingStorage, DeviceMapping, parseFirmwareVersion } from '../co
 import { logger } from '../logger';
 import { telemetry } from '../logger/telemetry';
 import { normalizeMappingKeys } from './mappingUtils';
-import { isEplPolygonOnlyDevice } from './firmwareVersionUtils';
+import { isPolygonOnlyDevice } from './firmwareVersionUtils';
 import {
   deriveEntityPrefixFromRegistryEntries,
   extractEsphomeNodeName,
@@ -248,7 +248,7 @@ export class EntityDiscoveryService {
     const profileEntities = (profile as unknown as Record<string, unknown>).entities as Record<string, EntityDefinitionWithTemplate> | undefined;
     const rawEntityMap = (profile as unknown as Record<string, unknown>).entityMap as Record<string, unknown>;
     const capabilities = profile.capabilities as Record<string, unknown>;
-    const polygonOnlyEpl = isEplPolygonOnlyDevice({
+    const polygonOnlyEpl = isPolygonOnlyDevice({
       profileId,
       firmwareVersion,
       model: (profile as unknown as Record<string, unknown>).model as string | undefined,
@@ -1049,7 +1049,7 @@ export class EntityDiscoveryService {
   ): Promise<{ valid: boolean; errors: Array<{ key: string; entityId: string; error: string }> }> {
     const errors: Array<{ key: string; entityId: string; error: string }> = [];
     const existingMapping = deviceId ? deviceMappingStorage.getMapping(deviceId) : null;
-    const skipLegacyRectangles = isEplPolygonOnlyDevice({
+    const skipLegacyRectangles = isPolygonOnlyDevice({
       profileId: existingMapping?.profileId,
       firmwareVersion: existingMapping?.firmwareVersion,
     });

--- a/everything-presence-mmwave-configurator/backend/src/domain/firmwareVersionUtils.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/firmwareVersionUtils.ts
@@ -4,7 +4,10 @@ export interface ParsedVersion {
   patch: number;
 }
 
+// Firmware versions where rectangular zones are removed per device model.
+// Must stay in sync with frontend/src/utils/firmware.ts ZONE_MIGRATION_VERSION_BY_MODEL.
 const EPL_POLYGON_ONLY_VERSION = '1.5.0';
+const EPP_POLYGON_ONLY_VERSION = '1.2.0';
 
 export function parseVersion(version: string | undefined | null): ParsedVersion | null {
   if (!version) return null;
@@ -44,16 +47,34 @@ export function isEverythingPresenceLite(profileId?: string | null, model?: stri
   return normalized.includes('everything presence lite') || normalized.includes('everything-presence-lite');
 }
 
-export function isEplPolygonOnlyDevice(args: {
+export function isEverythingPresencePro(profileId?: string | null, model?: string | null): boolean {
+  if (profileId === 'everything_presence_pro') return true;
+  const normalized = normalizeModel(model);
+  return normalized.includes('everything presence pro') || normalized.includes('everything-presence-pro');
+}
+
+/**
+ * Whether the device firmware only supports polygon zones (rectangular zones removed).
+ * Covers every model with a polygon-only migration threshold (EPL >= 1.5.0, EP Pro >= 1.2.0).
+ * Returns false when the firmware version is unknown or unparseable so callers
+ * fall back to entity-based detection.
+ */
+export function isPolygonOnlyDevice(args: {
   profileId?: string | null;
   firmwareVersion?: string | null;
   model?: string | null;
 }): boolean {
-  if (!isEverythingPresenceLite(args.profileId, args.model)) {
+  let threshold: string | null = null;
+  if (isEverythingPresenceLite(args.profileId, args.model)) {
+    threshold = EPL_POLYGON_ONLY_VERSION;
+  } else if (isEverythingPresencePro(args.profileId, args.model)) {
+    threshold = EPP_POLYGON_ONLY_VERSION;
+  }
+  if (!threshold) {
     return false;
   }
 
-  const comparison = compareVersions(args.firmwareVersion, EPL_POLYGON_ONLY_VERSION);
+  const comparison = compareVersions(args.firmwareVersion, threshold);
   return comparison !== null && comparison >= 0;
 }
 

--- a/everything-presence-mmwave-configurator/backend/src/routes/devices.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/devices.ts
@@ -9,7 +9,7 @@ import { RoomConfig, ZonePolygon, EntityMappings } from '../domain/types';
 import { EntityResolver } from '../domain/entityResolver';
 import { deviceEntityService } from '../domain/deviceEntityService';
 import { deviceMappingStorage, parseFirmwareVersion } from '../config/deviceMappingStorage';
-import { isEplPolygonOnlyDevice } from '../domain/firmwareVersionUtils';
+import { isPolygonOnlyDevice } from '../domain/firmwareVersionUtils';
 import { logger } from '../logger';
 
 export interface DevicesRouterDependencies {
@@ -37,22 +37,21 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
     return normalized === 'unavailable';
   };
   const getDeviceFirmwareVersion = async (deviceId: string): Promise<string | undefined> => {
-    const existingMapping = deviceMappingStorage.getMapping(deviceId);
-    if (existingMapping?.firmwareVersion) {
-      return existingMapping.firmwareVersion;
-    }
 
     try {
       const devices = await readTransport.listDevices();
       const device = devices.find((candidate) => candidate.id === deviceId);
-      if (!device?.sw_version) {
-        return undefined;
+      if (device?.sw_version) {
+        const parsed = parseFirmwareVersion(device.sw_version).firmwareVersion;
+        if (parsed) {
+          return parsed;
+        }
       }
-      return parseFirmwareVersion(device.sw_version).firmwareVersion;
     } catch (error) {
       logger.warn({ error, deviceId }, 'Failed to fetch firmware version for device route');
-      return undefined;
     }
+
+    return deviceMappingStorage.getMapping(deviceId)?.firmwareVersion;
   };
 
   router.get('/', async (_req, res) => {
@@ -400,7 +399,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
     // Check if device has device-level mappings (preferred)
     const hasDeviceMapping = deviceMappingStorage.hasMapping(deviceId);
     const firmwareVersion = await getDeviceFirmwareVersion(deviceId);
-    const polygonOnlyEpl = isEplPolygonOnlyDevice({
+    const polygonOnlyEpl = isPolygonOnlyDevice({
       profileId: profile.id,
       firmwareVersion,
       model: (profile as unknown as { model?: string }).model,
@@ -725,6 +724,19 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
       return res.json({ supported: false, enabled: false, controllable: false });
     }
 
+    // Firmware-version check first: polygon-only firmware has no mode toggle, and the
+    // legacy switch entity may linger in HA as a restored "unavailable" ghost that would
+    // otherwise be read as "polygon mode off". The registry sw_version is reliable even
+    // when the device is offline.
+    const firmwareVersion = await getDeviceFirmwareVersion(deviceId);
+    if (isPolygonOnlyDevice({
+      profileId: profile.id,
+      firmwareVersion,
+      model: (profile as unknown as { model?: string }).model,
+    })) {
+      return res.json({ supported: true, enabled: true, controllable: false });
+    }
+
     const entityMap = profile.entityMap as any;
     const entityTemplate = entityMap?.polygonZonesEnabledEntity;
 
@@ -796,9 +808,14 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
         statesMapSize: states.size
       }, 'Polygon mode entity state lookup result');
 
-      // If the old toggle entity no longer exists, fall back to polygon-only detection.
-      if (!state) {
-        logger.info({ entityId: switchEntityId }, 'Polygon mode entity not found - checking polygon-only zone entities');
+      // If the old toggle entity no longer exists (or only lingers as a restored
+      // "unavailable" ghost after a polygon-only firmware update), fall back to
+      // polygon-only detection via the polygon zone text entities.
+      if (!state || isUnavailableState(state.state)) {
+        logger.info(
+          { entityId: switchEntityId, stateValue: state?.state ?? null },
+          'Polygon mode entity missing or unavailable - checking polygon-only zone entities'
+        );
 
         let polygonZoneEntity: string | null = null;
         if (hasDeviceMapping) {
@@ -819,7 +836,10 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
 
         const polygonStates = await readTransport.getStates([polygonZoneEntity]);
         const polygonState = polygonStates.get(polygonZoneEntity);
-        if (!polygonState) {
+        // Require a live polygon zone state: an offline pre-migration device reports
+        // every entity (including the real toggle) as unavailable, and must not be
+        // mistaken for a polygon-only device.
+        if (!polygonState || isReadinessUnavailableState(polygonState.state)) {
           return res.json({ supported: false, enabled: false, controllable: true });
         }
 
@@ -860,6 +880,23 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
     const entityMap = profile.entityMap as any;
 
     try {
+      // Polygon-only firmware has no mode toggle: writing the legacy switch would
+      // silently no-op against a ghost entity and revert on the next status read.
+      const firmwareVersion = await getDeviceFirmwareVersion(deviceId);
+      if (isPolygonOnlyDevice({
+        profileId: profile.id,
+        firmwareVersion,
+        model: (profile as unknown as { model?: string }).model,
+      })) {
+        if (!enabled) {
+          return res.status(409).json({
+            message: 'This firmware only supports polygon zones; rectangle mode is no longer available.',
+            code: 'POLYGON_ONLY_FIRMWARE',
+          });
+        }
+        return res.json({ ok: true, enabled: true });
+      }
+
       await zoneWriter.setPolygonMode(entityMap, entityNamePrefix, enabled, entityMappings, deviceId);
       return res.json({ ok: true, enabled });
     } catch (error) {

--- a/everything-presence-mmwave-configurator/frontend/src/pages/LiveTrackingPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/LiveTrackingPage.tsx
@@ -676,11 +676,22 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
           entityMappingsToUse
         );
         if (!cancelled) {
-          setPolygonModeStatus(status);
+          // Polygon-only firmware has no rectangle mode: never let a stale mode toggle
+          // (e.g. a ghost switch entity left behind by the firmware update) report
+          // rectangle mode, which would hide every zone overlay.
+          if (polygonOnlyZones && (!status.enabled || !status.supported)) {
+            setPolygonModeStatus({ supported: true, enabled: true, controllable: false });
+          } else {
+            setPolygonModeStatus(status);
+          }
         }
       } catch (err) {
         if (!cancelled) {
-          setPolygonModeStatus({ supported: false, enabled: false, controllable: false });
+          if (polygonOnlyZones) {
+            setPolygonModeStatus({ supported: true, enabled: true, controllable: false });
+          } else {
+            setPolygonModeStatus({ supported: false, enabled: false, controllable: false });
+          }
         }
       }
     };
@@ -699,6 +710,7 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
     devices,
     mappingLoading,
     deviceHasValidMappings,
+    polygonOnlyZones,
   ]);
 
   useEffect(() => {

--- a/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
@@ -936,12 +936,18 @@ export const WizardPage: React.FC<WizardPageProps> = ({
       try {
         // Skip entityMappings if device has valid mappings stored
         const entityMappingsToUse = deviceHasValidMappings ? undefined : selectedRoom.entityMappings;
-        const status = await fetchPolygonModeStatus(
+        let status = await fetchPolygonModeStatus(
           selectedRoom.deviceId,
           selectedRoom.profileId,
           entityNamePrefix,
           entityMappingsToUse
         );
+        // Polygon-only firmware has no rectangle mode: never let a stale mode toggle
+        // (e.g. a ghost switch entity left behind by the firmware update) push the
+        // wizard into rectangle mode, where zone slots can't be enabled.
+        if (polygonOnlyZones && (!status.enabled || !status.supported)) {
+          status = { supported: true, enabled: true, controllable: false };
+        }
         setPolygonModeStatus(status);
 
         // If polygon mode is enabled, fetch polygon zones
@@ -967,12 +973,16 @@ export const WizardPage: React.FC<WizardPageProps> = ({
         // entities do exist.
       } catch (err) {
         console.error('Failed to fetch polygon mode status:', err);
-        setPolygonModeStatus({ supported: false, enabled: false, controllable: false });
+        if (polygonOnlyZones) {
+          setPolygonModeStatus({ supported: true, enabled: true, controllable: false });
+        } else {
+          setPolygonModeStatus({ supported: false, enabled: false, controllable: false });
+        }
       }
     };
 
     loadPolygonModeStatus();
-  }, [currentStep, selectedRoom?.id, selectedRoom?.deviceId, selectedRoom?.profileId, selectedRoom?.entityNamePrefix, selectedRoom?.entityMappings, devices, zonesLoadingComplete, deviceHasValidMappings]);
+  }, [currentStep, selectedRoom?.id, selectedRoom?.deviceId, selectedRoom?.profileId, selectedRoom?.entityNamePrefix, selectedRoom?.entityMappings, devices, zonesLoadingComplete, deviceHasValidMappings, polygonOnlyZones]);
 
   // Track if we've auto-enabled Zone 1 for this room to avoid re-enabling if user manually disables
   const autoEnabledZoneRef = useRef<Set<string>>(new Set());

--- a/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
@@ -630,14 +630,25 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
           entityNamePrefix,
           entityMappingsToUse
         );
-        setPolygonModeStatus(status);
+        // Polygon-only firmware has no rectangle mode: never let a stale mode toggle
+        // (e.g. a ghost switch entity left behind by the firmware update) push the
+        // editor into rectangle mode, where all zone slots are hidden.
+        if (polygonOnlyZones && (!status.enabled || !status.supported)) {
+          setPolygonModeStatus({ supported: true, enabled: true, controllable: false });
+        } else {
+          setPolygonModeStatus(status);
+        }
       } catch (err) {
-        setPolygonModeStatus({ supported: false, enabled: false, controllable: false });
+        if (polygonOnlyZones) {
+          setPolygonModeStatus({ supported: true, enabled: true, controllable: false });
+        } else {
+          setPolygonModeStatus({ supported: false, enabled: false, controllable: false });
+        }
       }
     };
 
     loadPolygonModeStatus();
-  }, [selectedRoom?.id, selectedRoom?.deviceId, selectedRoom?.profileId, selectedRoom?.entityNamePrefix, selectedRoom?.entityMappings, devices, deviceHasValidMappings]);
+  }, [selectedRoom?.id, selectedRoom?.deviceId, selectedRoom?.profileId, selectedRoom?.entityNamePrefix, selectedRoom?.entityMappings, devices, deviceHasValidMappings, polygonOnlyZones]);
 
   // Fetch polygon zones when polygon mode is enabled
   useEffect(() => {


### PR DESCRIPTION
Some users on EPL 1.5.0 (and EP Pro 1.2.0+) couldn't add polygon zones. The Zone Editor would show polygon mode as active but render no zone slots, and the add zone buttons did nothing

When firmware removes rectangular zones, the old "Polygon Zones" toggle switch is deleted from the device. Home Assistant doesn't always remove the entity from its registry though - on some installs it lingers as a restored entity that still reports a state of `unavailable`.

`GET /polygon-mode` only fell back to polygon-only detection when the switch state was completely missing. A lingering `unavailable` state passed that check and was read as "polygon mode off", so the backend reported rectangle mode for firmware that has no rectangle zones. The frontend then hid all rectangular zone data (because the firmware
version check says polygon-only) while rendering the rectangle-mode UI - so the slot list was empty and the add buttons wrote into state the display ignore