### PR TITLE
Use device mappings as the runtime source of truth

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/domain/heatmapService.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/heatmapService.ts
@@ -109,7 +109,7 @@ export class HeatmapService {
    * @param deviceId - Device ID for device-level mapping lookup (preferred)
    */
   async generateHeatmap(
-    entityNamePrefix: string,
+    entityNamePrefix: string | undefined,
     hours: number,
     resolution: number,
     zones?: Zone[],
@@ -174,7 +174,7 @@ export class HeatmapService {
    * Uses device mappings first, then EntityResolver for legacy fallback.
    * Returns both the entity list and target info for correlation.
    */
-  private getTrackingEntities(entityNamePrefix: string, entityMappings?: EntityMappings, deviceId?: string): { entities: string[]; targetInfo: TargetEntityInfo[] } {
+  private getTrackingEntities(entityNamePrefix: string | undefined, entityMappings?: EntityMappings, deviceId?: string): { entities: string[]; targetInfo: TargetEntityInfo[] } {
     const entities: string[] = [];
     const targetInfo: TargetEntityInfo[] = [];
     const hasDeviceMapping = deviceId ? deviceMappingStorage.hasMapping(deviceId) : false;

--- a/everything-presence-mmwave-configurator/backend/src/ha/zoneReader.ts
+++ b/everything-presence-mmwave-configurator/backend/src/ha/zoneReader.ts
@@ -39,7 +39,7 @@ export class ZoneReader {
    */
   async readPolygonZones(
     entityMap: any,
-    entityNamePrefix: string,
+    entityNamePrefix: string | undefined,
     entityMappings?: EntityMappings,
     deviceId?: string
   ): Promise<ZonePolygon[]> {
@@ -190,7 +190,7 @@ export class ZoneReader {
    */
   async readZones(
     zoneMap: any,
-    entityNamePrefix: string,
+    entityNamePrefix: string | undefined,
     entityMappings?: EntityMappings,
     deviceId?: string
   ): Promise<ZoneRect[]> {

--- a/everything-presence-mmwave-configurator/backend/src/ha/zoneWriter.ts
+++ b/everything-presence-mmwave-configurator/backend/src/ha/zoneWriter.ts
@@ -110,7 +110,7 @@ export class ZoneWriter {
   async applyPolygonZones(
     entityMap: any,
     zones: ZonePolygon[],
-    entityNamePrefix: string,
+    entityNamePrefix: string | undefined,
     entityMappings?: EntityMappings,
     deviceId?: string
   ): Promise<ZoneWriteResult> {
@@ -240,7 +240,7 @@ export class ZoneWriter {
    */
   async setPolygonMode(
     entityMap: any,
-    entityNamePrefix: string,
+    entityNamePrefix: string | undefined,
     enabled: boolean,
     entityMappings?: EntityMappings,
     deviceId?: string
@@ -287,7 +287,7 @@ export class ZoneWriter {
   async applyZones(
     zoneMap: any,
     zones: ZoneRect[],
-    entityNamePrefix: string,
+    entityNamePrefix: string | undefined,
     entityMappings?: EntityMappings,
     deviceId?: string
   ): Promise<ZoneWriteResult> {

--- a/everything-presence-mmwave-configurator/backend/src/routes/devices.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/devices.ts
@@ -36,9 +36,20 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
     // Treat "unknown" as available for readiness purposes; it's common immediately after reboot.
     return normalized === 'unavailable';
   };
-  const resolveEntityNamePrefix = (deviceId: string, explicitPrefix?: string | null): string | null => {
-    return deviceEntityService.getDeviceNamePrefix(deviceId) ?? explicitPrefix?.trim() ?? null;
+  const parseEntityMappings = (value: unknown, logContext: string): EntityMappings | undefined => {
+    if (!value || typeof value !== 'string') {
+      return undefined;
+    }
+
+    try {
+      return JSON.parse(value) as EntityMappings;
+    } catch {
+      logger.warn({ logContext }, 'Invalid entityMappings JSON');
+      return undefined;
+    }
   };
+  const hasRuntimeMappings = (deviceId: string, entityMappings?: EntityMappings): boolean =>
+    deviceMappingStorage.hasMapping(deviceId) || !!entityMappings;
   const getDeviceFirmwareVersion = async (deviceId: string): Promise<string | undefined> => {
 
     try {
@@ -374,13 +385,8 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
   router.get('/:deviceId/zone-availability', async (req, res) => {
     const { deviceId } = req.params;
     const { profileId, entityMappings: entityMappingsJson } = req.query;
-    const entityNamePrefix = resolveEntityNamePrefix(
-      deviceId,
-      typeof req.query?.entityNamePrefix === 'string' ? req.query.entityNamePrefix : null
-    );
-
-    if (!profileId || !entityNamePrefix) {
-      return res.status(400).json({ message: 'profileId and entityNamePrefix are required' });
+    if (!profileId) {
+      return res.status(400).json({ message: 'profileId is required' });
     }
 
     const profile = profileLoader.getProfileById(profileId as string);
@@ -394,13 +400,12 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
     }
 
     // Parse entityMappings if provided (JSON string in query param)
-    let entityMappings: EntityMappings | undefined;
-    if (entityMappingsJson && typeof entityMappingsJson === 'string') {
-      try {
-        entityMappings = JSON.parse(entityMappingsJson);
-      } catch {
-        logger.warn('Invalid entityMappings JSON in zone-availability query');
-      }
+    const entityMappings = parseEntityMappings(entityMappingsJson, 'zone-availability');
+    if (!hasRuntimeMappings(deviceId, entityMappings)) {
+      return res.status(409).json({
+        message: 'Device mapping not found. Run entity re-sync to create mappings.',
+        code: 'MAPPING_NOT_FOUND',
+      });
     }
 
     // Check if device has device-level mappings (preferred)
@@ -414,7 +419,6 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
 
     try {
       const entityRegistry = await readTransport.listEntityRegistry();
-      const prefix = entityNamePrefix as string;
 
       const availability: Record<string, { enabled: boolean; disabledBy: string | null; status: 'enabled' | 'disabled' | 'unavailable' | 'unknown' }> = {};
       const polygonAvailability: Record<string, { enabled: boolean; disabledBy: string | null; status: 'enabled' | 'disabled' | 'unavailable' | 'unknown' }> = {};
@@ -422,13 +426,13 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
       const zoneEntitiesByKey = new Map<string, string[]>();
       const polygonEntitiesByKey = new Map<string, string[]>();
 
-      // Helper to resolve zone entity set - tries device mapping first, then legacy
+      // Helper to resolve zone entity set - tries device mapping first, then room-stored mappings.
       const resolveZoneSet = (type: 'regular' | 'exclusion' | 'entry', index: number, groupKey: 'zoneConfigEntities' | 'exclusionZoneConfigEntities' | 'entryZoneConfigEntities', key: string, mapping?: Record<string, string>) => {
         if (hasDeviceMapping) {
           const zoneSet = deviceEntityService.getZoneEntitySet(deviceId, type, index);
           if (zoneSet) return zoneSet;
         }
-        return EntityResolver.resolveZoneEntitySet(entityMappings, prefix, groupKey, key, mapping);
+        return EntityResolver.resolveZoneEntitySet(entityMappings, undefined, groupKey, key, mapping);
       };
 
       // Helper to extract zone index from key like "zone1" or "entry2"
@@ -488,7 +492,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
           const entityId = deviceEntityService.getPolygonZoneEntity(deviceId, type, index);
           if (entityId) return entityId;
         }
-        return EntityResolver.resolvePolygonZoneEntity(entityMappings, prefix, groupKey, key, template);
+        return EntityResolver.resolvePolygonZoneEntity(entityMappings, undefined, groupKey, key, template);
       };
 
       const addPolygonAvailability = (
@@ -579,7 +583,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
       if (!polygonZone1Entity && zoneMap.polygonZoneEntities?.zone1) {
         polygonZone1Entity = EntityResolver.resolvePolygonZoneEntity(
           entityMappings,
-          prefix,
+          undefined,
           'polygonZoneEntities',
           'zone1',
           zoneMap.polygonZoneEntities.zone1
@@ -598,7 +602,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
         if (!polygonEntry1Entity && zoneMap.polygonEntryEntities?.entry1) {
           polygonEntry1Entity = EntityResolver.resolvePolygonZoneEntity(
             entityMappings,
-            prefix,
+            undefined,
             'polygonEntryEntities',
             'entry1',
             zoneMap.polygonEntryEntities.entry1
@@ -619,7 +623,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
           const entryEntities = zoneMap.entryZoneConfigEntities.entry1 as Record<string, string>;
           const entryZoneSet = EntityResolver.resolveZoneEntitySet(
             entityMappings,
-            prefix,
+            undefined,
             'entryZoneConfigEntities',
             'entry1',
             entryEntities
@@ -642,13 +646,8 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
   router.get('/:deviceId/zones', async (req, res) => {
     const { deviceId } = req.params;
     const { profileId, entityMappings: entityMappingsJson } = req.query;
-    const entityNamePrefix = resolveEntityNamePrefix(
-      deviceId,
-      typeof req.query?.entityNamePrefix === 'string' ? req.query.entityNamePrefix : null
-    );
-
-    if (!profileId || !entityNamePrefix) {
-      return res.status(400).json({ message: 'profileId and entityNamePrefix are required' });
+    if (!profileId) {
+      return res.status(400).json({ message: 'profileId is required' });
     }
 
     const profile = profileLoader.getProfileById(profileId as string);
@@ -662,17 +661,16 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
     }
 
     // Parse entityMappings if provided (JSON string in query param)
-    let entityMappings: EntityMappings | undefined;
-    if (entityMappingsJson && typeof entityMappingsJson === 'string') {
-      try {
-        entityMappings = JSON.parse(entityMappingsJson);
-      } catch {
-        logger.warn('Invalid entityMappings JSON in query');
-      }
+    const entityMappings = parseEntityMappings(entityMappingsJson, 'zones');
+    if (!hasRuntimeMappings(deviceId, entityMappings)) {
+      return res.status(409).json({
+        message: 'Device mapping not found. Run entity re-sync to create mappings.',
+        code: 'MAPPING_NOT_FOUND',
+      });
     }
 
     try {
-      const zones = await zoneReader.readZones(zoneMap, entityNamePrefix, entityMappings, deviceId);
+      const zones = await zoneReader.readZones(zoneMap, undefined, entityMappings, deviceId);
       return res.json({ zones });
     } catch (error) {
       logger.error({ error }, 'Failed to read zones');
@@ -683,18 +681,17 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
   router.post('/:deviceId/zones', async (req, res) => {
     const { deviceId } = req.params;
     const profileId = (req.body?.profileId as string | undefined) ?? (req.body?.profile_id as string | undefined);
-    const entityNamePrefix = resolveEntityNamePrefix(
-      deviceId,
-      (req.body?.entityNamePrefix as string | undefined) ?? (req.body?.entity_name_prefix as string | undefined) ?? null
-    );
     const zones = (req.body?.zones as RoomConfig['zones']) ?? [];
     const entityMappings = req.body?.entityMappings as EntityMappings | undefined;
 
     if (!profileId) {
       return res.status(400).json({ message: 'profileId is required' });
     }
-    if (!entityNamePrefix) {
-      return res.status(400).json({ message: 'entityNamePrefix is required' });
+    if (!hasRuntimeMappings(deviceId, entityMappings)) {
+      return res.status(409).json({
+        message: 'Device mapping not found. Run entity re-sync to create mappings.',
+        code: 'MAPPING_NOT_FOUND',
+      });
     }
     const profile = profileLoader.getProfileById(profileId);
     if (!profile) {
@@ -707,7 +704,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
     }
 
     try {
-      const result = await zoneWriter.applyZones(zoneMap, zones, entityNamePrefix, entityMappings, deviceId);
+      const result = await zoneWriter.applyZones(zoneMap, zones, undefined, entityMappings, deviceId);
       return res.json({ ok: result.ok, warnings: result.failures });
     } catch (error) {
       logger.error({ error }, 'Failed to apply zones');
@@ -723,13 +720,8 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
   router.get('/:deviceId/polygon-mode', async (req, res) => {
     const { deviceId } = req.params;
     const { profileId, entityMappings: entityMappingsJson } = req.query;
-    const entityNamePrefix = resolveEntityNamePrefix(
-      deviceId,
-      typeof req.query?.entityNamePrefix === 'string' ? req.query.entityNamePrefix : null
-    );
-
-    if (!profileId || !entityNamePrefix) {
-      return res.status(400).json({ message: 'profileId and entityNamePrefix are required' });
+    if (!profileId) {
+      return res.status(400).json({ message: 'profileId is required' });
     }
 
     const profile = profileLoader.getProfileById(profileId as string);
@@ -762,13 +754,12 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
     const hasDeviceMapping = deviceMappingStorage.hasMapping(deviceId);
 
     // Parse entityMappings if provided (JSON string in query param)
-    let entityMappings: EntityMappings | undefined;
-    if (entityMappingsJson && typeof entityMappingsJson === 'string') {
-      try {
-        entityMappings = JSON.parse(entityMappingsJson);
-      } catch {
-        logger.warn('Invalid entityMappings JSON in polygon-mode query');
-      }
+    const entityMappings = parseEntityMappings(entityMappingsJson, 'polygon-mode');
+    if (!hasRuntimeMappings(deviceId, entityMappings)) {
+      return res.status(409).json({
+        message: 'Device mapping not found. Run entity re-sync to create mappings.',
+        code: 'MAPPING_NOT_FOUND',
+      });
     }
 
     try {
@@ -780,7 +771,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
       if (!switchEntityId) {
         switchEntityId = EntityResolver.resolve(
           entityMappings,
-          entityNamePrefix,
+          undefined,
           'polygonZonesEnabledEntity',
           entityTemplate
         );
@@ -795,7 +786,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
         if (!polygonZoneEntity && entityMap?.polygonZoneEntities?.zone1) {
           polygonZoneEntity = EntityResolver.resolvePolygonZoneEntity(
             entityMappings,
-            entityNamePrefix,
+            undefined,
             'polygonZoneEntities',
             'zone1',
             entityMap.polygonZoneEntities.zone1
@@ -814,7 +805,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
         return res.json({ supported: true, enabled: true, controllable: false });
       }
 
-      logger.info({ entityId: switchEntityId, entityNamePrefix, usedDeviceMapping: hasDeviceMapping }, 'Checking polygon mode entity');
+      logger.info({ entityId: switchEntityId, usedDeviceMapping: hasDeviceMapping }, 'Checking polygon mode entity');
 
       const states = await readTransport.getStates([switchEntityId]);
       const state = states.get(switchEntityId);
@@ -842,7 +833,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
         if (!polygonZoneEntity && entityMap?.polygonZoneEntities?.zone1) {
           polygonZoneEntity = EntityResolver.resolvePolygonZoneEntity(
             entityMappings,
-            entityNamePrefix,
+            undefined,
             'polygonZoneEntities',
             'zone1',
             entityMap.polygonZoneEntities.zone1
@@ -882,15 +873,17 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
   router.post('/:deviceId/polygon-mode', async (req, res) => {
     const { deviceId } = req.params;
     const profileId = req.body?.profileId as string | undefined;
-    const entityNamePrefix = resolveEntityNamePrefix(
-      deviceId,
-      (req.body?.entityNamePrefix as string | undefined) ?? null
-    );
     const enabled = req.body?.enabled as boolean | undefined;
     const entityMappings = req.body?.entityMappings as EntityMappings | undefined;
 
-    if (!profileId || !entityNamePrefix || enabled === undefined) {
-      return res.status(400).json({ message: 'profileId, entityNamePrefix, and enabled are required' });
+    if (!profileId || enabled === undefined) {
+      return res.status(400).json({ message: 'profileId and enabled are required' });
+    }
+    if (!hasRuntimeMappings(deviceId, entityMappings)) {
+      return res.status(409).json({
+        message: 'Device mapping not found. Run entity re-sync to create mappings.',
+        code: 'MAPPING_NOT_FOUND',
+      });
     }
 
     const profile = profileLoader.getProfileById(profileId);
@@ -918,7 +911,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
         return res.json({ ok: true, enabled: true });
       }
 
-      await zoneWriter.setPolygonMode(entityMap, entityNamePrefix, enabled, entityMappings, deviceId);
+      await zoneWriter.setPolygonMode(entityMap, undefined, enabled, entityMappings, deviceId);
       return res.json({ ok: true, enabled });
     } catch (error) {
       logger.error({ error }, 'Failed to set polygon mode');
@@ -932,13 +925,8 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
   router.get('/:deviceId/polygon-zones', async (req, res) => {
     const { deviceId } = req.params;
     const { profileId, entityMappings: entityMappingsJson } = req.query;
-    const entityNamePrefix = resolveEntityNamePrefix(
-      deviceId,
-      typeof req.query?.entityNamePrefix === 'string' ? req.query.entityNamePrefix : null
-    );
-
-    if (!profileId || !entityNamePrefix) {
-      return res.status(400).json({ message: 'profileId and entityNamePrefix are required' });
+    if (!profileId) {
+      return res.status(400).json({ message: 'profileId is required' });
     }
 
     const profile = profileLoader.getProfileById(profileId as string);
@@ -949,17 +937,16 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
     const entityMap = profile.entityMap as any;
 
     // Parse entityMappings if provided (JSON string in query param)
-    let entityMappings: EntityMappings | undefined;
-    if (entityMappingsJson && typeof entityMappingsJson === 'string') {
-      try {
-        entityMappings = JSON.parse(entityMappingsJson);
-      } catch {
-        logger.warn('Invalid entityMappings JSON in query');
-      }
+    const entityMappings = parseEntityMappings(entityMappingsJson, 'polygon-zones');
+    if (!hasRuntimeMappings(deviceId, entityMappings)) {
+      return res.status(409).json({
+        message: 'Device mapping not found. Run entity re-sync to create mappings.',
+        code: 'MAPPING_NOT_FOUND',
+      });
     }
 
     try {
-      const zones = await zoneReader.readPolygonZones(entityMap, entityNamePrefix, entityMappings, deviceId);
+      const zones = await zoneReader.readPolygonZones(entityMap, undefined, entityMappings, deviceId);
       return res.json({ zones });
     } catch (error) {
       logger.error({ error }, 'Failed to read polygon zones');
@@ -973,15 +960,17 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
   router.post('/:deviceId/polygon-zones', async (req, res) => {
     const { deviceId } = req.params;
     const profileId = req.body?.profileId as string | undefined;
-    const entityNamePrefix = resolveEntityNamePrefix(
-      deviceId,
-      (req.body?.entityNamePrefix as string | undefined) ?? null
-    );
     const zones = req.body?.zones as ZonePolygon[] | undefined;
     const entityMappings = req.body?.entityMappings as EntityMappings | undefined;
 
-    if (!profileId || !entityNamePrefix) {
-      return res.status(400).json({ message: 'profileId and entityNamePrefix are required' });
+    if (!profileId) {
+      return res.status(400).json({ message: 'profileId is required' });
+    }
+    if (!hasRuntimeMappings(deviceId, entityMappings)) {
+      return res.status(409).json({
+        message: 'Device mapping not found. Run entity re-sync to create mappings.',
+        code: 'MAPPING_NOT_FOUND',
+      });
     }
 
     const profile = profileLoader.getProfileById(profileId);
@@ -1010,7 +999,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
           type === 'polygon' ? 'polygonZoneEntities'
             : type === 'polygonExclusion' ? 'polygonExclusionEntities'
               : 'polygonEntryEntities';
-        return EntityResolver.resolvePolygonZoneEntity(entityMappings, entityNamePrefix, groupKey, key, template);
+        return EntityResolver.resolvePolygonZoneEntity(entityMappings, undefined, groupKey, key, template);
       };
 
       const polygonMap = entityMap?.polygonZoneEntities as Record<string, string> | undefined;
@@ -1100,7 +1089,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
         }
       }
 
-      const result = await zoneWriter.applyPolygonZones(entityMap, zones ?? [], entityNamePrefix, entityMappings, deviceId);
+      const result = await zoneWriter.applyPolygonZones(entityMap, zones ?? [], undefined, entityMappings, deviceId);
       const combinedWarnings = [...warnings, ...result.failures];
       return res.json({ ok: result.ok, warnings: combinedWarnings });
     } catch (error) {

--- a/everything-presence-mmwave-configurator/backend/src/routes/heatmap.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/heatmap.ts
@@ -5,6 +5,7 @@ import { ZoneReader } from '../ha/zoneReader';
 import type { IHaReadTransport } from '../ha/readTransport';
 import type { HaAuthConfig } from '../ha/types';
 import type { EntityMappings } from '../domain/types';
+import { deviceMappingStorage } from '../config/deviceMappingStorage';
 import { logger } from '../logger';
 
 export interface HeatmapRouterDependencies {
@@ -25,10 +26,10 @@ export const createHeatmapRouter = (deps: HeatmapRouterDependencies): Router => 
    * Generate heatmap data from HA history.
    */
   router.get('/:deviceId/heatmap', async (req, res) => {
-    const { profileId, entityNamePrefix, hours, resolution, entityMappings: entityMappingsJson } = req.query;
+    const { profileId, hours, resolution, entityMappings: entityMappingsJson } = req.query;
 
-    if (!profileId || !entityNamePrefix) {
-      return res.status(400).json({ message: 'profileId and entityNamePrefix are required' });
+    if (!profileId) {
+      return res.status(400).json({ message: 'profileId is required' });
     }
 
     const profile = profileLoader.getProfileById(profileId as string);
@@ -58,13 +59,16 @@ export const createHeatmapRouter = (deps: HeatmapRouterDependencies): Router => 
     try {
       // Get deviceId from route params
       const { deviceId } = req.params;
+      if (!deviceMappingStorage.hasMapping(deviceId) && !entityMappings) {
+        return res.status(409).json({ message: 'Device mapping not found. Run entity re-sync to create mappings.', code: 'MAPPING_NOT_FOUND' });
+      }
 
       // Get current zones for zone stats calculation
       const entityMap = profile.entityMap as Record<string, unknown>;
       let zones;
       try {
-        const polygonZones = await zoneReader.readPolygonZones(entityMap, entityNamePrefix as string, entityMappings, deviceId);
-        const rectZones = await zoneReader.readZones(entityMap, entityNamePrefix as string, entityMappings, deviceId);
+        const polygonZones = await zoneReader.readPolygonZones(entityMap, undefined, entityMappings, deviceId);
+        const rectZones = await zoneReader.readZones(entityMap, undefined, entityMappings, deviceId);
         // Deduplicate zones by ID (prefer polygon zones if both exist)
         const zoneMap = new Map<string, typeof polygonZones[0] | typeof rectZones[0]>();
         for (const zone of rectZones) {
@@ -80,7 +84,7 @@ export const createHeatmapRouter = (deps: HeatmapRouterDependencies): Router => 
       }
 
       const heatmap = await heatmapService.generateHeatmap(
-        entityNamePrefix as string,
+        undefined,
         hoursNum,
         resolutionNum,
         zones,

--- a/everything-presence-mmwave-configurator/backend/src/routes/live.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/live.ts
@@ -23,7 +23,7 @@ export function createLiveRouter(
   router.get('/:deviceId/state', async (req, res) => {
     try {
       const { deviceId } = req.params;
-      const { profileId, entityNamePrefix, entityMappings: entityMappingsJson } = req.query;
+      const { profileId, entityMappings: entityMappingsJson } = req.query;
 
       if (!deviceId) {
         return res.status(400).json({ error: 'deviceId required' });
@@ -32,14 +32,6 @@ export function createLiveRouter(
       const profile = profileId ? profileLoader.getProfileById(profileId as string) : null;
       if (!profile) {
         return res.status(404).json({ error: 'Profile not found' });
-      }
-
-      // Use entityNamePrefix if provided, otherwise try to extract from deviceId
-      const deviceName = (entityNamePrefix as string) ||
-        deviceId.replace(/^(sensor|binary_sensor|number)\./, '').replace(/_occupancy$|_mmwave_target_distance$/, '');
-
-      if (!deviceName) {
-        return res.status(400).json({ error: 'Could not determine entity name prefix' });
       }
 
       // Parse entityMappings if provided (JSON string in query param)
@@ -52,13 +44,14 @@ export function createLiveRouter(
         }
       }
 
-      // Check if device has device-level mappings (preferred)
       const hasDeviceMapping = deviceMappingStorage.hasMapping(deviceId);
       const hasMappings = hasDeviceMapping || !!entityMappings;
 
-      // Log warning if no mappings found
       if (!hasMappings) {
-        logger.warn({ deviceId, profileId }, 'No device mappings found - entity resolution may fail');
+        return res.status(409).json({
+          error: 'Device mapping not found. Run entity re-sync to create mappings.',
+          code: 'MAPPING_NOT_FOUND',
+        });
       }
 
       const liveState: any = {
@@ -103,16 +96,15 @@ export function createLiveRouter(
         return null;
       };
 
-      // Helper to get entity state by pattern - tries device mapping first, then legacy
+      // Helper to get entity state by mapping key, with room-stored mappings as a compatibility layer.
       const getEntityState = async (mappingKey: string, template: string | null) => {
         // Try device-level mapping first (preferred)
         let entityId: string | null = null;
         if (hasDeviceMapping) {
           entityId = deviceEntityService.getEntityId(deviceId, mappingKey);
         }
-        // Fallback to legacy resolution
         if (!entityId) {
-          entityId = EntityResolver.resolve(entityMappings, deviceName, mappingKey, template);
+          entityId = EntityResolver.resolve(entityMappings, undefined, mappingKey, template);
         }
         if (!entityId) return null;
         try {
@@ -240,7 +232,7 @@ export function createLiveRouter(
           return value;
         };
 
-        // Helper to get target entity state - tries device mapping first, then legacy
+        // Helper to get target entity state - tries device mapping first, then room-stored mappings.
         const getTargetState = async (targetNum: number, property: 'x' | 'y' | 'speed' | 'resolution' | 'angle' | 'distance' | 'active') => {
           let entityId: string | null = null;
           // Try device-level mapping first
@@ -250,9 +242,8 @@ export function createLiveRouter(
               entityId = targetSet[property] as string;
             }
           }
-          // Fallback to legacy resolution
           if (!entityId) {
-            entityId = EntityResolver.resolveTargetEntity(entityMappings, deviceName, targetNum, property);
+            entityId = EntityResolver.resolveTargetEntity(entityMappings, undefined, targetNum, property);
           }
           if (!entityId) return null;
           try {

--- a/everything-presence-mmwave-configurator/backend/src/routes/liveWs.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/liveWs.ts
@@ -33,7 +33,7 @@ export function createLiveWebSocketServer(
         const message = JSON.parse(data.toString());
 
         if (message.type === 'subscribe') {
-          const { deviceId, profileId, entityNamePrefix, entityMappings } = message;
+          const { deviceId, profileId, entityMappings } = message;
 
           if (!deviceId || !profileId) {
             ws.send(JSON.stringify({ type: 'error', error: 'deviceId and profileId required' }));
@@ -43,17 +43,6 @@ export function createLiveWebSocketServer(
           const profile = profileLoader.getProfileById(profileId);
           if (!profile) {
             ws.send(JSON.stringify({ type: 'error', error: 'Profile not found' }));
-            return;
-          }
-
-          // Use entityNamePrefix if provided, otherwise try to extract from deviceId
-          const deviceName = entityNamePrefix ||
-            deviceId
-              .replace(/^(sensor|binary_sensor|number)\./, '')
-              .replace(/_occupancy$|_mmwave_target_distance$/, '');
-
-          if (!deviceName) {
-            ws.send(JSON.stringify({ type: 'error', error: 'Could not determine entity name prefix' }));
             return;
           }
 
@@ -71,20 +60,16 @@ export function createLiveWebSocketServer(
             }
           }
 
-          // Check if device has device-level mappings (preferred)
           const hasDeviceMapping = deviceMappingStorage.hasMapping(deviceId);
-
-          // Signal MAPPING_NOT_FOUND if no device mapping and no legacy mappings provided
           const hasMappings = hasDeviceMapping || !!parsedMappings;
           if (!hasMappings) {
-            logger.warn({ deviceId, profileId }, 'No device mappings found - entity resolution may fail');
-            // Send warning to client - they should run entity discovery
             ws.send(JSON.stringify({
-              type: 'warning',
+              type: 'error',
               code: 'MAPPING_NOT_FOUND',
               message: 'No entity mappings found for this device. Run entity discovery to auto-match entities.',
               deviceId,
             }));
+            return;
           }
 
           // Build list of entity IDs to monitor using EntityResolver
@@ -92,16 +77,15 @@ export function createLiveWebSocketServer(
           const entityKeysById = new Map<string, string>();
           const entityMap = profile.entityMap as any;
 
-          // Helper to resolve entity ID - tries device mapping first, then legacy
+          // Helper to resolve entity ID - tries device mapping first, then room-stored mappings.
           const addEntity = (mappingKey: string, pattern: string | null | undefined) => {
             let entityId: string | null = null;
             // Try device-level mapping first
             if (hasDeviceMapping) {
               entityId = deviceEntityService.getEntityId(deviceId, mappingKey);
             }
-            // Fallback to legacy resolution
             if (!entityId) {
-              entityId = EntityResolver.resolve(parsedMappings, deviceName, mappingKey, pattern);
+              entityId = EntityResolver.resolve(parsedMappings, undefined, mappingKey, pattern);
             }
             if (entityId) {
               entityIds.add(entityId);
@@ -182,8 +166,7 @@ export function createLiveWebSocketServer(
             }
           }
 
-          // Subscribe to target position entities (target_1, target_2, target_3)
-          // Tries device mapping first, then legacy resolution
+          // Subscribe to target position entities (target_1, target_2, target_3).
           for (let i = 1; i <= 3; i++) {
             const targetProps: Array<'x' | 'y' | 'distance' | 'speed' | 'angle' | 'resolution' | 'active'> =
               ['x', 'y', 'distance', 'speed', 'angle', 'resolution', 'active'];
@@ -200,9 +183,8 @@ export function createLiveWebSocketServer(
               if (targetSet && targetSet[prop]) {
                 entityId = targetSet[prop] as string;
               }
-              // Fallback to legacy resolution
               if (!entityId) {
-                entityId = EntityResolver.resolveTargetEntity(parsedMappings, deviceName, i, prop);
+                entityId = EntityResolver.resolveTargetEntity(parsedMappings, undefined, i, prop);
               }
               if (entityId) {
                 entityIds.add(entityId);

--- a/everything-presence-mmwave-configurator/backend/src/routes/zoneBackups.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/zoneBackups.ts
@@ -112,7 +112,6 @@ export const createZoneBackupsRouter = (deps: ZoneBackupsRouterDependencies): Ro
   router.post('/', async (req, res) => {
     const deviceId = req.body?.deviceId as string | undefined;
     const profileId = req.body?.profileId as string | undefined;
-    const entityNamePrefix = req.body?.entityNamePrefix as string | undefined;
     const entityMappings = parseEntityMappings(req.body?.entityMappings);
 
     if (!deviceId) {
@@ -127,19 +126,16 @@ export const createZoneBackupsRouter = (deps: ZoneBackupsRouterDependencies): Ro
       return res.status(404).json({ message: 'Profile not found' });
     }
 
-    const prefix =
-      deviceEntityService.getDeviceNamePrefix(deviceId) ||
-      entityNamePrefix ||
-      undefined;
-    if (!prefix) {
-      return res.status(400).json({ message: 'entityNamePrefix is required when device mapping is missing' });
+    const hasDeviceMapping = deviceMappingStorage.hasMapping(deviceId);
+    if (!hasDeviceMapping && !entityMappings) {
+      return res.status(409).json({ message: 'Device mapping not found. Run entity re-sync to create mappings.', code: 'MAPPING_NOT_FOUND' });
     }
 
     try {
-      const polygonZones = await zoneReader.readPolygonZones(profile.entityMap as any, prefix, entityMappings, deviceId);
+      const polygonZones = await zoneReader.readPolygonZones(profile.entityMap as any, undefined, entityMappings, deviceId);
       const zones = polygonZones.length > 0
         ? polygonZones
-        : await zoneReader.readZones(profile.entityMap as any, prefix, entityMappings, deviceId);
+        : await zoneReader.readZones(profile.entityMap as any, undefined, entityMappings, deviceId);
       const mapping = deviceMappingStorage.getMapping(deviceId);
       const backup: ZoneBackup = {
         id: generateId(),
@@ -153,7 +149,7 @@ export const createZoneBackupsRouter = (deps: ZoneBackupsRouterDependencies): Ro
         zones,
         zoneLabels: mapping?.zoneLabels ?? undefined,
         metadata: {
-          entityNamePrefix: prefix,
+          entityNamePrefix: deviceEntityService.getDeviceNamePrefix(deviceId) ?? undefined,
           notes: polygonZones.length > 0 ? 'polygon' : 'rectangular',
         },
       };
@@ -225,7 +221,6 @@ export const createZoneBackupsRouter = (deps: ZoneBackupsRouterDependencies): Ro
 
     const deviceId = (req.body?.deviceId as string | undefined) ?? backup.deviceId;
     const profileId = (req.body?.profileId as string | undefined) ?? backup.profileId;
-    const entityNamePrefix = req.body?.entityNamePrefix as string | undefined;
     const entityMappings = parseEntityMappings(req.body?.entityMappings);
 
     if (!deviceId) {
@@ -245,12 +240,9 @@ export const createZoneBackupsRouter = (deps: ZoneBackupsRouterDependencies): Ro
       return res.status(409).json({ message: 'Polygon zones are not supported for this device profile' });
     }
 
-    const prefix =
-      deviceEntityService.getDeviceNamePrefix(deviceId) ||
-      entityNamePrefix ||
-      undefined;
-    if (!prefix) {
-      return res.status(400).json({ message: 'entityNamePrefix is required when device mapping is missing' });
+    const hasDeviceMapping = deviceMappingStorage.hasMapping(deviceId);
+    if (!hasDeviceMapping && !entityMappings) {
+      return res.status(409).json({ message: 'Device mapping not found. Run entity re-sync to create mappings.', code: 'MAPPING_NOT_FOUND' });
     }
 
     const limits = profile.limits ?? {};
@@ -319,8 +311,8 @@ export const createZoneBackupsRouter = (deps: ZoneBackupsRouterDependencies): Ro
     ].filter((zone) => isValidPolygon(zone.vertices));
 
     try {
-      await zoneWriter.setPolygonMode(profile.entityMap as any, prefix, true, entityMappings, deviceId);
-      const result = await zoneWriter.applyPolygonZones(profile.entityMap as any, polygons, prefix, entityMappings, deviceId);
+      await zoneWriter.setPolygonMode(profile.entityMap as any, undefined, true, entityMappings, deviceId);
+      const result = await zoneWriter.applyPolygonZones(profile.entityMap as any, polygons, undefined, entityMappings, deviceId);
 
       const warnings = [...result.failures];
       if (backup.zoneLabels) {

--- a/everything-presence-mmwave-configurator/frontend/src/App.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/App.tsx
@@ -104,14 +104,11 @@ function App() {
       return;
     }
 
-    const entityParam = selectedRoom.entityNamePrefix
-      ? `&entityNamePrefix=${encodeURIComponent(selectedRoom.entityNamePrefix)}`
-      : '';
     const mappingsParam = selectedRoom.entityMappings
       ? `&entityMappings=${encodeURIComponent(JSON.stringify(selectedRoom.entityMappings))}`
       : '';
     const restUrl = ingressAware(
-      `api/live/${selectedRoom.deviceId}/state?profileId=${selectedProfile.id}${entityParam}${mappingsParam}`
+      `api/live/${selectedRoom.deviceId}/state?profileId=${selectedProfile.id}${mappingsParam}`
     );
 
     try {
@@ -172,7 +169,6 @@ function App() {
               type: 'subscribe',
               deviceId: selectedRoom.deviceId,
               profileId: selectedProfile.id,
-              entityNamePrefix: selectedRoom.entityNamePrefix,
               entityMappings: selectedRoom.entityMappings,
             }),
           );
@@ -182,7 +178,7 @@ function App() {
           try {
             const message = JSON.parse(event.data);
 
-            if (message.type === 'warning' && message.code === 'MAPPING_NOT_FOUND') {
+            if ((message.type === 'warning' || message.type === 'error') && message.code === 'MAPPING_NOT_FOUND') {
               // Device has no entity mappings - user should run entity discovery
               console.warn('MAPPING_NOT_FOUND:', message.message);
               // Set error to prompt user to configure entity mappings

--- a/everything-presence-mmwave-configurator/frontend/src/api/client.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/api/client.ts
@@ -240,17 +240,19 @@ export const deleteCustomFurniture = async (id: string) => {
 export const fetchHeatmap = async (
   deviceId: string,
   profileId: string,
-  entityNamePrefix: string,
+  entityNamePrefix: string | null,
   hours: number = 24,
   resolution: number = 400,
   entityMappings?: EntityMappings
 ): Promise<HeatmapResponse> => {
   const params = new URLSearchParams({
     profileId,
-    entityNamePrefix,
     hours: hours.toString(),
     resolution: resolution.toString(),
   });
+  if (entityNamePrefix) {
+    params.set('entityNamePrefix', entityNamePrefix);
+  }
   if (entityMappings) {
     params.set('entityMappings', JSON.stringify(entityMappings));
   }

--- a/everything-presence-mmwave-configurator/frontend/src/hooks/useHeatmap.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/hooks/useHeatmap.ts
@@ -26,7 +26,7 @@ export const useHeatmap = (options: UseHeatmapOptions): UseHeatmapResult => {
   const { deviceId, profileId, entityNamePrefix, entityMappings, hours, enabled } = options;
 
   const load = useCallback(async () => {
-    if (!enabled || !deviceId || !profileId || !entityNamePrefix) {
+    if (!enabled || !deviceId || !profileId) {
       setData(null);
       return;
     }

--- a/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
@@ -364,17 +364,14 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
 
     let cancelled = false;
 
-    const loadLiveState = async () => {
+      const loadLiveState = async () => {
       try {
-        const entityParam = selectedRoom.entityNamePrefix
-          ? `&entityNamePrefix=${encodeURIComponent(selectedRoom.entityNamePrefix)}`
-          : '';
         const mappingsParam = selectedRoom.entityMappings
           ? `&entityMappings=${encodeURIComponent(JSON.stringify(selectedRoom.entityMappings))}`
           : '';
         const res = await fetch(
           ingressAware(
-            `api/live/${selectedRoom.deviceId}/state?profileId=${selectedRoom.profileId}${entityParam}${mappingsParam}`
+            `api/live/${selectedRoom.deviceId}/state?profileId=${selectedRoom.profileId}${mappingsParam}`
           )
         );
         if (!res.ok) {


### PR DESCRIPTION
- stop using `entityNamePrefix` guessing in normal runtime flows
- require device mappings for live state, heatmap, zone reads/writes, polygon flows, and zone backups
- return clear re-sync errors when mappings are missing

Fixes #362