### PR TITLE
Persist the metric/imperial unit preference

### DIFF
--- a/everything-presence-mmwave-configurator/frontend/src/hooks/useDisplaySettings.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/hooks/useDisplaySettings.ts
@@ -15,6 +15,7 @@ export interface DisplaySettings {
   zoneLabelScale: number;
   showAlignedDirection: boolean;
   clipRadarToWalls: boolean;
+  units: 'metric' | 'imperial';
   // Heatmap settings
   heatmapEnabled: boolean;
   heatmapHours: number;
@@ -38,6 +39,7 @@ const defaultSettings: DisplaySettings = {
   zoneLabelScale: 1,
   showAlignedDirection: false,
   clipRadarToWalls: true,
+  units: 'metric',
   // Heatmap defaults
   heatmapEnabled: false,
   heatmapHours: 24,
@@ -131,6 +133,10 @@ export const useDisplaySettings = () => {
     setSettings((prev) => ({ ...prev, clipRadarToWalls: value }));
   }, []);
 
+  const setUnits = useCallback((value: 'metric' | 'imperial') => {
+    setSettings((prev) => ({ ...prev, units: value }));
+  }, []);
+
   const setHeatmapEnabled = useCallback((value: boolean) => {
     setSettings((prev) => ({ ...prev, heatmapEnabled: value }));
   }, []);
@@ -159,6 +165,7 @@ export const useDisplaySettings = () => {
     zoneLabelScale: settings.zoneLabelScale,
     showAlignedDirection: settings.showAlignedDirection,
     clipRadarToWalls: settings.clipRadarToWalls,
+    units: settings.units,
     heatmapEnabled: settings.heatmapEnabled,
     heatmapHours: settings.heatmapHours,
     heatmapThreshold: settings.heatmapThreshold,
@@ -177,6 +184,7 @@ export const useDisplaySettings = () => {
     setZoneLabelScale,
     setShowAlignedDirection,
     setClipRadarToWalls,
+    setUnits,
     setHeatmapEnabled,
     setHeatmapHours,
     setHeatmapThreshold,

--- a/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
@@ -88,7 +88,6 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   const [angleSnapEnabled, setAngleSnapEnabled] = useState(false);
   const [cursorPos, setCursorPos] = useState<{ x: number; y: number } | null>(null);
   const [cursorDelta, setCursorDelta] = useState<{ dx: number; dy: number; len: number } | null>(null);
-  const [displayUnits, setDisplayUnits] = useState<'metric' | 'imperial'>('metric');
   const [zoom, setZoom] = useState(1.1);
   const [isCanvasDragging, setIsCanvasDragging] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
@@ -107,6 +106,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     showZoneLabels, setShowZoneLabels,
     zoneLabelScale, setZoneLabelScale,
     clipRadarToWalls, setClipRadarToWalls,
+    units: displayUnits, setUnits: setDisplayUnits,
   } = useDisplaySettings();
   const isMobileCanvas = useIsMobileCanvas();
   const [panOffsetMm, setPanOffsetMm] = useState<{ x: number; y: number }>({ x: 0, y: 0 });

--- a/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
@@ -104,7 +104,6 @@ export const WizardPage: React.FC<WizardPageProps> = ({
   const [roomId, setRoomId] = useState<string | null>(rooms[0]?.id ?? null);
   const [roomPath, setRoomPath] = useState<'new' | 'existing' | 'skip' | null>(null);
   const [newRoomName, setNewRoomName] = useState('');
-  const [units, setUnits] = useState<'metric' | 'imperial'>('metric');
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pushingZones, setPushingZones] = useState(false);
@@ -142,6 +141,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
     showZoneLabels, setShowZoneLabels,
     zoneLabelScale, setZoneLabelScale,
     clipRadarToWalls, setClipRadarToWalls,
+    units, setUnits,
   } = useDisplaySettings();
 
   // Cursor position tracking


### PR DESCRIPTION
Fixes #385.

## Problem

The metric/imperial choice lived in two independent, non-persisted `useState('metric')` declarations — one in `RoomBuilderPage.tsx`, one in `WizardPage.tsx` — so it reset to metric on every mount: navigating away and back, reloading, or moving between the wizard and the room all lost it.

## Approach

The issue offered two options and asked which you'd prefer. Since there was no reply I went with the one that follows the existing convention in the codebase: `units` is now part of `useDisplaySettings`, the hook that already persists 14 other display preferences to `localStorage`. Both pages already call that hook, so this is a small change — 10 lines added, 2 removed, no new files, no new storage key, no plumbing through props.

This makes units a **user-level** preference (imperial for all your rooms), which I'd guess matches expectation. It also fixes the wizard side as a by-product: the wizard and Room Builder now read the same value, so a unit picked in the wizard carries into the room.

Very happy to rework this as the per-room alternative instead — threading the wizard's choice through `onCreateRoom` into the two `createRoom` calls and initialising from `selectedRoom.units`, which would make the existing `RoomConfig.units` field meaningful. Just say the word. I deliberately did **not** touch `App.tsx` or the backend here, to keep this to one concern.

## Verification

The repo has no test runner configured, so this was verified manually:

- `npm run build` at `everything-presence-mmwave-configurator/` succeeds (backend `tsc` + frontend `vite build`).
- `npx tsc --noEmit` and `npx biome lint` on all three touched files produce identical output before and after — no new errors or warnings (there are pre-existing ones).
- Exercised the hook directly under Node with a `localStorage` stub to confirm the merge-with-defaults path:
  - fresh install → `metric`
  - an existing stored payload from 2.2.4 with no `units` key → `metric`, and its other saved settings are preserved
  - stored `units: 'imperial'` → read back as `imperial`
  - corrupt/unparseable payload → falls back to defaults as before

So no migration is needed and existing users see no change until they pick imperial.

## Not included

The FAQ note from the issue ("Zone Configurator uses metric units… no imperial unit option") is a docs change, so I left it out of this PR to keep it to one concern. Glad to send it separately if useful.

Thanks for the add-on.
