### PR TITLE
Fix rectangle zone labels rendering upside down when rotated

### DIFF
--- a/everything-presence-mmwave-configurator/frontend/src/components/ZoneCanvas.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/ZoneCanvas.tsx
@@ -641,6 +641,10 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
           // Get device rotation for SVG transform
           const rotationDeg = devicePlacement ? effectiveRotationDeg : 0;
 
+          // Label anchor in canvas space, so the label can be drawn upright
+          // (untransformed) at the zone centre like polygon zone labels are
+          const canvasCenter = toCanvas(deviceToRoom(zone.x + zone.width / 2, zone.y + zone.height / 2));
+
           const isSelected = selectedId === zone.id;
 
           // Zone colors: different colors for each regular zone, fixed colors for special types
@@ -703,14 +707,14 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
               />
               {showZoneLabels && (
                 <text
-                  x={canvasWidth / 2}
-                  y={20 * effectiveZoneLabelScale}
+                  x={canvasCenter.x}
+                  y={canvasCenter.y}
                   fill="white"
                   fontSize={13 * effectiveZoneLabelScale}
                   fontWeight="600"
                   textAnchor="middle"
+                  dominantBaseline="middle"
                   pointerEvents="none"
-                  transform={`translate(${canvasTopLeft.x}, ${canvasTopLeft.y}) rotate(${rotationDeg})`}
                   style={{
                     filter: 'drop-shadow(0 1px 2px rgb(0 0 0 / 0.8))',
                     textShadow: '0 1px 3px rgba(0,0,0,0.8)'


### PR DESCRIPTION
Fixes #386.

## Problem

In the rectangle zone branch of `ZoneCanvas.tsx`, the `<text>` label is given the *same* `translate(...) rotate(${rotationDeg})` transform as the `<rect>`, so the label rotates with the zone. Once the effective device rotation passes ~90° the text renders sideways, and around 180° it is fully upside down. The zone geometry itself is correct — this is label rendering only.

## Change

One file, one concern. The label is now drawn upright (no transform) at the zone's centre in canvas space, which is exactly what the polygon zone branch a little further down already does — it renders at the precomputed `centroid` with `dominantBaseline="middle"` and no rotate. This just brings the two branches into agreement rather than introducing a new approach.

The anchor reuses the existing `toCanvas(deviceToRoom(...))` helpers already used for `canvasTopLeft`, so no new rotation math is added.

Side effect worth flagging: at 0° the label moves from just inside the top edge to the zone centre. That is what makes it rotation-invariant (the old top-edge anchor swings to the opposite edge at 180°), and it matches polygon labels — but if you'd rather keep the top-edge position, the alternative is to keep the current anchor and append `rotate(${-rotationDeg}, x, y)` to counter-rotate in place. Happy to switch it over if you prefer that.

## Verification

The repo has no test runner configured, so this was verified manually:

- `npm run build` at `everything-presence-mmwave-configurator/` succeeds (backend `tsc` + frontend `vite build`).
- `npx tsc --noEmit` and `npx biome lint src/components/ZoneCanvas.tsx` produce byte-identical output before and after the change — no new errors or warnings introduced (there are some pre-existing ones).
- Reproduced the transform math standalone and confirmed the new anchor lands exactly on the rotated rect's centre (max error ~1e-13 px) at 0°, 10°, 45°, 90°, 180°, 270° and 359°.
- Rendered before/after SVGs at 0°, 10°, 90°, 180° and 270°: before, the label tilts at 10°, reads vertically at 90°/270° and is inverted at 180°; after, it is upright and centred at every rotation.

Thanks for the add-on, and happy to adjust anything here.
