### PR TITLE
Fix zone editor not working when room prefix is missing

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/domain/deviceDiscovery.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/deviceDiscovery.ts
@@ -4,6 +4,7 @@ import {
   filterEverythingPresenceDevices,
   normalizeManufacturer,
 } from './everythingPresenceDevices';
+import { deviceEntityService } from './deviceEntityService';
 
 export interface DiscoveredDevice {
   id: string;
@@ -61,6 +62,7 @@ export class DeviceDiscoveryService {
       const { areaId, ...rest } = device;
       return {
         ...rest,
+        entityNamePrefix: deviceEntityService.getDeviceNamePrefix(device.id) ?? undefined,
         areaName: areaId ? areaMap.get(areaId) : undefined,
       };
     });

--- a/everything-presence-mmwave-configurator/backend/src/routes/devices.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/devices.ts
@@ -36,6 +36,9 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
     // Treat "unknown" as available for readiness purposes; it's common immediately after reboot.
     return normalized === 'unavailable';
   };
+  const resolveEntityNamePrefix = (deviceId: string, explicitPrefix?: string | null): string | null => {
+    return deviceEntityService.getDeviceNamePrefix(deviceId) ?? explicitPrefix?.trim() ?? null;
+  };
   const getDeviceFirmwareVersion = async (deviceId: string): Promise<string | undefined> => {
 
     try {
@@ -370,7 +373,11 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
 
   router.get('/:deviceId/zone-availability', async (req, res) => {
     const { deviceId } = req.params;
-    const { profileId, entityNamePrefix, entityMappings: entityMappingsJson } = req.query;
+    const { profileId, entityMappings: entityMappingsJson } = req.query;
+    const entityNamePrefix = resolveEntityNamePrefix(
+      deviceId,
+      typeof req.query?.entityNamePrefix === 'string' ? req.query.entityNamePrefix : null
+    );
 
     if (!profileId || !entityNamePrefix) {
       return res.status(400).json({ message: 'profileId and entityNamePrefix are required' });
@@ -634,7 +641,11 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
 
   router.get('/:deviceId/zones', async (req, res) => {
     const { deviceId } = req.params;
-    const { profileId, entityNamePrefix, entityMappings: entityMappingsJson } = req.query;
+    const { profileId, entityMappings: entityMappingsJson } = req.query;
+    const entityNamePrefix = resolveEntityNamePrefix(
+      deviceId,
+      typeof req.query?.entityNamePrefix === 'string' ? req.query.entityNamePrefix : null
+    );
 
     if (!profileId || !entityNamePrefix) {
       return res.status(400).json({ message: 'profileId and entityNamePrefix are required' });
@@ -661,7 +672,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
     }
 
     try {
-      const zones = await zoneReader.readZones(zoneMap, entityNamePrefix as string, entityMappings, deviceId);
+      const zones = await zoneReader.readZones(zoneMap, entityNamePrefix, entityMappings, deviceId);
       return res.json({ zones });
     } catch (error) {
       logger.error({ error }, 'Failed to read zones');
@@ -672,7 +683,10 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
   router.post('/:deviceId/zones', async (req, res) => {
     const { deviceId } = req.params;
     const profileId = (req.body?.profileId as string | undefined) ?? (req.body?.profile_id as string | undefined);
-    const entityNamePrefix = (req.body?.entityNamePrefix as string | undefined) ?? (req.body?.entity_name_prefix as string | undefined);
+    const entityNamePrefix = resolveEntityNamePrefix(
+      deviceId,
+      (req.body?.entityNamePrefix as string | undefined) ?? (req.body?.entity_name_prefix as string | undefined) ?? null
+    );
     const zones = (req.body?.zones as RoomConfig['zones']) ?? [];
     const entityMappings = req.body?.entityMappings as EntityMappings | undefined;
 
@@ -708,7 +722,11 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
    */
   router.get('/:deviceId/polygon-mode', async (req, res) => {
     const { deviceId } = req.params;
-    const { profileId, entityNamePrefix, entityMappings: entityMappingsJson } = req.query;
+    const { profileId, entityMappings: entityMappingsJson } = req.query;
+    const entityNamePrefix = resolveEntityNamePrefix(
+      deviceId,
+      typeof req.query?.entityNamePrefix === 'string' ? req.query.entityNamePrefix : null
+    );
 
     if (!profileId || !entityNamePrefix) {
       return res.status(400).json({ message: 'profileId and entityNamePrefix are required' });
@@ -762,7 +780,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
       if (!switchEntityId) {
         switchEntityId = EntityResolver.resolve(
           entityMappings,
-          entityNamePrefix as string,
+          entityNamePrefix,
           'polygonZonesEnabledEntity',
           entityTemplate
         );
@@ -777,7 +795,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
         if (!polygonZoneEntity && entityMap?.polygonZoneEntities?.zone1) {
           polygonZoneEntity = EntityResolver.resolvePolygonZoneEntity(
             entityMappings,
-            entityNamePrefix as string,
+            entityNamePrefix,
             'polygonZoneEntities',
             'zone1',
             entityMap.polygonZoneEntities.zone1
@@ -824,7 +842,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
         if (!polygonZoneEntity && entityMap?.polygonZoneEntities?.zone1) {
           polygonZoneEntity = EntityResolver.resolvePolygonZoneEntity(
             entityMappings,
-            entityNamePrefix as string,
+            entityNamePrefix,
             'polygonZoneEntities',
             'zone1',
             entityMap.polygonZoneEntities.zone1
@@ -864,7 +882,10 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
   router.post('/:deviceId/polygon-mode', async (req, res) => {
     const { deviceId } = req.params;
     const profileId = req.body?.profileId as string | undefined;
-    const entityNamePrefix = req.body?.entityNamePrefix as string | undefined;
+    const entityNamePrefix = resolveEntityNamePrefix(
+      deviceId,
+      (req.body?.entityNamePrefix as string | undefined) ?? null
+    );
     const enabled = req.body?.enabled as boolean | undefined;
     const entityMappings = req.body?.entityMappings as EntityMappings | undefined;
 
@@ -910,7 +931,11 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
    */
   router.get('/:deviceId/polygon-zones', async (req, res) => {
     const { deviceId } = req.params;
-    const { profileId, entityNamePrefix, entityMappings: entityMappingsJson } = req.query;
+    const { profileId, entityMappings: entityMappingsJson } = req.query;
+    const entityNamePrefix = resolveEntityNamePrefix(
+      deviceId,
+      typeof req.query?.entityNamePrefix === 'string' ? req.query.entityNamePrefix : null
+    );
 
     if (!profileId || !entityNamePrefix) {
       return res.status(400).json({ message: 'profileId and entityNamePrefix are required' });
@@ -934,7 +959,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
     }
 
     try {
-      const zones = await zoneReader.readPolygonZones(entityMap, entityNamePrefix as string, entityMappings, deviceId);
+      const zones = await zoneReader.readPolygonZones(entityMap, entityNamePrefix, entityMappings, deviceId);
       return res.json({ zones });
     } catch (error) {
       logger.error({ error }, 'Failed to read polygon zones');
@@ -948,7 +973,10 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
   router.post('/:deviceId/polygon-zones', async (req, res) => {
     const { deviceId } = req.params;
     const profileId = req.body?.profileId as string | undefined;
-    const entityNamePrefix = req.body?.entityNamePrefix as string | undefined;
+    const entityNamePrefix = resolveEntityNamePrefix(
+      deviceId,
+      (req.body?.entityNamePrefix as string | undefined) ?? null
+    );
     const zones = req.body?.zones as ZonePolygon[] | undefined;
     const entityMappings = req.body?.entityMappings as EntityMappings | undefined;
 

--- a/everything-presence-mmwave-configurator/backend/src/routes/rooms.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/rooms.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { storage } from '../config/storage';
+import { deviceEntityService } from '../domain/deviceEntityService';
 import { DevicePlacement, Door, EntityMappings, FurnitureInstance, RoomConfig, RoomShell, ZoneRect, ZoneEntitySet, TargetEntitySet } from '../domain/types';
 
 export const createRoomsRouter = (): Router => {
@@ -250,6 +251,22 @@ export const createRoomsRouter = (): Router => {
     metadata: body?.metadata ?? {},
   });
 
+  const applyDeviceMappingPrefix = (room: RoomConfig): RoomConfig => {
+    if (room.entityNamePrefix || !room.deviceId) {
+      return room;
+    }
+
+    const mappingPrefix = deviceEntityService.getDeviceNamePrefix(room.deviceId);
+    if (!mappingPrefix) {
+      return room;
+    }
+
+    return {
+      ...room,
+      entityNamePrefix: mappingPrefix,
+    };
+  };
+
   router.get('/', (_req, res) => {
     res.json({ rooms: storage.listRooms() });
   });
@@ -263,7 +280,7 @@ export const createRoomsRouter = (): Router => {
   });
 
   router.post('/', (req, res) => {
-    const room = normalizeRoom(req.body);
+    const room = applyDeviceMappingPrefix(normalizeRoom(req.body));
     storage.saveRoom(room);
     res.json({ room });
   });
@@ -273,7 +290,7 @@ export const createRoomsRouter = (): Router => {
     if (!existing) {
       return res.status(404).json({ message: 'Room not found' });
     }
-    const room = normalizeRoom({ ...existing, ...req.body }, existing.id);
+    const room = applyDeviceMappingPrefix(normalizeRoom({ ...existing, ...req.body }, existing.id));
     storage.saveRoom(room);
     return res.json({ room });
   });

--- a/everything-presence-mmwave-configurator/backend/src/routes/zoneBackups.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/zoneBackups.ts
@@ -128,8 +128,8 @@ export const createZoneBackupsRouter = (deps: ZoneBackupsRouterDependencies): Ro
     }
 
     const prefix =
-      entityNamePrefix ||
       deviceEntityService.getDeviceNamePrefix(deviceId) ||
+      entityNamePrefix ||
       undefined;
     if (!prefix) {
       return res.status(400).json({ message: 'entityNamePrefix is required when device mapping is missing' });
@@ -246,8 +246,8 @@ export const createZoneBackupsRouter = (deps: ZoneBackupsRouterDependencies): Ro
     }
 
     const prefix =
-      entityNamePrefix ||
       deviceEntityService.getDeviceNamePrefix(deviceId) ||
+      entityNamePrefix ||
       undefined;
     if (!prefix) {
       return res.status(400).json({ message: 'entityNamePrefix is required when device mapping is missing' });

--- a/everything-presence-mmwave-configurator/frontend/src/pages/SettingsPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/SettingsPage.tsx
@@ -268,6 +268,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onBack, onRoomDelete
       const updatedProfileId = savedMapping.profileId || syncingRoom.profileId;
       const result = await updateRoom(syncingRoom.id, {
         entityMappings: mappings,
+        entityNamePrefix: savedMapping.esphomeNodeName ?? syncingRoom.entityNamePrefix,
         profileId: updatedProfileId,
       });
       const updatedRoom = result.room;


### PR DESCRIPTION
Fix zone editing for rooms that no longer have a stored entityNamePrefix.

Zone and polygon routes now resolve the prefix from the device mapping first and only fall back to the legacy room prefix when no device mapping exists. Room create/update and entity re-sync also restore the prefix from the saved mapping so older broken rooms recover without manual edit

Should fix #366