### PR TITLE
[BUG] - Walls deleted without save

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/config/roomSnapshotStorage.ts
+++ b/everything-presence-mmwave-configurator/backend/src/config/roomSnapshotStorage.ts
@@ -1,0 +1,102 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { logger } from '../logger';
+import type { RoomConfig } from '../domain/types';
+import type { RoomSnapshot } from '../types/roomSnapshot';
+
+const DATA_DIR = process.env.DATA_DIR ?? '/config/everything-presence-zone-configurator';
+const SNAPSHOTS_FILE = path.join(DATA_DIR, 'room-snapshots.json');
+
+/** How many snapshots we retain per room before pruning the oldest. */
+export const MAX_SNAPSHOTS_PER_ROOM = 20;
+
+const ensureDataDir = () => {
+  if (!fs.existsSync(DATA_DIR)) {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+  }
+};
+
+const readSnapshots = (): RoomSnapshot[] => {
+  ensureDataDir();
+  if (!fs.existsSync(SNAPSHOTS_FILE)) {
+    return [];
+  }
+
+  try {
+    const raw = fs.readFileSync(SNAPSHOTS_FILE, 'utf-8');
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as RoomSnapshot[]) : [];
+  } catch (error) {
+    logger.warn({ error }, 'Failed to read room-snapshots.json; returning empty');
+    return [];
+  }
+};
+
+const writeSnapshots = (snapshots: RoomSnapshot[]): void => {
+  ensureDataDir();
+  fs.writeFileSync(SNAPSHOTS_FILE, JSON.stringify(snapshots, null, 2));
+};
+
+const generateId = (): string => {
+  if (typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return crypto.randomBytes(16).toString('hex');
+};
+
+const prune = (snapshots: RoomSnapshot[], roomId: string): RoomSnapshot[] => {
+  const forRoom = snapshots.filter((snapshot) => snapshot.roomId === roomId);
+  if (forRoom.length <= MAX_SNAPSHOTS_PER_ROOM) {
+    return snapshots;
+  }
+  const keep = new Set(
+    [...forRoom]
+      .sort((a, b) => (a.createdAt < b.createdAt ? 1 : a.createdAt > b.createdAt ? -1 : 0))
+      .slice(0, MAX_SNAPSHOTS_PER_ROOM)
+      .map((snapshot) => snapshot.id),
+  );
+  return snapshots.filter((snapshot) => snapshot.roomId !== roomId || keep.has(snapshot.id));
+};
+
+export const roomSnapshotStorage = {
+  listSnapshots: (roomId?: string): RoomSnapshot[] => {
+    const snapshots = roomId ? readSnapshots().filter((s) => s.roomId === roomId) : readSnapshots();
+    // Newest first so callers can offer "restore previous version" without sorting.
+    return [...snapshots].sort((a, b) => (a.createdAt < b.createdAt ? 1 : a.createdAt > b.createdAt ? -1 : 0));
+  },
+
+  getSnapshot: (id: string): RoomSnapshot | undefined => readSnapshots().find((snapshot) => snapshot.id === id),
+
+  /** Store the pre-save state of a room so an accidental overwrite stays recoverable. */
+  appendSnapshot: (room: RoomConfig): RoomSnapshot => {
+    const snapshot: RoomSnapshot = {
+      id: generateId(),
+      schemaVersion: 1,
+      createdAt: new Date().toISOString(),
+      reason: 'auto',
+      roomId: room.id,
+      roomName: room.name,
+      room,
+    };
+    try {
+      const snapshots = readSnapshots();
+      snapshots.push(snapshot);
+      writeSnapshots(prune(snapshots, room.id));
+    } catch (error) {
+      // Snapshots are a safety net; never fail the save they are protecting.
+      logger.warn({ error, roomId: room.id }, 'Failed to write room snapshot');
+    }
+    return snapshot;
+  },
+
+  deleteSnapshot: (id: string): boolean => {
+    const snapshots = readSnapshots();
+    const next = snapshots.filter((snapshot) => snapshot.id !== id);
+    if (next.length === snapshots.length) {
+      return false;
+    }
+    writeSnapshots(next);
+    return true;
+  },
+};

--- a/everything-presence-mmwave-configurator/backend/src/config/storage.ts
+++ b/everything-presence-mmwave-configurator/backend/src/config/storage.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { AppSettings, CustomFloorMaterial, CustomFurnitureType, RoomConfig } from '../domain/types';
 import { logger } from '../logger';
+import { roomSnapshotStorage } from './roomSnapshotStorage';
 
 // Use /config/everything-presence-zone-configurator for persistent storage across add-on reinstalls
 // The /config directory is mapped to Home Assistant's config folder via config:rw in config.yaml
@@ -148,6 +149,18 @@ const writeCustomFurniture = (furniture: CustomFurnitureType[]) => {
   fs.writeFileSync(CUSTOM_FURNITURE_FILE, JSON.stringify(furniture, null, 2));
 };
 
+// Geometry is the expensive-to-recreate part of a room (walls, doors, furniture,
+// device placement). We snapshot the previous version whenever it changes so an
+// accidental overwrite - e.g. a room saved with its outline cleared - stays
+// recoverable, instead of rooms.json being overwritten with no history.
+const geometrySignature = (room: RoomConfig): string =>
+  JSON.stringify({
+    roomShell: room.roomShell ?? null,
+    doors: room.doors ?? [],
+    furniture: room.furniture ?? [],
+    devicePlacement: room.devicePlacement ?? null,
+  });
+
 export const storage = {
   // Rooms
   listRooms: (): RoomConfig[] => readRooms(),
@@ -156,6 +169,10 @@ export const storage = {
     const rooms = readRooms();
     const idx = rooms.findIndex((r) => r.id === room.id);
     if (idx >= 0) {
+      const previous = rooms[idx];
+      if (geometrySignature(previous) !== geometrySignature(room)) {
+        roomSnapshotStorage.appendSnapshot(previous);
+      }
       rooms[idx] = room;
     } else {
       rooms.push(room);

--- a/everything-presence-mmwave-configurator/backend/src/routes/rooms.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/rooms.ts
@@ -1,6 +1,8 @@
 import { Router } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { storage } from '../config/storage';
+import { roomSnapshotStorage } from '../config/roomSnapshotStorage';
+import { logger } from '../logger';
 import { deviceEntityService } from '../domain/deviceEntityService';
 import { DevicePlacement, Door, EntityMappings, FurnitureInstance, RoomConfig, RoomShell, ZoneRect, ZoneEntitySet, TargetEntitySet } from '../domain/types';
 
@@ -290,7 +292,42 @@ export const createRoomsRouter = (): Router => {
     if (!existing) {
       return res.status(404).json({ message: 'Room not found' });
     }
-    const room = applyDeviceMappingPrefix(normalizeRoom({ ...existing, ...req.body }, existing.id));
+    const body = req.body ?? {};
+    const merged: any = { ...existing, ...body };
+
+    // A room outline is expensive to redraw and impossible to recover from a
+    // shallow merge, so it is only ever removed on an explicit request: send
+    // `roomShell: null` to clear it. An absent key, an empty `points` array, or
+    // anything else that does not parse to a usable shell keeps what is stored.
+    const shellProvided = Object.prototype.hasOwnProperty.call(body, 'roomShell');
+    const explicitClear = shellProvided && body.roomShell === null;
+    if (existing.roomShell && !explicitClear && !parseRoomShell(merged.roomShell)) {
+      if (shellProvided) {
+        logger.warn(
+          { roomId: existing.id },
+          'Ignoring room update that would erase the stored room outline; send roomShell: null to clear it explicitly',
+        );
+      }
+      merged.roomShell = existing.roomShell;
+    }
+
+    const room = applyDeviceMappingPrefix(normalizeRoom(merged, existing.id));
+    storage.saveRoom(room);
+    return res.json({ room });
+  });
+
+  router.get('/:id/snapshots', (req, res) => {
+    const snapshots = roomSnapshotStorage.listSnapshots(req.params.id);
+    return res.json({ snapshots });
+  });
+
+  router.post('/:id/snapshots/:snapshotId/restore', (req, res) => {
+    const snapshot = roomSnapshotStorage.getSnapshot(req.params.snapshotId);
+    if (!snapshot || snapshot.roomId !== req.params.id) {
+      return res.status(404).json({ message: 'Snapshot not found' });
+    }
+    // saveRoom snapshots the current state first, so a restore is itself undoable.
+    const room = applyDeviceMappingPrefix(normalizeRoom(snapshot.room, req.params.id));
     storage.saveRoom(room);
     return res.json({ room });
   });

--- a/everything-presence-mmwave-configurator/backend/src/types/roomSnapshot.ts
+++ b/everything-presence-mmwave-configurator/backend/src/types/roomSnapshot.ts
@@ -1,0 +1,14 @@
+import type { RoomConfig } from '../domain/types';
+
+export type RoomSnapshotReason = 'auto';
+
+export interface RoomSnapshot {
+  id: string;
+  schemaVersion: 1;
+  createdAt: string;
+  reason: RoomSnapshotReason;
+  roomId: string;
+  roomName?: string;
+  /** Full room configuration as it looked *before* the save that triggered this snapshot. */
+  room: RoomConfig;
+}

--- a/everything-presence-mmwave-configurator/frontend/src/api/rooms.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/api/rooms.ts
@@ -1,5 +1,15 @@
-import { RoomConfig } from '../types';
+import { RoomConfig } from './types';
 import { ingressAware } from './client';
+
+/**
+ * Payload accepted by the rooms PUT endpoint. The backend never removes a stored
+ * room outline implicitly: omit `roomShell` (or send one that has no points) to
+ * leave the saved outline untouched, and send `roomShell: null` to clear it on
+ * purpose.
+ */
+export type RoomUpdatePayload = Partial<Omit<RoomConfig, 'roomShell'>> & {
+  roomShell?: RoomConfig['roomShell'] | null;
+};
 
 const handle = async <T>(res: Response): Promise<T> => {
   if (!res.ok) {
@@ -23,7 +33,7 @@ export const createRoom = async (payload: Partial<RoomConfig>) => {
   return handle<{ room: RoomConfig }>(res);
 };
 
-export const updateRoom = async (id: string, payload: Partial<RoomConfig>) => {
+export const updateRoom = async (id: string, payload: RoomUpdatePayload) => {
   const res = await fetch(ingressAware(`api/rooms/${id}`), {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },

--- a/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { fetchDevices, fetchProfiles, ingressAware } from '../api/client';
 import { fetchRooms, updateRoom } from '../api/rooms';
+import type { RoomUpdatePayload } from '../api/rooms';
 import { RoomCanvas } from '../components/RoomCanvas';
 import { DiscoveredDevice, DeviceProfile, RoomConfig, LiveState, FurnitureInstance, FurnitureType, Door, DevicePlacement } from '../api/types';
 import { useWallDrawing } from '../hooks/useWallDrawing';
@@ -48,8 +49,28 @@ interface RoomBuilderPageProps {
 
 type MobileRoomBuilderSheet = 'navigation' | 'tools' | 'zoom' | null;
 type RoomBuilderSettingsTab = 'canvas' | 'device' | 'display' | 'floor';
+type RoomBuilderView = 'wizard' | 'zoneEditor' | 'roomBuilder' | 'settings' | 'liveDashboard';
+type PendingLeave = { type: 'navigate'; view: RoomBuilderView } | { type: 'back' };
 
 const clampNumber = (v: number, min: number, max: number) => Math.min(Math.max(v, min), max);
+
+// Stable, key-order independent stringify so a room reserialised by the backend
+// compares equal to the identical room held in local state.
+const stableStringify = (value: unknown): string => {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value ?? null) ?? 'null';
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`);
+  return `{${entries.join(',')}}`;
+};
+
+const roomSignature = (room: RoomConfig | null | undefined): string => (room ? stableStringify(room) : '');
 
 export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   onBack,
@@ -70,6 +91,12 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   const [heightMm, setHeightMm] = useState(4000);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Last state each room was known to have on the server; the baseline for
+  // "do I have unsaved changes?" and for discarding them again.
+  const [savedRooms, setSavedRooms] = useState<Record<string, RoomConfig>>({});
+  const [pendingLeave, setPendingLeave] = useState<PendingLeave | null>(null);
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
+  const [clearedPoints, setClearedPoints] = useState<{ x: number; y: number }[] | null>(null);
   const [hoveredSegment, setHoveredSegment] = useState<number | null>(null);
   const [selectedSegment, setSelectedSegment] = useState<number | null>(null);
   const [wallLengthInput, setWallLengthInput] = useState('');
@@ -598,6 +625,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
         setDevices(deviceRes.devices);
         setProfiles(profileRes.profiles);
         setRooms(roomRes.rooms);
+        setSavedRooms(Object.fromEntries(roomRes.rooms.map((room) => [room.id, room])));
 
         const initialRoom =
           (initialRoomId && roomRes.rooms.find((r) => r.id === initialRoomId)) || roomRes.rooms[0] || null;
@@ -618,6 +646,8 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   useEffect(() => {
     // reset pan when switching rooms
     setPanOffsetMm({ x: 0, y: 0 });
+    setClearedPoints(null);
+    setShowClearConfirm(false);
   }, [selectedRoomId]);
 
   useEffect(() => {
@@ -652,8 +682,30 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
 
   const handleClear = () => {
     if (!selectedRoom) return;
+    if (!selectedRoom.roomShell?.points?.length) {
+      stopDrawing();
+      return;
+    }
+    // Clearing removes every wall at once and cannot be undone with Undo (Del),
+    // so ask first.
+    setShowClearConfirm(true);
+  };
+
+  const confirmClear = () => {
+    if (!selectedRoom) {
+      setShowClearConfirm(false);
+      return;
+    }
+    setClearedPoints(selectedRoom.roomShell?.points ?? null);
     handlePointsChange([]);
     stopDrawing();
+    setShowClearConfirm(false);
+  };
+
+  const restoreClearedPoints = () => {
+    if (!clearedPoints?.length) return;
+    handlePointsChange(clearedPoints);
+    setClearedPoints(null);
   };
 
   const handleCloseLoop = () => {
@@ -1069,12 +1121,26 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     }
   };
 
-  const handleSaveRoom = async (): Promise<boolean> => {
+  const hasUnsavedChanges = useMemo(() => {
+    if (!selectedRoom) return false;
+    const saved = savedRooms[selectedRoom.id];
+    if (!saved) return false;
+    return roomSignature(saved) !== roomSignature(selectedRoom);
+  }, [savedRooms, selectedRoom]);
+
+  const handleSaveRoom = useCallback(async (): Promise<boolean> => {
     if (!selectedRoom) return false;
     setSaving(true);
     try {
-      const result = await updateRoom(selectedRoom.id, selectedRoom);
+      // The backend only removes a stored outline on an explicit `roomShell: null`,
+      // so an intentional save of an emptied room has to say so.
+      const payload: RoomUpdatePayload = {
+        ...selectedRoom,
+        roomShell: selectedRoom.roomShell?.points?.length ? selectedRoom.roomShell : null,
+      };
+      const result = await updateRoom(selectedRoom.id, payload);
       setRooms((prev) => prev.map((r) => (r.id === selectedRoom.id ? result.room : r)));
+      setSavedRooms((prev) => ({ ...prev, [result.room.id]: result.room }));
       onWizardProgress?.({ outlineDone: true, placementDone: true });
       setError(null);
       return true;
@@ -1084,19 +1150,72 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     } finally {
       setSaving(false);
     }
-  };
+  }, [onWizardProgress, selectedRoom]);
 
-  const navigateWithSave = useCallback(
-    async (view: 'wizard' | 'zoneEditor' | 'roomBuilder' | 'settings' | 'liveDashboard') => {
-      if (!onNavigate) return;
-      if (selectedRoom) {
-        const saved = await handleSaveRoom();
-        if (!saved) return;
+  const leave = useCallback(
+    (target: PendingLeave) => {
+      if (target.type === 'back') {
+        onBack?.();
+        return;
       }
-      onNavigate(view);
+      onNavigate?.(target.view);
     },
-    [onNavigate, selectedRoom, handleSaveRoom]
+    [onBack, onNavigate]
   );
+
+  // Leaving the Room Builder never writes silently: unsaved edits (including
+  // deleted walls) prompt for Save / Discard / Cancel first.
+  const requestLeave = useCallback(
+    (target: PendingLeave) => {
+      if (target.type === 'navigate' && !onNavigate) return;
+      if (target.type === 'back' && !onBack) return;
+      if (selectedRoom && hasUnsavedChanges) {
+        setPendingLeave(target);
+        return;
+      }
+      leave(target);
+    },
+    [hasUnsavedChanges, leave, onBack, onNavigate, selectedRoom]
+  );
+
+  const navigateTo = useCallback(
+    (view: RoomBuilderView) => requestLeave({ type: 'navigate', view }),
+    [requestLeave]
+  );
+
+  const handlePendingSaveAndLeave = useCallback(async () => {
+    const target = pendingLeave;
+    if (!target) return;
+    const saved = await handleSaveRoom();
+    if (!saved) return; // keep the prompt open; the error toast explains why
+    setPendingLeave(null);
+    leave(target);
+  }, [handleSaveRoom, leave, pendingLeave]);
+
+  const handlePendingDiscardAndLeave = useCallback(() => {
+    const target = pendingLeave;
+    if (!target) return;
+    if (selectedRoom) {
+      const saved = savedRooms[selectedRoom.id];
+      if (saved) {
+        setRooms((prev) => prev.map((r) => (r.id === saved.id ? saved : r)));
+      }
+    }
+    setClearedPoints(null);
+    setPendingLeave(null);
+    leave(target);
+  }, [leave, pendingLeave, savedRooms, selectedRoom]);
+
+  // Reloading or closing the tab also discards unsaved room edits - warn first.
+  useEffect(() => {
+    if (!hasUnsavedChanges) return;
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [hasUnsavedChanges]);
 
   const handleAutoZoom = useCallback((room: RoomConfig | null) => {
     if (!room?.roomShell?.points?.length) {
@@ -1234,12 +1353,107 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
         </div>
       )}
 
+      {/* Unsaved changes prompt - shown instead of silently saving when leaving */}
+      {pendingLeave && (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={() => setPendingLeave(null)} />
+          <div className="relative z-10 w-full max-w-md mx-4 rounded-2xl border border-slate-700/50 bg-slate-900/95 backdrop-blur shadow-2xl animate-in zoom-in-95 fade-in duration-200">
+            <div className="p-6">
+              <h3 className="text-xl font-bold text-white text-center mb-2">Unsaved changes</h3>
+              <p className="text-sm text-slate-300 text-center mb-5">
+                This room has changes that have not been saved yet. Save them before leaving, or discard them and keep
+                the last saved version of the room.
+              </p>
+              <div className="flex flex-col gap-2">
+                <button
+                  onClick={handlePendingSaveAndLeave}
+                  disabled={saving}
+                  className="w-full rounded-xl bg-gradient-to-r from-aqua-600 to-aqua-500 px-4 py-2.5 text-sm font-bold text-white shadow-lg shadow-aqua-500/30 transition-all hover:shadow-xl disabled:opacity-50 active:scale-95"
+                >
+                  {saving ? 'Saving...' : 'Save and leave'}
+                </button>
+                <button
+                  onClick={handlePendingDiscardAndLeave}
+                  disabled={saving}
+                  className="w-full rounded-xl border border-rose-600/50 bg-rose-600/10 px-4 py-2.5 text-sm font-semibold text-rose-100 transition-all hover:bg-rose-600/20 disabled:opacity-50 active:scale-95"
+                >
+                  Discard changes
+                </button>
+                <button
+                  onClick={() => setPendingLeave(null)}
+                  disabled={saving}
+                  className="w-full rounded-xl border border-slate-600 bg-slate-800 px-4 py-2.5 text-sm font-semibold text-slate-200 transition-all hover:bg-slate-700 disabled:opacity-50 active:scale-95"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Clear walls confirmation */}
+      {showClearConfirm && (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={() => setShowClearConfirm(false)} />
+          <div className="relative z-10 w-full max-w-md mx-4 rounded-2xl border border-slate-700/50 bg-slate-900/95 backdrop-blur shadow-2xl animate-in zoom-in-95 fade-in duration-200">
+            <div className="p-6">
+              <div className="flex justify-center mb-4">
+                <div className="w-12 h-12 rounded-full bg-rose-500/20 flex items-center justify-center">
+                  <span className="text-xl">🗑️</span>
+                </div>
+              </div>
+              <h3 className="text-xl font-bold text-white text-center mb-2">Delete all walls?</h3>
+              <p className="text-sm text-slate-300 text-center mb-5">
+                This removes the entire outline of {selectedRoom?.name ?? 'this room'}. Undo (Del) cannot bring it back
+                once cleared - only the saved version on disk can.
+              </p>
+              <div className="flex gap-3">
+                <button
+                  onClick={() => setShowClearConfirm(false)}
+                  className="flex-1 rounded-xl border border-slate-600 bg-slate-800 px-4 py-2.5 text-sm font-semibold text-slate-200 transition-all hover:bg-slate-700 active:scale-95"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={confirmClear}
+                  className="flex-1 rounded-xl bg-gradient-to-r from-rose-600 to-rose-500 px-4 py-2.5 text-sm font-bold text-white shadow-lg shadow-rose-500/30 transition-all hover:shadow-xl active:scale-95"
+                >
+                  Delete walls
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* In-session recovery for a cleared outline */}
+      {clearedPoints?.length && !(selectedRoom?.roomShell?.points?.length) ? (
+        <div className="absolute bottom-24 left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-xl border border-amber-500/40 bg-slate-900/95 px-4 py-3 text-sm text-amber-100 shadow-2xl backdrop-blur md:bottom-6">
+          <span>Walls cleared. Nothing is saved until you press Save Room.</span>
+          <button
+            type="button"
+            onClick={restoreClearedPoints}
+            className="rounded-lg border border-amber-500/50 bg-amber-500/20 px-3 py-1.5 text-xs font-bold text-amber-100 transition-all hover:bg-amber-500/30 active:scale-95"
+          >
+            Restore walls
+          </button>
+          <button
+            type="button"
+            onClick={() => setClearedPoints(null)}
+            className="rounded-lg border border-slate-700 px-3 py-1.5 text-xs font-semibold text-slate-300 transition-all hover:bg-slate-800 active:scale-95"
+          >
+            Dismiss
+          </button>
+        </div>
+      ) : null}
+
       <div className="md:hidden">
         <CanvasTopBar
           left={onBack && !onNavigate ? (
             <button
               type="button"
-              onClick={onBack}
+              onClick={() => requestLeave({ type: 'back' })}
               className="min-h-[40px] rounded-lg border border-slate-700 bg-slate-900 px-3 text-sm font-semibold text-slate-100"
             >
               Back
@@ -1274,7 +1488,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
               disabled={saving || !selectedRoom}
               className="min-h-[40px] rounded-lg bg-aqua-600 px-3 text-xs font-bold text-white shadow-lg shadow-aqua-500/20 disabled:opacity-50"
             >
-              {saving ? 'Saving' : 'Save'}
+              {saving ? 'Saving' : hasUnsavedChanges ? 'Save •' : 'Save'}
             </button>
           )}
         />
@@ -1283,7 +1497,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
       {/* Navigation (top left) */}
       {onBack && !onNavigate && (
         <button
-          onClick={onBack}
+          onClick={() => requestLeave({ type: 'back' })}
           className="absolute top-6 left-6 z-40 hidden group rounded-xl border border-slate-700/50 bg-slate-900/90 backdrop-blur px-4 py-2.5 text-sm font-semibold text-slate-100 shadow-lg transition-all hover:border-slate-600 hover:bg-slate-800 hover:shadow-xl active:scale-95 md:block"
         >
           <span className="inline-block transition-transform group-hover:-translate-x-0.5">←</span> Back
@@ -1311,36 +1525,36 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
               <div className="absolute top-14 left-0 z-50 min-w-[200px] rounded-xl border border-slate-700/50 bg-slate-900/95 backdrop-blur shadow-2xl overflow-hidden">
                 <div className="p-2 space-y-1">
                   <button
-                    onClick={async () => {
-                      await navigateWithSave('liveDashboard');
+                    onClick={() => {
                       setShowNavMenu(false);
+                      navigateTo('liveDashboard');
                     }}
                     className="w-full text-left px-4 py-2.5 text-sm font-medium text-slate-100 rounded-lg transition-all hover:bg-aqua-600/20 hover:text-aqua-400 active:scale-95"
                   >
                     📡 Live Dashboard
                   </button>
                   <button
-                    onClick={async () => {
-                      await navigateWithSave('wizard');
+                    onClick={() => {
                       setShowNavMenu(false);
+                      navigateTo('wizard');
                     }}
                     className="w-full text-left px-4 py-2.5 text-sm font-medium text-slate-100 rounded-lg transition-all hover:bg-aqua-600/20 hover:text-aqua-400 active:scale-95"
                   >
                     ➕ Add Device
                   </button>
                   <button
-                    onClick={async () => {
-                      await navigateWithSave('zoneEditor');
+                    onClick={() => {
                       setShowNavMenu(false);
+                      navigateTo('zoneEditor');
                     }}
                     className="w-full text-left px-4 py-2.5 text-sm font-medium text-slate-100 rounded-lg transition-all hover:bg-aqua-600/20 hover:text-aqua-400 active:scale-95"
                   >
                     📐 Zone Editor
                   </button>
                   <button
-                    onClick={async () => {
-                      await navigateWithSave('settings');
+                    onClick={() => {
                       setShowNavMenu(false);
+                      navigateTo('settings');
                     }}
                     className="w-full text-left px-4 py-2.5 text-sm font-medium text-slate-100 rounded-lg transition-all hover:bg-aqua-600/20 hover:text-aqua-400 active:scale-95"
                   >
@@ -1359,8 +1573,17 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
         disabled={saving}
         className={`absolute top-6 z-40 hidden rounded-xl bg-gradient-to-r from-aqua-600 to-aqua-500 px-6 py-2.5 text-sm font-bold text-white shadow-lg shadow-aqua-500/30 transition-all hover:shadow-xl hover:shadow-aqua-500/40 disabled:opacity-50 active:scale-95 md:block ${desktopEditorOpen ? 'right-[22rem]' : 'right-6'}`}
       >
-        {saving ? 'Saving...' : 'Save Room'}
+        {saving ? 'Saving...' : hasUnsavedChanges ? 'Save Room •' : 'Save Room'}
       </button>
+      {hasUnsavedChanges && !saving && (
+        <div
+          className={`pointer-events-none absolute top-[4.25rem] z-40 hidden rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-1.5 text-xs font-semibold text-amber-200 backdrop-blur md:block ${
+            desktopEditorOpen ? 'right-[22rem]' : 'right-6'
+          }`}
+        >
+          Unsaved changes
+        </div>
+      )}
 
       {/* Canvas Content - Full Page */}
       {!selectedRoom && (
@@ -2584,9 +2807,9 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
             <>
               <button
                 type="button"
-                onClick={async () => {
-                  await navigateWithSave('liveDashboard');
+                onClick={() => {
                   setActiveMobileSheet(null);
+                  navigateTo('liveDashboard');
                 }}
                 className="w-full rounded-lg border border-slate-700 bg-slate-800 px-4 py-3 text-left text-sm font-semibold text-slate-100"
               >
@@ -2594,9 +2817,9 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
               </button>
               <button
                 type="button"
-                onClick={async () => {
-                  await navigateWithSave('wizard');
+                onClick={() => {
                   setActiveMobileSheet(null);
+                  navigateTo('wizard');
                 }}
                 className="w-full rounded-lg border border-slate-700 bg-slate-800 px-4 py-3 text-left text-sm font-semibold text-slate-100"
               >
@@ -2604,9 +2827,9 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
               </button>
               <button
                 type="button"
-                onClick={async () => {
-                  await navigateWithSave('zoneEditor');
+                onClick={() => {
                   setActiveMobileSheet(null);
+                  navigateTo('zoneEditor');
                 }}
                 className="w-full rounded-lg border border-slate-700 bg-slate-800 px-4 py-3 text-left text-sm font-semibold text-slate-100"
               >
@@ -2614,9 +2837,9 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
               </button>
               <button
                 type="button"
-                onClick={async () => {
-                  await navigateWithSave('settings');
+                onClick={() => {
                   setActiveMobileSheet(null);
+                  navigateTo('settings');
                 }}
                 className="w-full rounded-lg border border-slate-700 bg-slate-800 px-4 py-3 text-left text-sm font-semibold text-slate-100"
               >


### PR DESCRIPTION
## Summary
Fixed the silent, unrecoverable loss of room walls in the Room Builder (issue #352) at three levels.
1) Frontend – no more save-on-navigate. RoomBuilderPage now keeps a per-room baseline of the last server-returned room (`savedRooms`, populated on load and after every successful save) and derives `hasUnsavedChanges` from an order-insensitive stable-stringify comparison against the in-memory room. `navigateWithSave()` (which unconditionally PUT the whole in-memory room before switching view) is replaced by `requestLeave()/navigateTo()`: leaving with unsaved changes opens a Save / Discard / Cancel dialog instead of writing; leaving with a clean room navigates plainly, matching ZoneEditorPage. All eight menu entries (desktop dropdown + mobile sheet) and both Back buttons go through the guard. 'Discard changes' restores the room from the saved baseline before leaving. Save buttons show a '•' marker plus an 'Unsaved changes' badge when dirty, and a beforeunload handler warns on tab close/reload.
2) Frontend – Clear is now confirmable/recoverable. '🗑️ Clear' (desktop and mobile) opens a 'Delete all walls?' confirmation; after confirming, the previous polygon is retained in session state and a toast offers 'Restore walls' (Undo/Del can only pop the last point), plus a reminder that nothing is saved until Save Room.
3) Backend – outlines are never erased implicitly.

## Verification
Build: `npm run build` at the repo root (backend `tsc`, frontend `vite build`).
Manual (the reported scenario): open Room Builder on a room with walls → click 🗑️ Clear → confirm the new 'Delete all walls?' dialog → open the ☰ Menu and pick Zone Editor. Expect an 'Unsaved changes' dialog; choose Cancel or Discard changes and confirm via `GET /api/rooms` (or reload the page) that the walls are still stored. Choosing 'Save and leave' is the only path that persists the deletion. Also check the 'Restore walls' toast brings the outline back in-session, that the Save button shows the '•'/'Unsaved changes' marker only while dirty, and that navigating with no edits goes straight through with no PUT (visible in the network tab / backend logs).
Backend guard: `curl -X PUT -H 'Content-Type: application/json' -d '{"roomShell":{"points":[]}}' http://<host>/api/rooms/<id>` → response still contains the original roomShell and a warning is logged; `-d '{"roomShell":null}'` → outline is cleared (this is what the Save button sends for an intentionally emptied room).
Snapshots: after any geometry-changing save, `curl http://<host>/api/rooms/<id>/snapshots` lists prior versions newest-first (also visible in `<DATA_DIR>/room-snapshots.json`); `curl -X POST http://<host>/api/rooms/<id>/snapshots/<snapshotId>/restore` puts the old geometry back.

Fixes #352