### PR TITLE
Avoid eager entity prefix discovery during startup

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/domain/deviceDiscovery.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/deviceDiscovery.ts
@@ -4,7 +4,6 @@ import {
   filterEverythingPresenceDevices,
   normalizeManufacturer,
 } from './everythingPresenceDevices';
-import { deviceEntityService } from './deviceEntityService';
 
 export interface DiscoveredDevice {
   id: string;
@@ -62,7 +61,6 @@ export class DeviceDiscoveryService {
       const { areaId, ...rest } = device;
       return {
         ...rest,
-        entityNamePrefix: deviceEntityService.getDeviceNamePrefix(device.id) ?? undefined,
         areaName: areaId ? areaMap.get(areaId) : undefined,
       };
     });

--- a/everything-presence-mmwave-configurator/frontend/src/components/FirmwareUpdateSection.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/FirmwareUpdateSection.tsx
@@ -39,6 +39,7 @@ import { useDeviceMappings } from '../contexts/DeviceMappingsContext';
 import { DeviceMapping, discoverAndSaveMapping } from '../api/deviceMappings';
 import { fetchPolygonZonesFromDevice } from '../api/zones';
 import { compareVersions, getZoneMigrationThreshold, requiresZoneMigration } from '../utils/firmware';
+import { resolveEntityPrefix } from '../utils/entityUtils';
 import polygonMigrationGraphic from '../assets/polygon-migration.png';
 
 interface FirmwareUpdateSectionProps {
@@ -882,7 +883,10 @@ export const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({
 
     const mapping = backupMapping ?? (await getMapping(selectedDeviceId));
     const profileId = mapping?.profileId ?? getDeviceProfile(device)?.id ?? '';
-    const entityNamePrefix = device.entityNamePrefix || undefined;
+    const entityNamePrefix = resolveEntityPrefix({
+      mappingPrefix: mapping?.esphomeNodeName,
+      devicePrefix: device.entityNamePrefix,
+    }) ?? undefined;
 
     if (!profileId) {
       onErrorRef.current('Device profile not found. Run entity discovery to sync the device.');
@@ -1409,6 +1413,7 @@ export const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({
     const deviceName =
       backupMapping?.deviceName ??
       device.name ??
+      backupMapping?.esphomeNodeName ??
       device.entityNamePrefix ??
       device.model ??
       'Device';
@@ -1907,6 +1912,7 @@ export const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({
       const deviceName =
         backupMapping?.deviceName ??
         device.name ??
+        backupMapping?.esphomeNodeName ??
         device.entityNamePrefix ??
         device.model ??
         'Device';
@@ -1949,8 +1955,10 @@ export const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({
       }
 
       // Before restoring zones, wait for polygon entities to become available after the update.
-      const entityNamePrefix =
-        device.entityNamePrefix ?? result.mapping?.esphomeNodeName ?? backupMapping?.esphomeNodeName ?? null;
+      const entityNamePrefix = resolveEntityPrefix({
+        mappingPrefix: result.mapping?.esphomeNodeName ?? backupMapping?.esphomeNodeName,
+        devicePrefix: device.entityNamePrefix,
+      });
       if (entityNamePrefix) {
         const backupId = migrationBackupId ?? lastBackupId ?? latestBackup?.id ?? null;
         const backup = backupId ? zoneBackups.find((item) => item.id === backupId) ?? null : null;

--- a/everything-presence-mmwave-configurator/frontend/src/pages/LiveTrackingPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/LiveTrackingPage.tsx
@@ -30,6 +30,7 @@ import { useDeviceMappings, useDeviceMapping } from '../contexts/DeviceMappingsC
 import { getDeviceIconUrl } from '../utils/deviceIcon';
 import { resolveCoverageFov } from '../utils/coverage';
 import { usesPolygonOnlyZones } from '../utils/firmware';
+import { resolveEntityPrefix } from '../utils/entityUtils';
 import {
   buildCeilingExclusionZones,
   buildCeilingSliceZones,
@@ -321,10 +322,18 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
 
   // Derive entityNamePrefix for heatmap
   const entityNamePrefix = useMemo(() => {
-    if (selectedRoom?.entityNamePrefix) return selectedRoom.entityNamePrefix;
-    const device = devices.find(d => d.id === selectedRoom?.deviceId);
-    return device?.entityNamePrefix ?? null;
-  }, [selectedRoom, devices]);
+    return resolveEntityPrefix({
+      entityMappings: selectedRoom?.entityMappings,
+      entityNamePrefix: selectedRoom?.entityNamePrefix,
+      mappingPrefix: deviceMapping?.esphomeNodeName,
+      devicePrefix: selectedDevice?.entityNamePrefix,
+    });
+  }, [
+    deviceMapping?.esphomeNodeName,
+    selectedDevice?.entityNamePrefix,
+    selectedRoom?.entityMappings,
+    selectedRoom?.entityNamePrefix,
+  ]);
 
   // Heatmap data - skip entityMappings if device has valid mappings stored
   const { data: heatmapData, loading: heatmapLoading, refresh: refreshHeatmap } = useHeatmap({
@@ -572,12 +581,12 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
         return;
       }
 
-      // Try to get entityNamePrefix from the room, or look it up from devices
-      let entityNamePrefix = selectedRoom.entityNamePrefix;
-      if (!entityNamePrefix) {
-        const device = devices.find(d => d.id === selectedRoom.deviceId);
-        entityNamePrefix = device?.entityNamePrefix;
-      }
+      const entityNamePrefix = resolveEntityPrefix({
+        entityMappings: selectedRoom.entityMappings,
+        entityNamePrefix: selectedRoom.entityNamePrefix,
+        mappingPrefix: deviceMapping?.esphomeNodeName,
+        devicePrefix: selectedDevice?.entityNamePrefix,
+      });
 
       if (!entityNamePrefix) {
         return;
@@ -655,11 +664,12 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
         return;
       }
 
-      let entityNamePrefix = selectedRoom.entityNamePrefix;
-      if (!entityNamePrefix) {
-        const device = devices.find(d => d.id === selectedRoom.deviceId);
-        entityNamePrefix = device?.entityNamePrefix;
-      }
+      const entityNamePrefix = resolveEntityPrefix({
+        entityMappings: selectedRoom.entityMappings,
+        entityNamePrefix: selectedRoom.entityNamePrefix,
+        mappingPrefix: deviceMapping?.esphomeNodeName,
+        devicePrefix: selectedDevice?.entityNamePrefix,
+      });
 
       if (!entityNamePrefix) {
         setPolygonModeStatus({ supported: false, enabled: false, controllable: false });
@@ -722,11 +732,12 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
         return;
       }
 
-      let entityNamePrefix = selectedRoom.entityNamePrefix;
-      if (!entityNamePrefix) {
-        const device = devices.find(d => d.id === selectedRoom.deviceId);
-        entityNamePrefix = device?.entityNamePrefix;
-      }
+      const entityNamePrefix = resolveEntityPrefix({
+        entityMappings: selectedRoom.entityMappings,
+        entityNamePrefix: selectedRoom.entityNamePrefix,
+        mappingPrefix: deviceMapping?.esphomeNodeName,
+        devicePrefix: selectedDevice?.entityNamePrefix,
+      });
 
       if (!entityNamePrefix) {
         setPolygonZones([]);

--- a/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
@@ -27,6 +27,7 @@ import { getDeviceIconUrl } from '../utils/deviceIcon';
 import { resolveCoverageFov, resolveTrackingCoverageFov } from '../utils/coverage';
 import { formatSnapPresetLabel } from '../utils/snapLabels';
 import { usesPolygonOnlyZones } from '../utils/firmware';
+import { resolveEntityPrefix } from '../utils/entityUtils';
 
 interface WizardPageProps {
   devices: DiscoveredDevice[];
@@ -362,11 +363,13 @@ export const WizardPage: React.FC<WizardPageProps> = ({
         return;
       }
 
-      let entityNamePrefix = selectedRoom?.entityNamePrefix;
-      if (!entityNamePrefix) {
-        const device = devices.find(d => d.id === currentDeviceId);
-        entityNamePrefix = device?.entityNamePrefix;
-      }
+      const mapping = await getMapping(currentDeviceId);
+      const entityNamePrefix = resolveEntityPrefix({
+        entityMappings: selectedRoom?.entityMappings,
+        entityNamePrefix: selectedRoom?.entityNamePrefix,
+        mappingPrefix: mapping?.esphomeNodeName,
+        devicePrefix: devices.find((device) => device.id === currentDeviceId)?.entityNamePrefix,
+      });
 
       if (!entityNamePrefix) {
         setEntryZonesAvailable(null);
@@ -840,12 +843,13 @@ export const WizardPage: React.FC<WizardPageProps> = ({
         return;
       }
 
-      // Get entityNamePrefix from room or fall back to device
-      let entityNamePrefix = selectedRoom.entityNamePrefix;
-      if (!entityNamePrefix) {
-        const device = devices.find(d => d.id === selectedRoom.deviceId);
-        entityNamePrefix = device?.entityNamePrefix;
-      }
+      const mapping = await getMapping(selectedRoom.deviceId);
+      const entityNamePrefix = resolveEntityPrefix({
+        entityMappings: selectedRoom.entityMappings,
+        entityNamePrefix: selectedRoom.entityNamePrefix,
+        mappingPrefix: mapping?.esphomeNodeName,
+        devicePrefix: devices.find((device) => device.id === selectedRoom.deviceId)?.entityNamePrefix,
+      });
 
       if (!entityNamePrefix) {
         console.warn('Cannot load zones: entityNamePrefix not found for room or device');
@@ -922,11 +926,13 @@ export const WizardPage: React.FC<WizardPageProps> = ({
         return;
       }
 
-      let entityNamePrefix = selectedRoom.entityNamePrefix;
-      if (!entityNamePrefix) {
-        const device = devices.find(d => d.id === selectedRoom.deviceId);
-        entityNamePrefix = device?.entityNamePrefix;
-      }
+      const mapping = await getMapping(selectedRoom.deviceId);
+      const entityNamePrefix = resolveEntityPrefix({
+        entityMappings: selectedRoom.entityMappings,
+        entityNamePrefix: selectedRoom.entityNamePrefix,
+        mappingPrefix: mapping?.esphomeNodeName,
+        devicePrefix: devices.find((device) => device.id === selectedRoom.deviceId)?.entityNamePrefix,
+      });
 
       if (!entityNamePrefix) {
         setPolygonModeStatus({ supported: false, enabled: false, controllable: false });
@@ -1194,12 +1200,13 @@ export const WizardPage: React.FC<WizardPageProps> = ({
       return;
     }
 
-    // Get entityNamePrefix from room or device
-    let entityNamePrefix = selectedRoom?.entityNamePrefix;
-    if (!entityNamePrefix) {
-      const device = devices.find(d => d.id === deviceId);
-      entityNamePrefix = device?.entityNamePrefix;
-    }
+    const mapping = await getMapping(deviceId);
+    const entityNamePrefix = resolveEntityPrefix({
+      entityMappings: selectedRoom?.entityMappings,
+      entityNamePrefix: selectedRoom?.entityNamePrefix,
+      mappingPrefix: mapping?.esphomeNodeName,
+      devicePrefix: devices.find((device) => device.id === deviceId)?.entityNamePrefix,
+    });
 
     if (!entityNamePrefix) {
       setError('Cannot push zones: device entity name prefix not found');
@@ -1242,11 +1249,13 @@ export const WizardPage: React.FC<WizardPageProps> = ({
   const handleEnablePolygonMode = async () => {
     if (!selectedRoom?.deviceId || !selectedRoom?.profileId) return;
 
-    let entityNamePrefix = selectedRoom.entityNamePrefix;
-    if (!entityNamePrefix) {
-      const device = devices.find(d => d.id === selectedRoom.deviceId);
-      entityNamePrefix = device?.entityNamePrefix;
-    }
+    const mapping = await getMapping(selectedRoom.deviceId);
+    const entityNamePrefix = resolveEntityPrefix({
+      entityMappings: selectedRoom.entityMappings,
+      entityNamePrefix: selectedRoom.entityNamePrefix,
+      mappingPrefix: mapping?.esphomeNodeName,
+      devicePrefix: devices.find((device) => device.id === selectedRoom.deviceId)?.entityNamePrefix,
+    });
 
     if (!entityNamePrefix) {
       setError('Cannot enable polygon mode: device entity name prefix not found');

--- a/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
@@ -39,10 +39,11 @@ import {
 import { DisplaySettingsControls } from '../components/DisplaySettingsControls';
 import { useDisplaySettings } from '../hooks/useDisplaySettings';
 import { useIsMobileCanvas } from '../hooks/useMediaQuery';
-import { useDeviceMappings } from '../contexts/DeviceMappingsContext';
+import { useDeviceMapping, useDeviceMappings } from '../contexts/DeviceMappingsContext';
 import { getDeviceIconUrl } from '../utils/deviceIcon';
 import { resolveCoverageFov, resolveTrackingCoverageFov } from '../utils/coverage';
 import { usesPolygonOnlyZones } from '../utils/firmware';
+import { resolveEntityPrefix } from '../utils/entityUtils';
 import {
   buildCeilingExclusionZones,
   buildCeilingSliceZones,
@@ -244,6 +245,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
 
   // Device mappings context - used to check if device has valid entity mappings
   const { hasValidMappings, clearCache, getMapping } = useDeviceMappings();
+  const { mapping: selectedDeviceMapping } = useDeviceMapping(selectedRoom?.deviceId);
   const deviceHasValidMappings = selectedRoom?.deviceId ? hasValidMappings(selectedRoom.deviceId) : false;
   const hasPropLiveStateForRoom = Boolean(
     propLiveState && selectedRoom?.deviceId && propLiveState.deviceId === selectedRoom.deviceId
@@ -504,12 +506,12 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
 
       loadedRoomRef.current = selectedRoom.id;
 
-      // Try to get entityNamePrefix from the room, or look it up from devices
-      let entityNamePrefix = selectedRoom.entityNamePrefix;
-      if (!entityNamePrefix) {
-        const device = devices.find(d => d.id === selectedRoom.deviceId);
-        entityNamePrefix = device?.entityNamePrefix;
-      }
+      const entityNamePrefix = resolveEntityPrefix({
+        entityMappings: selectedRoom.entityMappings,
+        entityNamePrefix: selectedRoom.entityNamePrefix,
+        mappingPrefix: selectedDeviceMapping?.esphomeNodeName,
+        devicePrefix: selectedDevice?.entityNamePrefix,
+      });
 
       if (!entityNamePrefix) {
         return;
@@ -564,11 +566,12 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
         return;
       }
 
-      let entityNamePrefix = selectedRoom.entityNamePrefix;
-      if (!entityNamePrefix) {
-        const device = devices.find(d => d.id === selectedRoom.deviceId);
-        entityNamePrefix = device?.entityNamePrefix;
-      }
+      const entityNamePrefix = resolveEntityPrefix({
+        entityMappings: selectedRoom.entityMappings,
+        entityNamePrefix: selectedRoom.entityNamePrefix,
+        mappingPrefix: selectedDeviceMapping?.esphomeNodeName,
+        devicePrefix: selectedDevice?.entityNamePrefix,
+      });
 
       if (!entityNamePrefix) {
         setZoneAvailability({});
@@ -610,11 +613,12 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
         return;
       }
 
-      let entityNamePrefix = selectedRoom.entityNamePrefix;
-      if (!entityNamePrefix) {
-        const device = devices.find(d => d.id === selectedRoom.deviceId);
-        entityNamePrefix = device?.entityNamePrefix;
-      }
+      const entityNamePrefix = resolveEntityPrefix({
+        entityMappings: selectedRoom.entityMappings,
+        entityNamePrefix: selectedRoom.entityNamePrefix,
+        mappingPrefix: selectedDeviceMapping?.esphomeNodeName,
+        devicePrefix: selectedDevice?.entityNamePrefix,
+      });
 
       if (!entityNamePrefix) {
         setPolygonModeStatus({ supported: false, enabled: false, controllable: false });
@@ -658,11 +662,12 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
         return;
       }
 
-      let entityNamePrefix = selectedRoom.entityNamePrefix;
-      if (!entityNamePrefix) {
-        const device = devices.find(d => d.id === selectedRoom.deviceId);
-        entityNamePrefix = device?.entityNamePrefix;
-      }
+      const entityNamePrefix = resolveEntityPrefix({
+        entityMappings: selectedRoom.entityMappings,
+        entityNamePrefix: selectedRoom.entityNamePrefix,
+        mappingPrefix: selectedDeviceMapping?.esphomeNodeName,
+        devicePrefix: selectedDevice?.entityNamePrefix,
+      });
 
       if (!entityNamePrefix) {
         setPolygonZones([]);
@@ -783,14 +788,14 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
   const resolveZoneRestoreContext = useCallback(async () => {
     if (!selectedRoom?.deviceId) return null;
 
-    const device = devices.find((entry) => entry.id === selectedRoom.deviceId);
     const mapping = await getMapping(selectedRoom.deviceId);
     const profileId = selectedRoom.profileId || mapping?.profileId || null;
-    const entityNamePrefix =
-      selectedRoom.entityNamePrefix ||
-      device?.entityNamePrefix ||
-      mapping?.esphomeNodeName ||
-      null;
+    const entityNamePrefix = resolveEntityPrefix({
+      entityMappings: selectedRoom.entityMappings,
+      entityNamePrefix: selectedRoom.entityNamePrefix,
+      mappingPrefix: mapping?.esphomeNodeName,
+      devicePrefix: selectedDevice?.entityNamePrefix,
+    });
 
     if (!profileId) {
       setError('Device profile not found. Run entity discovery to sync the device.');
@@ -1048,11 +1053,12 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
   const handleTogglePolygonMode = async () => {
     if (!selectedRoom?.deviceId || !selectedRoom?.profileId) return;
 
-    let entityNamePrefix = selectedRoom.entityNamePrefix;
-    if (!entityNamePrefix) {
-      const device = devices.find(d => d.id === selectedRoom.deviceId);
-      entityNamePrefix = device?.entityNamePrefix;
-    }
+    const entityNamePrefix = resolveEntityPrefix({
+      entityMappings: selectedRoom.entityMappings,
+      entityNamePrefix: selectedRoom.entityNamePrefix,
+      mappingPrefix: selectedDeviceMapping?.esphomeNodeName,
+      devicePrefix: selectedDevice?.entityNamePrefix,
+    });
 
     if (!entityNamePrefix) return;
 
@@ -1175,12 +1181,12 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
     try {
       const effectiveProfile = selectedRoom.profileId ?? selectedProfileId;
 
-      // Get entityNamePrefix from room or device
-      let entityNamePrefix = selectedRoom.entityNamePrefix;
-      if (!entityNamePrefix) {
-        const device = devices.find(d => d.id === selectedRoom.deviceId);
-        entityNamePrefix = device?.entityNamePrefix;
-      }
+      const entityNamePrefix = resolveEntityPrefix({
+        entityMappings: selectedRoom.entityMappings,
+        entityNamePrefix: selectedRoom.entityNamePrefix,
+        mappingPrefix: selectedDeviceMapping?.esphomeNodeName,
+        devicePrefix: selectedDevice?.entityNamePrefix,
+      });
 
       if (selectedRoom.deviceId && effectiveProfile && entityNamePrefix) {
         // Skip entityMappings if device has valid mappings stored

--- a/everything-presence-mmwave-configurator/frontend/src/utils/entityUtils.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/entityUtils.ts
@@ -68,3 +68,21 @@ export const getEffectiveEntityPrefix = (
   const derived = deriveEntityPrefix(entityMappings);
   return derived || entityNamePrefix || null;
 };
+
+/**
+ * Resolve the best available entity prefix across room state, saved mappings,
+ * and legacy device discovery fields.
+ */
+export const resolveEntityPrefix = (args: {
+  entityMappings?: EntityMappings;
+  entityNamePrefix?: string | null;
+  mappingPrefix?: string | null;
+  devicePrefix?: string | null;
+}): string | null => {
+  const derived = deriveEntityPrefix(args.entityMappings);
+  const explicitPrefix = args.entityNamePrefix?.trim();
+  const mappingPrefix = args.mappingPrefix?.trim();
+  const devicePrefix = args.devicePrefix?.trim();
+
+  return derived || explicitPrefix || mappingPrefix || devicePrefix || null;
+};


### PR DESCRIPTION
- stop resolving `entityNamePrefix` during `/api/devices` discovery
- resolve prefixes in the frontend from saved mappings, room data, or legacy device data as needed

Fixes #361