### PR TITLE
Fix heatmap room clipping coordinates

### DIFF
--- a/everything-presence-mmwave-configurator/frontend/package.json
+++ b/everything-presence-mmwave-configurator/frontend/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",
+		"test": "node --test test/*.test.mjs",
 		"preview": "vite preview",
 		"format": "npx @biomejs/biome format",
 		"format:fix": "npx @biomejs/biome format --write",

--- a/everything-presence-mmwave-configurator/frontend/src/components/HeatmapOverlay.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/HeatmapOverlay.tsx
@@ -8,7 +8,7 @@ interface HeatmapOverlayProps {
   devicePlacement?: DevicePlacement | null;
   installationAngle?: number;
   intensityThreshold?: number; // 0-1, cells below this won't be shown
-  roomShellPoints?: Array<{ x: number; y: number }> | null; // Canvas coordinates for room boundary
+  roomShellPoints?: Array<{ x: number; y: number }> | null; // Room coordinates for room boundary
   clipToRoom?: boolean;
   showAveragePosition?: boolean;
 }
@@ -106,7 +106,7 @@ export const HeatmapOverlay: React.FC<HeatmapOverlayProps> = ({ data, visible, t
   const clipPathId = 'heatmap-room-clip';
   const shouldClip = clipToRoom && roomShellPoints && roomShellPoints.length >= 3;
   const clipPathD = shouldClip
-    ? `M ${roomShellPoints.map(p => `${p.x},${p.y}`).join(' L ')} Z`
+    ? `M ${roomShellPoints.map(p => toCanvas(p)).map(p => `${p.x},${p.y}`).join(' L ')} Z`
     : '';
 
   return (

--- a/everything-presence-mmwave-configurator/frontend/test/HeatmapOverlay.test.mjs
+++ b/everything-presence-mmwave-configurator/frontend/test/HeatmapOverlay.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { createServer } from 'vite';
+
+let server;
+let HeatmapOverlay;
+
+before(async () => {
+  server = await createServer({
+    logLevel: 'silent',
+    server: { middlewareMode: true },
+  });
+  ({ HeatmapOverlay } = await server.ssrLoadModule('/src/components/HeatmapOverlay.tsx'));
+});
+
+after(async () => {
+  await server?.close();
+});
+
+test('transforms the room clip path into the heatmap canvas coordinate system', () => {
+  const toCanvas = ({ x, y }) => ({
+    x: x * 2 + 10,
+    y: y * 3 - 5,
+  });
+  const data = {
+    resolution: 20,
+    bounds: { minX: 0, maxX: 20, minY: 0, maxY: 20 },
+    cells: [{ x: 0, y: 0, count: 1, intensity: 1 }],
+    stats: {
+      totalSamples: 1,
+      maxCount: 1,
+      timeRange: { start: '2026-01-01', end: '2026-01-02' },
+      dataAvailable: true,
+    },
+  };
+
+  const markup = renderToStaticMarkup(
+    React.createElement(HeatmapOverlay, {
+      data,
+      visible: true,
+      toCanvas,
+      roomShellPoints: [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 100, y: 100 },
+      ],
+      showAveragePosition: false,
+    }),
+  );
+
+  assert.match(markup, /<path d="M 10,-5 L 210,-5 L 210,295 Z"><\/path>/);
+  assert.match(markup, /<circle cx="30" cy="25"/);
+});


### PR DESCRIPTION
## Summary

Fix heatmap cells being clipped out when a room uses a non-identity room-to-canvas transform.

`RoomCanvas` passes `roomShellPoints` in room/world millimetres together with a `toCanvas` transform. `HeatmapOverlay` already converts heatmap cell centres through `toCanvas`, but previously built its SVG clipping polygon directly from the untransformed room points. That placed the circles and their clip path in different coordinate systems.

This change converts the room shell points through `toCanvas` before constructing the clip path, keeping the clipping polygon in the same canvas coordinate system as the heatmap circles.

## Scope and safety

- Frontend-only change in `HeatmapOverlay`.
- No API, recorder, storage, firmware, or Home Assistant integration changes.
- No generated assets are committed.
- No issue is linked; this draft pull request documents the bug directly.

## Regression test

Added a component render test using a non-identity `toCanvas` transform with both scaling and translation. It asserts that:

- the room clip path contains the transformed canvas points; and
- the heatmap circle centre is rendered in that same transformed coordinate system.

The test failed before the source change because the path remained `M 0,0 L 100,0 L 100,100 Z`, while the expected canvas path was `M 10,-5 L 210,-5 L 210,295 Z`.

## Verification

- `npm test` in `frontend`: 1 test passed, 0 failed.
- `npm run build` from the configurator workspace: backend TypeScript compilation and frontend Vite production build passed.
- Focused Biome lint for the new test and modified package manifest passed.
- `git diff --check` passed.

Repository-wide `npm run lint` is not currently a passing baseline: an unmodified checkout of `main` reports 551 existing errors and 307 warnings. Focused lint on `HeatmapOverlay.tsx` produces the same existing diagnostics before and after this change (1 error and 2 warnings), so this pull request does not add lint findings.

## Manual verification

No live Home Assistant instance or installed add-on was changed or used for pull request verification. This draft does not claim new visual proof from an upstream build.
