### PR TITLE
[FEATURE] Easy room shapes

### DIFF
--- a/everything-presence-mmwave-configurator/frontend/package.json
+++ b/everything-presence-mmwave-configurator/frontend/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",
+		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts",
 		"preview": "vite preview",
 		"format": "npx @biomejs/biome format",
 		"format:fix": "npx @biomejs/biome format --write",

--- a/everything-presence-mmwave-configurator/frontend/src/components/BasicRoomShapesPicker.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/BasicRoomShapesPicker.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { createLShapePoints, createRectanglePoints, type RoomShapePoint } from '../utils/roomShapes';
+
+export type BasicRoomShapeKind = 'rectangle' | 'l-shape';
+
+export interface BasicRoomShapeSelection {
+  kind: BasicRoomShapeKind;
+  width: number;
+  length: number;
+  cutoutWidth: number;
+  cutoutLength: number;
+}
+
+interface BasicRoomShapesPickerProps {
+  units: 'metric' | 'imperial';
+  onApply: (points: RoomShapePoint[], selection: BasicRoomShapeSelection) => void;
+  onDrawOwn: () => void;
+  onCancel?: () => void;
+}
+
+const pointsForSelection = (selection: BasicRoomShapeSelection) => selection.kind === 'rectangle'
+  ? createRectanglePoints(selection)
+  : createLShapePoints(selection);
+
+export const resizeBasicRoomShapeWall = (
+  selection: BasicRoomShapeSelection,
+  segmentIndex: number,
+  length: number,
+): { points: RoomShapePoint[]; selection: BasicRoomShapeSelection } => {
+  const next = { ...selection };
+  if (selection.kind === 'rectangle') {
+    if (segmentIndex === 0 || segmentIndex === 2) next.width = length;
+    else next.length = length;
+  } else {
+    if (segmentIndex === 0) next.width = length;
+    else if (segmentIndex === 1) next.length = length + selection.cutoutLength;
+    else if (segmentIndex === 2) next.cutoutWidth = length;
+    else if (segmentIndex === 3) next.cutoutLength = length;
+    else if (segmentIndex === 4) next.width = length + selection.cutoutWidth;
+    else next.length = length;
+  }
+  return { selection: next, points: pointsForSelection(next) };
+};
+
+const ShapeDiagram = ({ shape }: { shape: BasicRoomShapeKind }) => (
+  <svg viewBox="0 0 160 110" className="h-28 w-full" role="img" aria-label={`${shape === 'rectangle' ? 'Rectangle' : 'L-shaped room'} preview`}>
+    <path d={shape === 'rectangle' ? 'M 25 20 H 135 V 90 H 25 Z' : 'M 20 15 H 140 V 65 H 90 V 95 H 20 Z'} fill="rgba(34,211,238,.12)" stroke="currentColor" strokeWidth="4" strokeLinejoin="round" className="text-aqua-400" />
+  </svg>
+);
+
+export const BasicRoomShapesPicker: React.FC<BasicRoomShapesPickerProps> = ({ units, onApply, onDrawOwn, onCancel }) => {
+  const scale = units === 'metric' ? 1000 : 304.8;
+  const choose = (kind: BasicRoomShapeKind) => {
+    const selection: BasicRoomShapeSelection = {
+      kind,
+      width: 4 * scale,
+      length: 4 * scale,
+      cutoutWidth: 1.5 * scale,
+      cutoutLength: 1.5 * scale,
+    };
+    onApply(pointsForSelection(selection), selection);
+  };
+  return (
+    <div className="w-full max-w-3xl rounded-2xl border border-slate-700 bg-slate-900 p-5 shadow-2xl sm:p-7">
+      <div className="mb-5 flex items-start justify-between gap-4">
+        <div><h2 className="text-xl font-bold text-white">Choose your room shape</h2><p className="mt-1 text-sm text-slate-400">Choose a shape to place it on the canvas, then adjust its wall dimensions there.</p></div>
+        {onCancel && <button type="button" onClick={onCancel} className="text-sm text-slate-400 hover:text-white">Close</button>}
+      </div>
+      <div className="grid gap-3 sm:grid-cols-3">
+        {(['rectangle', 'l-shape'] as BasicRoomShapeKind[]).map((shape) => (
+          <button key={shape} type="button" onClick={() => choose(shape)} className="rounded-xl border border-slate-700 bg-slate-800/60 p-3 text-left transition hover:border-aqua-500 hover:bg-aqua-500/10">
+            <ShapeDiagram shape={shape} />
+            <span className="font-semibold text-white">{shape === 'rectangle' ? 'Rectangle' : 'L-shaped room'}</span>
+            <span className="mt-1 block text-xs text-slate-400">{shape === 'rectangle' ? 'Four straight sides.' : 'A room with one corner cut out.'}</span>
+          </button>
+        ))}
+        <button type="button" onClick={onDrawOwn} className="rounded-xl border border-slate-700 bg-slate-800/60 p-5 text-left hover:border-slate-500">
+          <div className="mb-4 text-4xl">✏️</div><span className="font-semibold text-white">Draw my own</span><span className="mt-2 block text-xs text-slate-400">Place and move each corner yourself.</span>
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/everything-presence-mmwave-configurator/frontend/src/components/RoomCanvas.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/RoomCanvas.tsx
@@ -81,6 +81,8 @@ interface RoomCanvasProps {
     deviceElement?: React.ReactNode;
   }) => React.ReactNode;
   lockShell?: boolean;
+  showAllWallLengthLabels?: boolean;
+  onWallLengthChange?: (segmentIndex: number, lengthMm: number) => void;
   furniture?: FurnitureInstance[];
   selectedFurnitureId?: string | null;
   onFurnitureSelect?: (id: string | null) => void;
@@ -547,6 +549,8 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
   onSegmentInsert,
   renderOverlay,
   lockShell = false,
+  showAllWallLengthLabels = false,
+  onWallLengthChange,
   furniture = [],
   selectedFurnitureId,
   onFurnitureSelect,
@@ -592,6 +596,8 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
 
   const svgRef = useRef<SVGSVGElement | null>(null);
   const [dragIdx, setDragIdx] = useState<number | null>(null);
+  const [editingWallLength, setEditingWallLength] = useState<number | null>(null);
+  const [wallLengthDraft, setWallLengthDraft] = useState('');
   const [dragDevice, setDragDevice] = useState<boolean>(false);
   const [panDrag, setPanDrag] = useState<{ start: Point; base: { x: number; y: number } } | null>(null);
   const [furnitureDrag, setFurnitureDrag] = useState<{ id: string; start: Point; basePos: Point; currentPos?: Point } | null>(null);
@@ -1166,6 +1172,64 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                       vectorEffect="non-scaling-stroke"
                       onPointerDown={handleDragStart(idx)}
                     />
+                  </g>
+                );
+              })}
+            {showAllWallLengthLabels &&
+              safePoints.map((point, index) => {
+                const next = safePoints[(index + 1) % safePoints.length];
+                const start = toCanvasCoord(point);
+                const end = toCanvasCoord(next);
+                const midX = (start.x + end.x) / 2;
+                const midY = (start.y + end.y) / 2;
+                const lengthMm = Math.hypot(next.x - point.x, next.y - point.y);
+                const label = formatLength(lengthMm);
+                const isEditing = editingWallLength === index;
+                const commit = () => {
+                  const scale = displayUnits === 'imperial' ? 304.8 : 1000;
+                  const nextLength = Number(wallLengthDraft) * scale;
+                  if (Number.isFinite(nextLength) && nextLength > 0) onWallLengthChange?.(index, nextLength);
+                  setEditingWallLength(null);
+                };
+                if (isEditing) {
+                  return (
+                    <foreignObject key={`locked-length-${index}`} x={midX - 38} y={midY - 16} width={76} height={32}>
+                      <input
+                        autoFocus
+                        aria-label={`Wall ${index + 1} length in ${displayUnits === 'imperial' ? 'feet' : 'meters'}`}
+                        type="number"
+                        min="0"
+                        step={displayUnits === 'imperial' ? 0.25 : 0.1}
+                        value={wallLengthDraft}
+                        onChange={(event) => setWallLengthDraft(event.target.value)}
+                        onBlur={commit}
+                        onKeyDown={(event) => {
+                          event.stopPropagation();
+                          if (event.key === 'Enter') event.currentTarget.blur();
+                          if (event.key === 'Escape') setEditingWallLength(null);
+                        }}
+                        onPointerDown={(event) => event.stopPropagation()}
+                        className="h-8 w-full rounded-md border border-aqua-400 bg-slate-950 px-1 text-center text-xs font-semibold text-white outline-none"
+                      />
+                    </foreignObject>
+                  );
+                }
+                return (
+                  <g
+                    key={`locked-length-${index}`}
+                    role={onWallLengthChange ? 'button' : undefined}
+                    aria-label={onWallLengthChange ? `Edit wall ${index + 1} length, currently ${label}` : undefined}
+                    className={onWallLengthChange ? 'cursor-pointer' : undefined}
+                    onClick={(event) => {
+                      if (!onWallLengthChange) return;
+                      event.stopPropagation();
+                      const scale = displayUnits === 'imperial' ? 304.8 : 1000;
+                      setWallLengthDraft(String(Number((lengthMm / scale).toFixed(2))));
+                      setEditingWallLength(index);
+                    }}
+                  >
+                    <rect x={midX - 27} y={midY - 10} width={54} height={20} rx={5} fill={canvasColors.outsideRoom} stroke="#22d3ee99" />
+                    <text x={midX} y={midY + 4} fill={isDark ? '#e2e8f0' : '#1e293b'} fontSize="11" fontWeight="600" textAnchor="middle">{label}</text>
                   </g>
                 );
               })}

--- a/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
@@ -16,6 +16,8 @@ import {
   CanvasTopBar,
 } from '../components/CanvasLayout';
 import { DisplaySettingsControls } from '../components/DisplaySettingsControls';
+import { BasicRoomShapesPicker, resizeBasicRoomShapeWall, type BasicRoomShapeSelection } from '../components/BasicRoomShapesPicker';
+import type { RoomShapePoint } from '../utils/roomShapes';
 import { useDisplaySettings } from '../hooks/useDisplaySettings';
 import { useIsMobileCanvas } from '../hooks/useMediaQuery';
 import { getInstallationAngleSuggestion } from '../utils/rotationSuggestion';
@@ -52,8 +54,6 @@ type RoomBuilderSettingsTab = 'canvas' | 'device' | 'display' | 'floor';
 type RoomBuilderView = 'wizard' | 'zoneEditor' | 'roomBuilder' | 'settings' | 'liveDashboard';
 type PendingLeave = { type: 'navigate'; view: RoomBuilderView } | { type: 'back' };
 
-const clampNumber = (v: number, min: number, max: number) => Math.min(Math.max(v, min), max);
-
 // Stable, key-order independent stringify so a room reserialised by the backend
 // compares equal to the identical room held in local state.
 const stableStringify = (value: unknown): string => {
@@ -87,8 +87,8 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
   const [selectedProfileId, setSelectedProfileId] = useState<string | null>(null);
   const [rangeMm, setRangeMm] = useState(15000);
-  const [widthMm, setWidthMm] = useState(4000);
-  const [heightMm, setHeightMm] = useState(4000);
+  const [showBasicShapes, setShowBasicShapes] = useState(false);
+  const [activeBasicShape, setActiveBasicShape] = useState<BasicRoomShapeSelection | null>(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // Last state each room was known to have on the server; the baseline for
@@ -648,18 +648,8 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     setPanOffsetMm({ x: 0, y: 0 });
     setClearedPoints(null);
     setShowClearConfirm(false);
+    setActiveBasicShape(null);
   }, [selectedRoomId]);
-
-  useEffect(() => {
-    if (!selectedRoom?.roomShell?.points?.length) return;
-    const pts = selectedRoom.roomShell.points;
-    const xs = pts.map((p) => p.x);
-    const ys = pts.map((p) => p.y);
-    const width = Math.max(...xs) - Math.min(...xs);
-    const height = Math.max(...ys) - Math.min(...ys);
-    if (Number.isFinite(width)) setWidthMm(Math.round(width));
-    if (Number.isFinite(height)) setHeightMm(Math.round(height));
-  }, [selectedRoom?.roomShell?.points]);
 
   const handleAddPoint = (p: { x: number; y: number }) => {
     if (!selectedRoom) return;
@@ -667,17 +657,31 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     handlePointsChange(nextPoints);
   };
 
-  const handleSetRectangle = () => {
+  const handleApplyBasicShape = (points: RoomShapePoint[], selection: BasicRoomShapeSelection) => {
     if (!selectedRoom) return;
-    const w = clampNumber(widthMm, 500, 20000);
-    const h = clampNumber(heightMm, 500, 20000);
-    const pts = [
-      { x: -w / 2, y: -h / 2 },
-      { x: w / 2, y: -h / 2 },
-      { x: w / 2, y: h / 2 },
-      { x: -w / 2, y: h / 2 },
-    ];
-    handlePointsChange(pts);
+    if (selectedRoom.roomShell?.points?.length && !window.confirm(
+      'Replace the current walls? Manual wall adjustments and doors attached to those walls will be removed.'
+    )) return;
+    const nextRoom: RoomConfig = { ...selectedRoom, roomShell: { points }, doors: [] };
+    setRooms((prev) => prev.map((room) => room.id === selectedRoom.id ? nextRoom : room));
+    stopDrawing();
+    setIsDoorPlacementMode(false);
+    setSelectedSegment(null);
+    setSegmentDragIndex(null);
+    setSegmentDragStart(null);
+    setSegmentDragBase(null);
+    setEndpointDrag(null);
+    setDoorDrag(null);
+    setSelectedDoorId(null);
+    setActiveBasicShape(selection);
+    setShowBasicShapes(false);
+    setActiveMobileSheet(null);
+    const maxDimension = Math.max(
+      Math.max(...points.map((point) => point.x)) - Math.min(...points.map((point) => point.x)),
+      Math.max(...points.map((point) => point.y)) - Math.min(...points.map((point) => point.y)),
+    );
+    setZoom(Math.min(5, Math.max(0.1, (0.8 * rangeMm) / Math.max(100, maxDimension + 1000))));
+    setPanOffsetMm({ x: 0, y: 0 });
   };
 
   const handleClear = () => {
@@ -698,6 +702,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     }
     setClearedPoints(selectedRoom.roomShell?.points ?? null);
     handlePointsChange([]);
+    setActiveBasicShape(null);
     stopDrawing();
     setShowClearConfirm(false);
   };
@@ -773,7 +778,12 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
       }
       if (e.key === 'a' || e.key === 'A') {
         e.preventDefault();
-        setIsDrawingWall((prev) => !prev);
+        if (activeBasicShape) {
+          setActiveBasicShape(null);
+          setIsDrawingWall(true);
+        } else {
+          setIsDrawingWall((prev) => !prev);
+        }
         return;
       }
       if (e.key === 'Enter') {
@@ -799,6 +809,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     deleteSelectedWallPoint,
     handleCloseLoop,
     isDrawingWall,
+    activeBasicShape,
     removeLastPoint,
     selectedRoom?.roomShell?.points,
     selectedSegment,
@@ -1293,6 +1304,22 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
         </div>
       )}
 
+      {showBasicShapes && (
+        <div className="fixed inset-0 z-[110] flex items-center justify-center overflow-y-auto bg-black/70 p-4 backdrop-blur-sm">
+          <BasicRoomShapesPicker
+            units={displayUnits}
+            onApply={handleApplyBasicShape}
+            onDrawOwn={() => {
+              setShowBasicShapes(false);
+              setActiveBasicShape(null);
+              setIsDoorPlacementMode(false);
+              setIsDrawingWall(true);
+            }}
+            onCancel={() => setShowBasicShapes(false)}
+          />
+        </div>
+      )}
+
       {/* Installation Angle Suggestion Modal */}
       {showRotationSuggestion && rotationSuggestion && (
         <div className="fixed inset-0 z-[100] flex items-center justify-center">
@@ -1630,6 +1657,21 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                     setIsCanvasDragging(false);
                   }}
                   onDragStateChange={setIsCanvasDragging}
+                  lockShell={!!activeBasicShape}
+                  showAllWallLengthLabels={!!activeBasicShape}
+                  onWallLengthChange={activeBasicShape ? (segmentIndex, lengthMm) => {
+                    try {
+                      const resized = resizeBasicRoomShapeWall(activeBasicShape, segmentIndex, lengthMm);
+                      setActiveBasicShape(resized.selection);
+                      handlePointsChange(resized.points);
+                      setPanOffsetMm({ x: 0, y: 0 });
+                      const maxDimension = Math.max(
+                        Math.max(...resized.points.map((point) => point.x)) - Math.min(...resized.points.map((point) => point.x)),
+                        Math.max(...resized.points.map((point) => point.y)) - Math.min(...resized.points.map((point) => point.y)),
+                      );
+                      setZoom(Math.min(5, Math.max(0.1, (0.8 * rangeMm) / Math.max(100, maxDimension + 1000))));
+                    } catch { /* Invalid dimensions leave the last valid centered outline unchanged. */ }
+                  } : undefined}
                   rangeMm={rangeMm}
                   gridSpacingMm={1000}
                   snapGridMm={snapGridMm}
@@ -1870,12 +1912,22 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
           <div className="absolute top-24 left-6 z-40 hidden rounded-xl border border-slate-700/50 bg-slate-900/90 backdrop-blur p-3 shadow-xl md:block">
             <div className="flex flex-col gap-2 text-sm">
               <button
+                className="rounded-xl border border-aqua-600/50 bg-aqua-600/10 px-4 py-2.5 font-semibold text-aqua-100 shadow-lg transition-all hover:bg-aqua-600/20"
+                onClick={() => setShowBasicShapes(true)}
+                disabled={!selectedRoom}
+              >
+                ▭ Basic Shapes
+              </button>
+              <button
                 className={`rounded-xl border px-4 py-2.5 font-semibold shadow-lg transition-all active:scale-95 ${
                   isDrawingWall
                     ? 'border-aqua-600/50 bg-aqua-600/20 text-aqua-100 hover:bg-aqua-600/30'
                     : 'border-slate-700/50 bg-slate-800/50 text-slate-200 hover:border-slate-600'
                 }`}
-                onClick={() => setIsDrawingWall((prev) => !prev)}
+                onClick={() => {
+                  if (activeBasicShape) setActiveBasicShape(null);
+                  setIsDrawingWall((prev) => activeBasicShape ? true : !prev);
+                }}
               >
                 {isDrawingWall ? '✕ Stop (Esc)' : '✏️ Add wall (A)'}
               </button>
@@ -2859,12 +2911,23 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
         <div className="grid grid-cols-2 gap-2 text-sm">
           <button
             type="button"
+            className="col-span-2 rounded-lg border border-aqua-600/60 bg-aqua-600/20 px-3 py-3 font-semibold text-aqua-100 disabled:opacity-40"
+            onClick={() => setShowBasicShapes(true)}
+            disabled={!selectedRoom}
+          >
+            Basic Shapes
+          </button>
+          <button
+            type="button"
             className={`rounded-lg border px-3 py-3 font-semibold ${
               isDrawingWall
                 ? 'border-aqua-500 bg-aqua-500/20 text-aqua-100'
                 : 'border-slate-700 bg-slate-800 text-slate-100'
             }`}
-            onClick={() => setIsDrawingWall((prev) => !prev)}
+            onClick={() => {
+              if (activeBasicShape) setActiveBasicShape(null);
+              setIsDrawingWall((prev) => activeBasicShape ? true : !prev);
+            }}
           >
             {isDrawingWall ? 'Stop Drawing' : 'Add Wall'}
           </button>
@@ -3055,6 +3118,3 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     </div>
   );
 };
-
-
-

--- a/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
@@ -15,6 +15,8 @@ import {
   CanvasTopBar,
 } from '../components/CanvasLayout';
 import { DisplaySettingsControls } from '../components/DisplaySettingsControls';
+import { BasicRoomShapesPicker, resizeBasicRoomShapeWall, type BasicRoomShapeSelection } from '../components/BasicRoomShapesPicker';
+import type { RoomShapePoint } from '../utils/roomShapes';
 import { updateRoom } from '../api/rooms';
 import { useWallDrawing } from '../hooks/useWallDrawing';
 import { pushZonesToDevice, fetchZonesFromDevice, fetchPolygonModeStatus, setPolygonMode, fetchPolygonZonesFromDevice, pushPolygonZonesToDevice, PolygonModeStatus } from '../api/zones';
@@ -130,6 +132,8 @@ export const WizardPage: React.FC<WizardPageProps> = ({
   const [isCanvasDragging, setIsCanvasDragging] = useState(false);
   const [canvasSnap, setCanvasSnap] = useState(100);
   const [canvasPan, setCanvasPan] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+  const [showOutlineShapeChoice, setShowOutlineShapeChoice] = useState(false);
+  const [activeBasicShape, setActiveBasicShape] = useState<BasicRoomShapeSelection | null>(null);
 
   // Zone selection for embedded zone drawing
   const [selectedZoneId, setSelectedZoneId] = useState<string | null>(null);
@@ -753,12 +757,39 @@ export const WizardPage: React.FC<WizardPageProps> = ({
     stopDrawing();
   }, [selectedRoom, handleRoomOutlineChange, stopDrawing]);
 
-  // Auto-enable drawing mode when on outline step
+  // New outlines begin with a simple method choice; saved outlines resume in review mode.
   useEffect(() => {
     if (currentStep === 'outline') {
-      setIsDrawingWall(true);
+      const hasUsableOutline = (selectedRoom?.roomShell?.points?.length ?? 0) >= 3;
+      setShowOutlineShapeChoice(!hasUsableOutline);
+      setIsDrawingWall(false);
     }
-  }, [currentStep, setIsDrawingWall]);
+  }, [currentStep, selectedRoom?.id, setIsDrawingWall]);
+
+  const handleApplyWizardShape = useCallback(async (points: RoomShapePoint[], selection: BasicRoomShapeSelection) => {
+    if (!selectedRoom) return;
+    if (selectedRoom.roomShell?.points?.length && !window.confirm(
+      'Replace the current walls? Manual wall adjustments and doors attached to those walls will be removed.'
+    )) return;
+    const updatedRoom: RoomConfig = { ...selectedRoom, roomShell: { points }, doors: [] };
+    onRoomUpdate?.(updatedRoom);
+    try {
+      await updateRoom(selectedRoom.id, updatedRoom);
+      setError(null);
+      setShowOutlineShapeChoice(false);
+      setActiveBasicShape(selection);
+      setIsDrawingWall(false);
+      setCanvasPan({ x: 0, y: 0 });
+      const maxDimension = Math.max(
+        Math.max(...points.map((point) => point.x)) - Math.min(...points.map((point) => point.x)),
+        Math.max(...points.map((point) => point.y)) - Math.min(...points.map((point) => point.y)),
+      );
+      setCanvasZoom(Math.min(5, Math.max(0.1, (0.8 * 15000) / Math.max(100, maxDimension + 1000))));
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Failed to update room outline');
+      onRoomUpdate?.(selectedRoom);
+    }
+  }, [onRoomUpdate, selectedRoom, setIsDrawingWall]);
 
   // Keyboard shortcuts for outline step
   useEffect(() => {
@@ -780,7 +811,12 @@ export const WizardPage: React.FC<WizardPageProps> = ({
       }
       if (e.key === 'a' || e.key === 'A') {
         e.preventDefault();
-        setIsDrawingWall((prev) => !prev);
+        if (activeBasicShape) {
+          setActiveBasicShape(null);
+          setIsDrawingWall(true);
+        } else {
+          setIsDrawingWall((prev) => !prev);
+        }
         return;
       }
       if (e.key === 'Enter') {
@@ -799,7 +835,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [currentStep, isDrawingWall, selectedRoom?.roomShell?.points, stopDrawing, setIsDrawingWall, removeLastPoint, handleCloseLoop]);
+  }, [currentStep, isDrawingWall, activeBasicShape, selectedRoom?.roomShell?.points, stopDrawing, setIsDrawingWall, removeLastPoint, handleCloseLoop]);
 
   // Auto-initialize device placement to room center when entering placement step
   useEffect(() => {
@@ -1413,6 +1449,23 @@ export const WizardPage: React.FC<WizardPageProps> = ({
     const mobileZonesBadge = polygonModeStatus.enabled ? polygonZones.length : `${enabledZones.length}/${displayZones.length}`;
     const currentRoomName = selectedRoom?.name ?? 'Setup Wizard';
 
+    if (currentStep === 'outline' && showOutlineShapeChoice) {
+      return (
+        <div className="fixed inset-0 flex items-center justify-center overflow-y-auto bg-slate-950 p-4">
+          <BasicRoomShapesPicker
+            units={units}
+            onApply={handleApplyWizardShape}
+            onDrawOwn={() => {
+              setShowOutlineShapeChoice(false);
+              setActiveBasicShape(null);
+              setShowWelcomePopup(false);
+              setIsDrawingWall(true);
+            }}
+          />
+        </div>
+      );
+    }
+
     return (
       <div className="fixed inset-0 bg-slate-950 overflow-hidden">
         {/* Welcome Popup */}
@@ -1584,12 +1637,28 @@ export const WizardPage: React.FC<WizardPageProps> = ({
           }}
         >
           {currentStep === 'outline' && (
+            <>
             <RoomCanvas
               points={selectedRoom?.roomShell?.points ?? []}
               onChange={handleRoomOutlineChange}
               onCanvasClick={wallDrawingClick}
               onCanvasMove={wallDrawingMove}
               onDragStateChange={setIsCanvasDragging}
+              lockShell={!!activeBasicShape}
+              showAllWallLengthLabels={!!activeBasicShape}
+              onWallLengthChange={activeBasicShape ? (segmentIndex, lengthMm) => {
+                try {
+                  const resized = resizeBasicRoomShapeWall(activeBasicShape, segmentIndex, lengthMm);
+                  setActiveBasicShape(resized.selection);
+                  void handleRoomOutlineChange(resized.points);
+                  setCanvasPan({ x: 0, y: 0 });
+                  const maxDimension = Math.max(
+                    Math.max(...resized.points.map((point) => point.x)) - Math.min(...resized.points.map((point) => point.x)),
+                    Math.max(...resized.points.map((point) => point.y)) - Math.min(...resized.points.map((point) => point.y)),
+                  );
+                  setCanvasZoom(Math.min(5, Math.max(0.1, (0.8 * 15000) / Math.max(100, maxDimension + 1000))));
+                } catch { /* Invalid dimensions leave the last valid centered outline unchanged. */ }
+              } : undefined}
               previewFrom={pendingStart}
               previewTo={pendingStart && previewPoint ? previewPoint : null}
               rangeMm={15000}
@@ -1603,6 +1672,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
               displayUnits={units}
               showWalls={showWalls}
             />
+            </>
           )}
 
           {currentStep === 'doors' && (
@@ -1935,12 +2005,24 @@ export const WizardPage: React.FC<WizardPageProps> = ({
           {currentStep === 'outline' && (
             <div className="absolute top-24 left-6 z-40 hidden flex-col gap-2 md:flex">
               <button
+                className="rounded-xl border border-aqua-600/50 bg-aqua-600/10 px-4 py-2.5 text-sm font-semibold text-aqua-100 shadow-lg hover:bg-aqua-600/20"
+                onClick={() => {
+                  stopDrawing();
+                  setShowOutlineShapeChoice(true);
+                }}
+              >
+                ▭ Basic Shapes
+              </button>
+              <button
                 className={`rounded-xl border px-4 py-2.5 text-sm font-semibold shadow-lg transition-all active:scale-95 ${
                   isDrawingWall
                     ? 'border-rose-600/50 bg-rose-600/10 text-rose-100 hover:bg-rose-600/20'
                     : 'border-aqua-600/50 bg-aqua-600/10 text-aqua-100 hover:bg-aqua-600/20'
                 }`}
-                onClick={() => setIsDrawingWall((prev) => !prev)}
+                onClick={() => {
+                  if (activeBasicShape) setActiveBasicShape(null);
+                  setIsDrawingWall((prev) => activeBasicShape ? true : !prev);
+                }}
               >
                 {isDrawingWall ? '✕ Stop (Esc)' : '✏️ Add wall (A)'}
               </button>
@@ -2268,12 +2350,25 @@ export const WizardPage: React.FC<WizardPageProps> = ({
               {currentStep === 'outline' && (
                 <div className="space-y-3">
                   <button
+                    className="w-full rounded-lg border border-aqua-600/50 bg-aqua-600/20 px-4 py-3 text-sm font-semibold text-aqua-100"
+                    onClick={() => {
+                      setActiveMobileCanvasSheet(null);
+                      stopDrawing();
+                      setShowOutlineShapeChoice(true);
+                    }}
+                  >
+                    Basic Shapes
+                  </button>
+                  <button
                     className={`w-full rounded-lg border px-4 py-3 text-sm font-semibold ${
                       isDrawingWall
                         ? 'border-rose-600/50 bg-rose-600/20 text-rose-100'
                         : 'border-aqua-600/50 bg-aqua-600/20 text-aqua-100'
                     }`}
-                    onClick={() => setIsDrawingWall((prev) => !prev)}
+                    onClick={() => {
+                      if (activeBasicShape) setActiveBasicShape(null);
+                      setIsDrawingWall((prev) => activeBasicShape ? true : !prev);
+                    }}
                   >
                     {isDrawingWall ? 'Stop Drawing' : 'Add Wall'}
                   </button>
@@ -3898,4 +3993,3 @@ export const WizardPage: React.FC<WizardPageProps> = ({
     </div>
   );
 };
-

--- a/everything-presence-mmwave-configurator/frontend/src/utils/roomShapes.test.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/roomShapes.test.ts
@@ -1,0 +1,43 @@
+// @ts-nocheck -- Node's built-in runner supplies these modules; frontend production types stay dependency-free.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createLShapePoints, createRectanglePoints } from './roomShapes.ts';
+
+const bounds = (points) => ({
+  minX: Math.min(...points.map((point) => point.x)),
+  maxX: Math.max(...points.map((point) => point.x)),
+  minY: Math.min(...points.map((point) => point.y)),
+  maxY: Math.max(...points.map((point) => point.y)),
+});
+
+test('rectangle is consistently ordered and centered for odd dimensions', () => {
+  const points = createRectanglePoints({ width: 4001, length: 3001 });
+  assert.deepEqual(points, [
+    { x: -2000.5, y: -1500.5 }, { x: 2000.5, y: -1500.5 },
+    { x: 2000.5, y: 1500.5 }, { x: -2000.5, y: 1500.5 },
+  ]);
+});
+
+test('L-shape is centered, orthogonal, and concave', () => {
+  const points = createLShapePoints({ width: 5000, length: 4000, cutoutWidth: 2000, cutoutLength: 1500 });
+  assert.deepEqual(bounds(points), { minX: -2500, maxX: 2500, minY: -2000, maxY: 2000 });
+  assert.equal(points.length, 6);
+  assert.deepEqual(points[3], { x: 500, y: 500 });
+  points.forEach((point, index) => {
+    const next = points[(index + 1) % points.length];
+    assert.ok(point.x === next.x || point.y === next.y);
+  });
+});
+
+test('accepts small positive boundary values', () => {
+  assert.equal(createRectanglePoints({ width: Number.MIN_VALUE, length: 1 }).length, 4);
+  assert.equal(createLShapePoints({ width: 2, length: 2, cutoutWidth: 1, cutoutLength: 1 }).length, 6);
+});
+
+test('rejects invalid dimensions and oversized cutouts', () => {
+  for (const invalid of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.throws(() => createRectanglePoints({ width: invalid, length: 1 }));
+  }
+  assert.throws(() => createLShapePoints({ width: 4, length: 4, cutoutWidth: 4, cutoutLength: 1 }));
+  assert.throws(() => createLShapePoints({ width: 4, length: 4, cutoutWidth: 1, cutoutLength: 5 }));
+});

--- a/everything-presence-mmwave-configurator/frontend/src/utils/roomShapes.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/roomShapes.ts
@@ -1,0 +1,61 @@
+export interface RoomShapePoint {
+  x: number;
+  y: number;
+}
+
+export interface RectangleDimensions {
+  width: number;
+  length: number;
+}
+
+export interface LShapeDimensions extends RectangleDimensions {
+  cutoutWidth: number;
+  cutoutLength: number;
+}
+
+const assertPositiveFinite = (name: string, value: number) => {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} must be a positive number.`);
+  }
+};
+
+const centerByBounds = (points: RoomShapePoint[]): RoomShapePoint[] => {
+  const xs = points.map((point) => point.x);
+  const ys = points.map((point) => point.y);
+  const centerX = (Math.min(...xs) + Math.max(...xs)) / 2;
+  const centerY = (Math.min(...ys) + Math.max(...ys)) / 2;
+  return points.map((point) => ({ x: point.x - centerX, y: point.y - centerY }));
+};
+
+export const createRectanglePoints = ({ width, length }: RectangleDimensions): RoomShapePoint[] => {
+  assertPositiveFinite('Width', width);
+  assertPositiveFinite('Length', length);
+  return centerByBounds([
+    { x: 0, y: 0 },
+    { x: width, y: 0 },
+    { x: width, y: length },
+    { x: 0, y: length },
+  ]);
+};
+
+export const createLShapePoints = ({
+  width,
+  length,
+  cutoutWidth,
+  cutoutLength,
+}: LShapeDimensions): RoomShapePoint[] => {
+  assertPositiveFinite('Overall width', width);
+  assertPositiveFinite('Overall length', length);
+  assertPositiveFinite('Cutout width', cutoutWidth);
+  assertPositiveFinite('Cutout length', cutoutLength);
+  if (cutoutWidth >= width) throw new Error('Cutout width must be smaller than the overall width.');
+  if (cutoutLength >= length) throw new Error('Cutout length must be smaller than the overall length.');
+  return centerByBounds([
+    { x: 0, y: 0 },
+    { x: width, y: 0 },
+    { x: width, y: length - cutoutLength },
+    { x: width - cutoutWidth, y: length - cutoutLength },
+    { x: width - cutoutWidth, y: length },
+    { x: 0, y: length },
+  ]);
+};


### PR DESCRIPTION
## Summary
Updated predefined-shape dimension editing so each floating wall-length label is now the control. Clicking a wall label replaces it with an inline metric or imperial number field; Enter or focus loss applies the new length. Rectangle and L-shape constraints update the corresponding template dimensions, regenerate the centered polygon, keep corners locked, refresh all wall labels, and auto-fit the canvas. The separate floating dimension window was removed from both the wizard and Room Builder.

## Verification
Automated: `npm test` in `everything-presence-mmwave-configurator/frontend` passed all 4 geometry tests.
Manual test steps: 1. Action: Select Rectangle and click one of its floating horizontal wall labels. ExpectedResult: The label becomes an inline numeric field directly on that wall. 2. Action: Enter a new length and press Enter. ExpectedResult: Both corresponding horizontal walls update, labels show the new value, corners remain locked, and the rectangle stays centered. 3. Action: Edit a vertical Rectangle wall. ExpectedResult: The room length updates without changing its width. 4. Action: Select an L-shaped room and edit each of its six wall labels. ExpectedResult: Overall and cutout dimensions update consistently while the room remains orthogonal, valid, centered, and auto-fitted. 5. Action: Repeat in imperial mode. ExpectedResult: Inline fields accept feet and wall labels remain imperial. 6. Action: Enter zero, a negative value, or a cutout length that cannot form a valid room. ExpectedResult: The last valid room remains unchanged. 7. Action: Repeat in the wizard and Room Builder on desktop and mobile. ExpectedResult: Inline controls work identically and no separate dimension window appears.

Fixes #178