### PR TITLE
Feature Request: Delete Nodes

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/ha/zoneWriter.ts
+++ b/everything-presence-mmwave-configurator/backend/src/ha/zoneWriter.ts
@@ -1,6 +1,6 @@
 import { IHaWriteClient } from './writeClient';
 import { ZoneRect, ZonePolygon, EntityMappings } from '../domain/types';
-import { polygonToText } from '../domain/polygonUtils';
+import { isValidPolygon, polygonToText } from '../domain/polygonUtils';
 import { EntityResolver } from '../domain/entityResolver';
 import { deviceEntityService } from '../domain/deviceEntityService';
 import { logger } from '../logger';
@@ -138,6 +138,10 @@ export class ZoneWriter {
         const key = `zone${idx + 1}`;
         const entityId = resolvePolygon('polygon', idx + 1, 'polygonZoneEntities', key, polyMap[key]);
         if (entityId) {
+          if (!isValidPolygon(zone.vertices)) {
+            logger.warn({ entityId, zoneId: zone.id, vertices: zone.vertices.length }, 'Skipping polygon zone with fewer than 3 distinct vertices');
+            return;
+          }
           const textValue = polygonToText(zone.vertices);
           logger.debug({ entityId, vertices: zone.vertices.length }, 'Setting polygon zone');
           tasks.push({
@@ -170,6 +174,10 @@ export class ZoneWriter {
         const key = `exclusion${idx + 1}`;
         const entityId = resolvePolygon('polygonExclusion', idx + 1, 'polygonExclusionEntities', key, polyMap[key]);
         if (entityId) {
+          if (!isValidPolygon(zone.vertices)) {
+            logger.warn({ entityId, zoneId: zone.id, vertices: zone.vertices.length }, 'Skipping exclusion polygon with fewer than 3 distinct vertices');
+            return;
+          }
           const textValue = polygonToText(zone.vertices);
           logger.debug({ entityId, vertices: zone.vertices.length }, 'Setting exclusion polygon');
           tasks.push({
@@ -201,6 +209,10 @@ export class ZoneWriter {
         const key = `entry${idx + 1}`;
         const entityId = resolvePolygon('polygonEntry', idx + 1, 'polygonEntryEntities', key, polyMap[key]);
         if (entityId) {
+          if (!isValidPolygon(zone.vertices)) {
+            logger.warn({ entityId, zoneId: zone.id, vertices: zone.vertices.length }, 'Skipping entry polygon with fewer than 3 distinct vertices');
+            return;
+          }
           const textValue = polygonToText(zone.vertices);
           logger.debug({ entityId, vertices: zone.vertices.length }, 'Setting entry polygon');
           tasks.push({

--- a/everything-presence-mmwave-configurator/frontend/package.json
+++ b/everything-presence-mmwave-configurator/frontend/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",
-		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts",
+		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts src/utils/polygonVertices.test.ts",
 		"preview": "vite preview",
 		"format": "npx @biomejs/biome format",
 		"format:fix": "npx @biomejs/biome format --write",

--- a/everything-presence-mmwave-configurator/frontend/src/components/ZoneCanvas.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/ZoneCanvas.tsx
@@ -4,6 +4,12 @@ import { RoomCanvas } from './RoomCanvas';
 import { DevicePlacement, Point as RoomPoint } from './RoomCanvas';
 import { getFurnitureIcon } from '../furniture/icons';
 import { getFurnitureColors } from '../furniture/colors';
+import { canDeleteVertex } from '../utils/polygonVertices';
+
+export interface PolygonVertexSelection {
+  zoneId: string;
+  vertexIndex: number;
+}
 
 interface ZoneCanvasProps {
   zones: ZoneRect[];
@@ -16,6 +22,11 @@ interface ZoneCanvasProps {
   polygonLateralOnlyAxis?: 'x' | 'y';
   selectedId?: string | null;
   onSelect?: (id: string | null) => void;
+  // Polygon vertex (node) selection + deletion. Selection state lives in the
+  // owning page so the keyboard shortcut stays out of read-only canvases.
+  selectedVertex?: PolygonVertexSelection | null;
+  onVertexSelect?: (selection: PolygonVertexSelection | null) => void;
+  onVertexDelete?: (zoneId: string, vertexIndex: number) => void;
   rangeMm?: number;
   snapGridMm?: number;
   height?: number | string;
@@ -77,6 +88,9 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
   polygonLateralOnlyAxis,
   selectedId,
   onSelect,
+  selectedVertex,
+  onVertexSelect,
+  onVertexDelete,
   rangeMm = 6000,
   snapGridMm = 0,
   height = 520,
@@ -135,6 +149,11 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
       // Older embedded webviews can reject capture on SVG nodes.
     }
   };
+
+  // Node (vertex) deletion is only offered while polygons are hand-editable:
+  // never read-only, and never in ceiling-slice mode where the lateral-only
+  // axis makes vertex count structural.
+  const vertexEditingEnabled = !polygonReadOnly && !polygonLateralOnlyAxis && !!onVertexDelete;
 
   const effectiveRotationDeg =
     devicePlacement ? (devicePlacement.rotationDeg ?? 0) + (installationAngle ?? 0) : 0;
@@ -575,6 +594,9 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
           setDraggingVertex({ zoneId: polygon.id, vertexIndex });
           onDragStateChange?.(true);
           onSelect?.(polygon.id);
+          if (vertexEditingEnabled) {
+            onVertexSelect?.({ zoneId: polygon.id, vertexIndex });
+          }
         };
 
         // Render furniture (before zones, so zones appear on top)
@@ -775,6 +797,10 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
           const pointsStr = canvasVertices.map((v) => `${v.x},${v.y}`).join(' ');
 
           const isSelected = selectedId === polygon.id;
+          const activeVertexIndex =
+            vertexEditingEnabled && selectedVertex && selectedVertex.zoneId === polygon.id
+              ? selectedVertex.vertexIndex
+              : null;
 
           // Zone colors based on type
           let color: string;
@@ -869,27 +895,34 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
                 </text>
               )}
               {/* Vertex handles (only when selected) */}
-              {isSelected && !polygonReadOnly && canvasVertices.map((v, idx) => (
-                <circle
-                  key={`vertex-${idx}`}
-                  cx={v.x}
-                  cy={v.y}
-                  r={11}
-                  fill="white"
-                  stroke={color}
-                  strokeWidth={2}
-                  style={{ cursor: polygonLateralOnlyAxis === 'x' ? 'ew-resize' : polygonLateralOnlyAxis === 'y' ? 'ns-resize' : 'move' }}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onSelect?.(polygon.id);
-                  }}
-                  pointerEvents="all"
-                  onPointerDown={(e) => startPolygonVertexDrag(e, polygon, idx)}
-                  onPointerMove={handlePolygonPointerMove}
-                  onPointerUp={handlePolygonPointerRelease}
-                  onPointerCancel={handlePolygonPointerRelease}
-                />
-              ))}
+              {isSelected && !polygonReadOnly && canvasVertices.map((v, idx) => {
+                const isVertexSelected = activeVertexIndex === idx;
+
+                return (
+                  <circle
+                    key={`vertex-${idx}`}
+                    cx={v.x}
+                    cy={v.y}
+                    r={isVertexSelected ? 13 : 11}
+                    fill={isVertexSelected ? color : 'white'}
+                    stroke={isVertexSelected ? 'white' : color}
+                    strokeWidth={isVertexSelected ? 3 : 2}
+                    style={{ cursor: polygonLateralOnlyAxis === 'x' ? 'ew-resize' : polygonLateralOnlyAxis === 'y' ? 'ns-resize' : 'move' }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onSelect?.(polygon.id);
+                      if (vertexEditingEnabled) {
+                        onVertexSelect?.({ zoneId: polygon.id, vertexIndex: idx });
+                      }
+                    }}
+                    pointerEvents="all"
+                    onPointerDown={(e) => startPolygonVertexDrag(e, polygon, idx)}
+                    onPointerMove={handlePolygonPointerMove}
+                    onPointerUp={handlePolygonPointerRelease}
+                    onPointerCancel={handlePolygonPointerRelease}
+                  />
+                );
+              })}
               {isSelected && !polygonReadOnly && polygonLateralOnlyAxis && lateralDragEdges.map(({ start, end, idx }) => (
                 <line
                   key={`lateral-edge-${idx}`}
@@ -945,6 +978,8 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
                       const updatedPolygon = { ...polygon, vertices: newVertices };
                       const next = polygonZones.map(p => p.id === polygon.id ? updatedPolygon : p);
                       onPolygonZonesChange(next);
+                      // Indices shift once a node is inserted, so drop any selection.
+                      onVertexSelect?.(null);
                     }}
                     onPointerDown={(e) => {
                       e.stopPropagation();
@@ -953,6 +988,46 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
                   />
                 );
               })}
+              {/* Delete badge for the selected node - rendered last so it stays
+                  on top of the vertex and midpoint handles (touch-friendly). */}
+              {isSelected && activeVertexIndex !== null && (() => {
+                const vertexIndex = activeVertexIndex;
+                const anchor = canvasVertices[vertexIndex];
+                if (!anchor) return null;
+                if (!canDeleteVertex(polygon.vertices, vertexIndex)) return null;
+
+                const badgeX = anchor.x + 20;
+                const badgeY = anchor.y - 20;
+
+                return (
+                  <g
+                    key={`vertex-delete-${vertexIndex}`}
+                    style={{ cursor: 'pointer' }}
+                    pointerEvents="all"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onVertexDelete?.(polygon.id, vertexIndex);
+                    }}
+                    onPointerDown={(e) => {
+                      e.stopPropagation();
+                      if (e.cancelable) e.preventDefault();
+                      capturePointer(e);
+                    }}
+                  >
+                    <title>{`Delete node ${vertexIndex + 1}`}</title>
+                    {/* Enlarged transparent hit area for touch */}
+                    <circle cx={badgeX} cy={badgeY} r={18} fill="transparent" />
+                    <circle cx={badgeX} cy={badgeY} r={11} fill="#f43f5e" stroke="white" strokeWidth={2} />
+                    <path
+                      d={`M ${badgeX - 4} ${badgeY - 4} L ${badgeX + 4} ${badgeY + 4} M ${badgeX + 4} ${badgeY - 4} L ${badgeX - 4} ${badgeY + 4}`}
+                      stroke="white"
+                      strokeWidth={2}
+                      strokeLinecap="round"
+                      pointerEvents="none"
+                    />
+                  </g>
+                );
+              })()}
             </g>
           );
         }).filter(Boolean) : [];

--- a/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
@@ -44,6 +44,7 @@ import { getDeviceIconUrl } from '../utils/deviceIcon';
 import { resolveCoverageFov, resolveTrackingCoverageFov } from '../utils/coverage';
 import { usesPolygonOnlyZones } from '../utils/firmware';
 import { resolveEntityPrefix } from '../utils/entityUtils';
+import { MIN_POLYGON_VERTICES, canDeleteVertex, deleteVertex } from '../utils/polygonVertices';
 import {
   buildCeilingExclusionZones,
   buildCeilingSliceZones,
@@ -89,6 +90,8 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
   const [rooms, setRooms] = useState<RoomConfig[]>([]);
   const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
   const [selectedZoneId, setSelectedZoneId] = useState<string | null>(null);
+  // Selected polygon node (vertex) for deletion; null when no node is picked.
+  const [selectedVertex, setSelectedVertex] = useState<{ zoneId: string; vertexIndex: number } | null>(null);
   const [selectedProfileId, setSelectedProfileId] = useState<string | null>(null);
   const [rangeMm, setRangeMm] = useState(15000);
   const [error, setError] = useState<string | null>(null);
@@ -781,6 +784,84 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
       setSelectedZoneId(nextZones[0].id);
     }
   };
+
+  const handleVertexSelect = useCallback((selection: { zoneId: string; vertexIndex: number } | null) => {
+    // Ceiling slice polygons are generated from slice config, so their nodes
+    // are not hand-editable.
+    if (isCeilingSliceMode || !polygonModeStatus.enabled) {
+      setSelectedVertex(null);
+      return;
+    }
+    setSelectedVertex(selection);
+  }, [isCeilingSliceMode, polygonModeStatus.enabled]);
+
+  const deletePolygonVertex = useCallback((zoneId: string, vertexIndex: number) => {
+    if (isCeilingSliceMode || !polygonModeStatus.enabled) return;
+    const target = polygonZones.find((zone) => zone.id === zoneId);
+    if (!target) return;
+    if (!canDeleteVertex(target.vertices, vertexIndex)) {
+      setWarning(`Polygon zones need at least ${MIN_POLYGON_VERTICES} nodes, so this one cannot be deleted.`);
+      return;
+    }
+    setPolygonZones(polygonZones.map((zone) => (
+      zone.id === zoneId
+        ? { ...zone, vertices: deleteVertex(zone.vertices, vertexIndex) }
+        : zone
+    )));
+    setSelectedVertex(null);
+  }, [isCeilingSliceMode, polygonModeStatus.enabled, polygonZones]);
+
+  const deleteSelectedVertex = useCallback(() => {
+    if (!selectedVertex) return;
+    deletePolygonVertex(selectedVertex.zoneId, selectedVertex.vertexIndex);
+  }, [deletePolygonVertex, selectedVertex]);
+
+  // Drop the node selection whenever it stops pointing at an editable node
+  // (zone deleted/renumbered, node removed, mode switched, zone deselected).
+  useEffect(() => {
+    if (!selectedVertex) return;
+    if (!polygonModeStatus.enabled || isCeilingSliceMode) {
+      setSelectedVertex(null);
+      return;
+    }
+    if (selectedZoneId !== selectedVertex.zoneId) {
+      setSelectedVertex(null);
+      return;
+    }
+    const zone = polygonZones.find((candidate) => candidate.id === selectedVertex.zoneId);
+    if (!zone || selectedVertex.vertexIndex >= zone.vertices.length) {
+      setSelectedVertex(null);
+    }
+  }, [isCeilingSliceMode, polygonModeStatus.enabled, polygonZones, selectedVertex, selectedZoneId]);
+
+  // Delete/Backspace removes the selected polygon node; Escape clears it.
+  useEffect(() => {
+    if (!selectedVertex || !polygonModeStatus.enabled || isCeilingSliceMode) return;
+
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName?.toLowerCase();
+      const isEditable =
+        target?.isContentEditable ||
+        tag === 'input' ||
+        tag === 'textarea' ||
+        tag === 'select' ||
+        tag === 'button';
+      if (isEditable) return;
+
+      if (e.key === 'Escape') {
+        setSelectedVertex(null);
+        return;
+      }
+      if (e.key === 'Backspace' || e.key === 'Delete') {
+        e.preventDefault();
+        deleteSelectedVertex();
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [deleteSelectedVertex, isCeilingSliceMode, polygonModeStatus.enabled, selectedVertex]);
 
   const resolveZoneRestoreContext = useCallback(async () => {
     if (!selectedRoom?.deviceId) return null;
@@ -1706,6 +1787,9 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
             polygonLateralOnlyAxis={isCeilingSliceMode ? ceilingSliceConfig.axis : undefined}
             selectedId={selectedZoneId}
             onSelect={(id) => setSelectedZoneId(id)}
+            selectedVertex={isCeilingSliceMode ? null : selectedVertex}
+            onVertexSelect={isCeilingSliceMode ? undefined : handleVertexSelect}
+            onVertexDelete={isCeilingSliceMode ? undefined : deletePolygonVertex}
             rangeMm={rangeMm}
             snapGridMm={snapGridMm}
             height="100%"
@@ -2228,6 +2312,11 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
                     activePolygonZones.map((polygon) => {
                       const isSelected = selectedZoneId === polygon.id;
                       const polygonStatus = getPolygonStatus(polygon.id);
+                      const zoneSelectedVertex =
+                        selectedVertex && selectedVertex.zoneId === polygon.id ? selectedVertex : null;
+                      const canDeleteSelectedVertex = zoneSelectedVertex
+                        ? canDeleteVertex(polygon.vertices, zoneSelectedVertex.vertexIndex)
+                        : false;
                       return (
                         <div
                           key={polygon.id}
@@ -2329,6 +2418,34 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
                               }}
                             />
                           </div>
+                          {/* Node (vertex) editing */}
+                          {isSelected && !isCeilingSliceMode && (
+                            <div className="mb-2 flex items-center justify-between gap-2">
+                              <span className="text-[10px] text-slate-400">
+                                {zoneSelectedVertex
+                                  ? `Node ${zoneSelectedVertex.vertexIndex + 1} of ${polygon.vertices.length} selected`
+                                  : 'Tap a node on the canvas to select it'}
+                              </span>
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  if (!zoneSelectedVertex) return;
+                                  deletePolygonVertex(polygon.id, zoneSelectedVertex.vertexIndex);
+                                }}
+                                disabled={!canDeleteSelectedVertex}
+                                title={
+                                  polygon.vertices.length <= MIN_POLYGON_VERTICES
+                                    ? `Polygon zones need at least ${MIN_POLYGON_VERTICES} nodes`
+                                    : zoneSelectedVertex
+                                      ? 'Delete the selected node'
+                                      : 'Select a node on the canvas first'
+                                }
+                                className="shrink-0 rounded-lg border border-rose-500/70 px-2.5 py-1 text-[11px] font-semibold text-rose-100 transition hover:bg-rose-500/10 disabled:cursor-not-allowed disabled:border-slate-700 disabled:text-slate-500 disabled:hover:bg-transparent"
+                              >
+                                Delete node
+                              </button>
+                            </div>
+                          )}
                           {/* Vertex info */}
                           <div className="text-[10px] text-slate-400 font-mono">
                             {polygon.vertices.slice(0, 3).map((v, i) => (

--- a/everything-presence-mmwave-configurator/frontend/src/utils/polygonVertices.test.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/polygonVertices.test.ts
@@ -1,0 +1,61 @@
+// @ts-nocheck -- Node's built-in runner supplies these modules; frontend production types stay dependency-free.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { MIN_POLYGON_VERTICES, canDeleteVertex, deleteVertex } from './polygonVertices.ts';
+
+const square = [
+  { x: 0, y: 0 },
+  { x: 1000, y: 0 },
+  { x: 1000, y: 1000 },
+  { x: 0, y: 1000 },
+];
+
+test('minimum vertex count matches the backend polygon rule', () => {
+  assert.equal(MIN_POLYGON_VERTICES, 3);
+});
+
+test('deletes a vertex above the minimum without mutating the input', () => {
+  const next = deleteVertex(square, 1);
+  assert.deepEqual(next, [
+    { x: 0, y: 0 },
+    { x: 1000, y: 1000 },
+    { x: 0, y: 1000 },
+  ]);
+  assert.equal(square.length, 4);
+  assert.notEqual(next, square);
+});
+
+test('refuses to delete at or below the minimum vertex count', () => {
+  const triangle = square.slice(0, 3);
+  for (let index = 0; index < triangle.length; index += 1) {
+    assert.equal(canDeleteVertex(triangle, index), false);
+    assert.equal(deleteVertex(triangle, index), triangle);
+  }
+});
+
+test('refuses deletions that would leave fewer than three distinct points', () => {
+  const degenerate = [
+    { x: 0, y: 0 },
+    { x: 1000, y: 0 },
+    { x: 1000, y: 0 },
+    { x: 0, y: 1000 },
+  ];
+  assert.equal(canDeleteVertex(degenerate, 3), false);
+  assert.equal(deleteVertex(degenerate, 3), degenerate);
+  // Removing one half of the duplicate pair still leaves three distinct points.
+  assert.equal(canDeleteVertex(degenerate, 2), true);
+  assert.equal(deleteVertex(degenerate, 2).length, 3);
+});
+
+test('rejects out-of-range and non-integer indexes', () => {
+  for (const invalid of [-1, 4, 1.5, Number.NaN]) {
+    assert.equal(canDeleteVertex(square, invalid), false);
+    assert.equal(deleteVertex(square, invalid), square);
+  }
+});
+
+test('tolerates missing vertex lists', () => {
+  assert.equal(canDeleteVertex(undefined, 0), false);
+  assert.equal(canDeleteVertex(null, 0), false);
+  assert.equal(canDeleteVertex([], 0), false);
+});

--- a/everything-presence-mmwave-configurator/frontend/src/utils/polygonVertices.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/polygonVertices.ts
@@ -1,0 +1,43 @@
+export interface PolygonVertex {
+  x: number;
+  y: number;
+}
+
+/**
+ * Firmware/backend floor for a polygon zone. `isValidPolygon` in
+ * backend/src/domain/polygonUtils.ts rejects anything with fewer than three
+ * distinct points, so the editor must never let a user delete below it.
+ */
+export const MIN_POLYGON_VERTICES = 3;
+
+const countDistinct = (vertices: PolygonVertex[]): number => (
+  new Set(vertices.map((vertex) => `${vertex.x},${vertex.y}`)).size
+);
+
+const isDeletableIndex = (vertices: PolygonVertex[] | undefined | null, index: number): boolean => {
+  if (!Array.isArray(vertices)) return false;
+  if (!Number.isInteger(index)) return false;
+  return index >= 0 && index < vertices.length;
+};
+
+/**
+ * Whether the vertex at `index` can be removed while keeping the polygon valid.
+ * Guards both the raw vertex count and the number of distinct points, matching
+ * the backend validation rule.
+ */
+export function canDeleteVertex(vertices: PolygonVertex[] | undefined | null, index: number): boolean {
+  if (!isDeletableIndex(vertices, index)) return false;
+  const list = vertices as PolygonVertex[];
+  if (list.length <= MIN_POLYGON_VERTICES) return false;
+  const remaining = list.filter((_, idx) => idx !== index);
+  return countDistinct(remaining) >= MIN_POLYGON_VERTICES;
+}
+
+/**
+ * Remove the vertex at `index`, returning a new array. Returns the original
+ * array untouched when the deletion would leave an invalid polygon.
+ */
+export function deleteVertex<T extends PolygonVertex>(vertices: T[], index: number): T[] {
+  if (!canDeleteVertex(vertices, index)) return vertices;
+  return vertices.filter((_, idx) => idx !== index);
+}


### PR DESCRIPTION
## Summary
Implemented polygon node (vertex) deletion in the Zone Editor, addressing issue #384. Added a dependency-free helper module `frontend/src/utils/polygonVertices.ts` exporting `MIN_POLYGON_VERTICES = 3`, `canDeleteVertex(vertices, index)` and `deleteVertex(vertices, index)`; the guard enforces both the raw count and the number of distinct points so a deletion can never produce a polygon the backend's `isValidPolygon` would reject. Covered it with a node:test unit file wired into the frontend `test` script. `ZoneCanvas` gained three OPTIONAL props (`selectedVertex`, `onVertexSelect`, `onVertexDelete`) plus an internal `vertexEditingEnabled` flag (`!polygonReadOnly && !polygonLateralOnlyAxis && !!onVertexDelete`), so read-only canvases (LiveTracking, Wizard, EP1 dashboard) are unchanged. When editing is enabled, clicking/tapping a vertex handle selects it (highlighted with a filled, slightly larger circle) and a rose × delete badge is drawn 20px up-right of the selected node, rendered last in the polygon group so it sits above the vertex and midpoint handles and with an 18px transparent hit circle for touch. The badge only appears when `canDeleteVertex` is true, so at 3 nodes there is no delete affordance. Adding a node via an edge midpoint clears the selection because indices shift.

## Verification
Automated: run `npm test` in `everything-presence-mmwave-configurator/frontend` (now runs roomShapes.test.ts + polygonVertices.test.ts) and `npm run build`/`npm run lint` at the workspace root for typecheck and Biome.
Manual (against a deployed preview, not run by me):
1. Action: open Zone Editor for a polygon-mode device, add a polygon zone, then click an edge midpoint twice to reach 5 nodes. Expected: the vertex badge in the zone card reads "5 vertices".
2. Action: click (or tap) one of the white vertex handles. Expected: the handle fills with the zone colour and a red × badge appears just above-right of it; the zone card shows "Node N of 5 selected".
3. Action: click the red × badge. Expected: that node disappears, the polygon re-shapes, the vertex count drops to 4, and the badge/selection clears.
4. Action: select a node and press Delete (or Backspace) with focus outside any text field. Expected: the selected node is removed; pressing Escape instead clears the selection without deleting.
5. Action: type in the zone-name input and press Backspace. Expected: the text edits normally and no node is deleted.
6. Action: reduce a zone to 3 nodes and select one. Expected: no × badge appears, the card's "Delete node" button is disabled with a tooltip about the 3-node minimum, and Delete/Backspace produces the warning banner instead of removing a node.
7. Action: Save Zones after deleting nodes, then reload the page/refetch from device. Expected: the reduced polygon persists with the smaller node count.
8. Action: on an EP Pro with ceiling mount (ceiling-slice mode) select a slice and press Delete. Expected: no node badge, no "Delete node" control, and nothing is deleted.
9. Action: open the Live Dashboard / wizard preview canvases. Expected: zones are unchanged and non-editable — no node badges anywhere.

Fixes #384