### PR TITLE
Bug: undo deletes more things

### DIFF
--- a/everything-presence-mmwave-configurator/frontend/package.json
+++ b/everything-presence-mmwave-configurator/frontend/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",
-		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts src/utils/polygonVertices.test.ts",
+		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts src/utils/polygonVertices.test.ts src/utils/roomHistory.test.ts",
 		"preview": "vite preview",
 		"format": "npx @biomejs/biome format",
 		"format:fix": "npx @biomejs/biome format --write",

--- a/everything-presence-mmwave-configurator/frontend/src/hooks/useWallDrawing.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/hooks/useWallDrawing.ts
@@ -135,12 +135,21 @@ export function useWallDrawing({ snapGridMm, onPointsChange, currentPoints }: Us
     setPreviewPoint(null);
   }, []);
 
+  /**
+   * Drop the point that was just drawn. This is a drawing-mode tool, not a
+   * general undo: on a finished outline it would silently eat vertices the user
+   * never placed in this session, so it only runs while drawing is active.
+   */
   const removeLastPoint = useCallback(() => {
+    if (!isDrawingWall) return;
     if (currentPoints.length > 0) {
       const newPoints = currentPoints.slice(0, -1);
       onPointsChange(newPoints);
+      // Keep the rubber-band preview anchored to a point that still exists.
+      setPendingStart(newPoints.length ? newPoints[newPoints.length - 1] : null);
+      setPreviewPoint(null);
     }
-  }, [currentPoints, onPointsChange]);
+  }, [currentPoints, isDrawingWall, onPointsChange]);
 
   return {
     isDrawingWall,
@@ -152,5 +161,7 @@ export function useWallDrawing({ snapGridMm, onPointsChange, currentPoints }: Us
     stopDrawing,
     removeLastPoint,
     setIsDrawingWall,
+    setPendingStart,
+    setPreviewPoint,
   };
 }

--- a/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
@@ -31,6 +31,20 @@ import {
   getCeilingSlicePosition,
   normalizeCeilingSliceConfig,
 } from '../utils/ceilingSlices';
+import { stableStringify } from '../utils/stableStringify';
+import {
+  ROOM_HISTORY_LIMIT,
+  applyRoomSnapshot,
+  canRedoRoomHistory,
+  canUndoRoomHistory,
+  createRoomHistory,
+  pushRoomHistory,
+  redoRoomHistory,
+  roomSnapshotSignature,
+  snapshotRoom,
+  undoRoomHistory,
+  type RoomHistory,
+} from '../utils/roomHistory';
 
 interface RoomBuilderPageProps {
   onBack?: () => void;
@@ -54,23 +68,13 @@ type RoomBuilderSettingsTab = 'canvas' | 'device' | 'display' | 'floor';
 type RoomBuilderView = 'wizard' | 'zoneEditor' | 'roomBuilder' | 'settings' | 'liveDashboard';
 type PendingLeave = { type: 'navigate'; view: RoomBuilderView } | { type: 'back' };
 
-// Stable, key-order independent stringify so a room reserialised by the backend
-// compares equal to the identical room held in local state.
-const stableStringify = (value: unknown): string => {
-  if (value === null || typeof value !== 'object') {
-    return JSON.stringify(value ?? null) ?? 'null';
-  }
-  if (Array.isArray(value)) {
-    return `[${value.map(stableStringify).join(',')}]`;
-  }
-  const entries = Object.entries(value as Record<string, unknown>)
-    .filter(([, v]) => v !== undefined)
-    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
-    .map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`);
-  return `{${entries.join(',')}}`;
-};
-
 const roomSignature = (room: RoomConfig | null | undefined): string => (room ? stableStringify(room) : '');
+
+// One user gesture should be one undo step. Continuous input (dragging
+// furniture, sweeping a slider, dragging a wall) fires a change per pointer
+// move, so those commits share a key and collapse onto the first snapshot until
+// the gesture ends.
+type CommitRoomOptions = { coalesceKey?: string };
 
 export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   onBack,
@@ -154,6 +158,12 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   const [wallEditorDragOffset, setWallEditorDragOffset] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
   const [wallEditorDragging, setWallEditorDragging] = useState(false);
   const [canvasViewportSize, setCanvasViewportSize] = useState({ width: 0, height: 0 });
+  // Session-only undo/redo, one stack per room. Held in a ref so a drag does not
+  // re-render per snapshot; `historyAvailability` mirrors just what the buttons
+  // need. Nothing here is persisted, so it dies with the page.
+  const historyRef = useRef<Map<string, RoomHistory>>(new Map());
+  const activeCoalesceKeyRef = useRef<string | null>(null);
+  const [historyAvailability, setHistoryAvailability] = useState({ canUndo: false, canRedo: false });
   const lastRotationSuggestionRef = useRef<number | null>(null);
   const wallEditorDragPointerRef = useRef<number | null>(null);
   const wallEditorDragStartRef = useRef<{ x: number; y: number; offsetX: number; offsetY: number } | null>(null);
@@ -168,6 +178,65 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   const selectedRoom = useMemo(
     () => (selectedRoomId ? rooms.find((r) => r.id === selectedRoomId) ?? null : null),
     [rooms, selectedRoomId],
+  );
+
+  const syncHistoryAvailability = useCallback((roomId: string | null) => {
+    const history = roomId ? historyRef.current.get(roomId) : null;
+    const next = { canUndo: canUndoRoomHistory(history), canRedo: canRedoRoomHistory(history) };
+    setHistoryAvailability((prev) =>
+      prev.canUndo === next.canUndo && prev.canRedo === next.canRedo ? prev : next,
+    );
+  }, []);
+
+  // A gesture ends on pointer-up or when focus leaves the control being used;
+  // the next edit then starts a fresh undo step.
+  const endHistoryGesture = useCallback(() => {
+    activeCoalesceKeyRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    const handler = () => endHistoryGesture();
+    window.addEventListener('pointerup', handler);
+    window.addEventListener('pointercancel', handler);
+    window.addEventListener('focusout', handler);
+    return () => {
+      window.removeEventListener('pointerup', handler);
+      window.removeEventListener('pointercancel', handler);
+      window.removeEventListener('focusout', handler);
+    };
+  }, [endHistoryGesture]);
+
+  /**
+   * The single write path for room edits made in the builder. Every edit
+   * records the pre-edit state so Undo can put it back, then applies the new
+   * room. Loading and saving deliberately bypass this: neither is a user edit.
+   */
+  const commitRoom = useCallback(
+    (nextRoom: RoomConfig, options?: CommitRoomOptions) => {
+      const previous = selectedRoom;
+      if (!previous || previous.id !== nextRoom.id) return;
+
+      const previousSnapshot = snapshotRoom(previous);
+      const coalesceKey = options?.coalesceKey ?? null;
+      // Events that change nothing (a slider re-emitting its current value)
+      // must not consume an undo step.
+      if (roomSnapshotSignature(previousSnapshot) !== roomSnapshotSignature(snapshotRoom(nextRoom))) {
+        const history = historyRef.current.get(previous.id) ?? createRoomHistory();
+        historyRef.current.set(
+          previous.id,
+          pushRoomHistory(history, previousSnapshot, {
+            coalesceKey,
+            activeCoalesceKey: activeCoalesceKeyRef.current,
+            limit: ROOM_HISTORY_LIMIT,
+          }),
+        );
+        activeCoalesceKeyRef.current = coalesceKey;
+        syncHistoryAvailability(previous.id);
+      }
+
+      setRooms((prev) => prev.map((r) => (r.id === previous.id ? nextRoom : r)));
+    },
+    [selectedRoom, syncHistoryAvailability],
   );
 
   const selectedProfile = useMemo(
@@ -224,8 +293,8 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     const base: DevicePlacement = selectedRoom.devicePlacement ?? { x: 0, y: 0, rotationDeg: 0 };
     const nextPlacement: DevicePlacement = { ...base, ...updates };
     const nextRoom: RoomConfig = { ...selectedRoom, devicePlacement: nextPlacement };
-    setRooms((prev) => prev.map((r) => (r.id === selectedRoom.id ? nextRoom : r)));
-  }, [selectedRoom]);
+    commitRoom(nextRoom, { coalesceKey: 'device:placement' });
+  }, [commitRoom, selectedRoom]);
 
   const coveragePresets = selectedProfile?.coverage?.presets ?? null;
   const coveragePresetId = useMemo(() => {
@@ -358,11 +427,11 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     }
   }, [selectedRoom?.deviceId, rotationSuggestion, resolveInstallationAngleEntityId]);
 
-  const handlePointsChange = useCallback((nextPoints: { x: number; y: number }[]) => {
+  const handlePointsChange = useCallback((nextPoints: { x: number; y: number }[], options?: CommitRoomOptions) => {
     if (!selectedRoom) return;
     const updated: RoomConfig = { ...selectedRoom, roomShell: { points: nextPoints } };
-    setRooms((prev) => prev.map((r) => (r.id === selectedRoom.id ? updated : r)));
-  }, [selectedRoom]);
+    commitRoom(updated, options);
+  }, [commitRoom, selectedRoom]);
 
   const handleAddFurniture = useCallback((furnitureType: FurnitureType) => {
     if (!selectedRoom) return;
@@ -394,11 +463,11 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
       ...selectedRoom,
       furniture: [...(selectedRoom.furniture ?? []), newFurniture],
     };
-    setRooms((prev) => prev.map((r) => (r.id === selectedRoom.id ? updated : r)));
+    commitRoom(updated);
     setSelectedFurnitureId(newFurniture.id);
     setShowFurnitureLibrary(false);
     setActiveMobileSheet(null);
-  }, [selectedRoom]);
+  }, [commitRoom, selectedRoom]);
 
   const handleFurnitureChange = useCallback((updatedFurniture: FurnitureInstance) => {
     if (!selectedRoom) return;
@@ -406,8 +475,10 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
       ...selectedRoom,
       furniture: (selectedRoom.furniture ?? []).map((f) => (f.id === updatedFurniture.id ? updatedFurniture : f)),
     };
-    setRooms((prev) => prev.map((r) => (r.id === selectedRoom.id ? updated : r)));
-  }, [selectedRoom]);
+    // Dragging, resizing, rotating and the sliders all land here per input
+    // event - one key per item keeps a whole gesture at one undo step.
+    commitRoom(updated, { coalesceKey: `furniture:${updatedFurniture.id}` });
+  }, [commitRoom, selectedRoom]);
 
   const handleFurnitureDelete = useCallback(() => {
     if (!selectedRoom || !selectedFurnitureId) return;
@@ -415,9 +486,9 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
       ...selectedRoom,
       furniture: (selectedRoom.furniture ?? []).filter((f) => f.id !== selectedFurnitureId),
     };
-    setRooms((prev) => prev.map((r) => (r.id === selectedRoom.id ? updated : r)));
+    commitRoom(updated);
     setSelectedFurnitureId(null);
-  }, [selectedRoom, selectedFurnitureId]);
+  }, [commitRoom, selectedRoom, selectedFurnitureId]);
 
   const handleAddDoor = useCallback(() => {
     if (!selectedRoom) return;
@@ -441,8 +512,9 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
       ...selectedRoom,
       doors: (selectedRoom.doors ?? []).map((d) => (d.id === updatedDoor.id ? updatedDoor : d)),
     };
-    setRooms((prev) => prev.map((r) => (r.id === selectedRoom.id ? updated : r)));
-  }, [selectedRoom]);
+    // Sliding a door along a wall fires per pointer move; coalesce per door.
+    commitRoom(updated, { coalesceKey: `door:${updatedDoor.id}` });
+  }, [commitRoom, selectedRoom]);
 
   const handleDoorDelete = useCallback(() => {
     if (!selectedRoom || !selectedDoorId) return;
@@ -450,9 +522,9 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
       ...selectedRoom,
       doors: (selectedRoom.doors ?? []).filter((d) => d.id !== selectedDoorId),
     };
-    setRooms((prev) => prev.map((r) => (r.id === selectedRoom.id ? updated : r)));
+    commitRoom(updated);
     setSelectedDoorId(null);
-  }, [selectedRoom, selectedDoorId]);
+  }, [commitRoom, selectedRoom, selectedDoorId]);
 
   // Helper to generate UUID
   const generateId = () => {
@@ -482,10 +554,10 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
       ...selectedRoom,
       doors: [...(selectedRoom.doors ?? []), newDoor],
     };
-    setRooms((prev) => prev.map((r) => (r.id === selectedRoom.id ? updated : r)));
+    commitRoom(updated);
     setSelectedDoorId(newDoor.id);
     setIsDoorPlacementMode(false); // Exit placement mode after placing
-  }, [selectedRoom, isDoorPlacementMode]);
+  }, [commitRoom, selectedRoom, isDoorPlacementMode]);
 
   const handleDoorDragStart = useCallback((doorId: string, x: number, y: number) => {
     const door = selectedRoom?.doors?.find((d) => d.id === doorId);
@@ -612,11 +684,59 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     stopDrawing,
     removeLastPoint,
     setIsDrawingWall,
+    setPendingStart,
   } = useWallDrawing({
     snapGridMm,
     onPointsChange: handlePointsChange,
     currentPoints: selectedRoom?.roomShell?.points ?? [],
   });
+
+  /**
+   * Undo/redo restores the whole builder state of the room, so it reverses any
+   * edit - a deleted door or furniture item comes back, not just wall points.
+   */
+  const stepHistory = useCallback(
+    (direction: 'undo' | 'redo') => {
+      const room = selectedRoom;
+      if (!room) return;
+      const history = historyRef.current.get(room.id);
+      if (!history) return;
+
+      const current = snapshotRoom(room);
+      const step = direction === 'undo' ? undoRoomHistory(history, current) : redoRoomHistory(history, current);
+      if (!step) return;
+
+      historyRef.current.set(room.id, step.history);
+      endHistoryGesture();
+      const restored = applyRoomSnapshot(room, step.snapshot);
+      setRooms((prev) => prev.map((r) => (r.id === room.id ? restored : r)));
+      syncHistoryAvailability(room.id);
+
+      // Drop any transient interaction that may now point at something that no
+      // longer exists (or exists again at a different index).
+      const points = restored.roomShell?.points ?? [];
+      setSelectedSegment((prev) => (prev !== null && prev >= points.length ? null : prev));
+      setHoveredSegment(null);
+      setSegmentDragIndex(null);
+      setSegmentDragStart(null);
+      setSegmentDragBase(null);
+      setEndpointDrag(null);
+      setDoorDrag(null);
+      setIsDoorPlacementMode(false);
+      setActiveBasicShape(null);
+      setSelectedFurnitureId((prev) => (prev && !(restored.furniture ?? []).some((f) => f.id === prev) ? null : prev));
+      setSelectedDoorId((prev) => (prev && !(restored.doors ?? []).some((d) => d.id === prev) ? null : prev));
+      if (isDrawingWall) {
+        setPendingStart(points.length ? points[points.length - 1] : null);
+      }
+    },
+    [endHistoryGesture, isDrawingWall, selectedRoom, setPendingStart, syncHistoryAvailability],
+  );
+
+  const handleUndo = useCallback(() => stepHistory('undo'), [stepHistory]);
+  const handleRedo = useCallback(() => stepHistory('redo'), [stepHistory]);
+  const canUndo = historyAvailability.canUndo && !!selectedRoom;
+  const canRedo = historyAvailability.canRedo && !!selectedRoom;
 
   useEffect(() => {
     const load = async () => {
@@ -649,7 +769,11 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     setClearedPoints(null);
     setShowClearConfirm(false);
     setActiveBasicShape(null);
-  }, [selectedRoomId]);
+    // Each room keeps its own stack for the session, so switching back to a room
+    // keeps its undo history.
+    endHistoryGesture();
+    syncHistoryAvailability(selectedRoomId);
+  }, [endHistoryGesture, selectedRoomId, syncHistoryAvailability]);
 
   const handleAddPoint = (p: { x: number; y: number }) => {
     if (!selectedRoom) return;
@@ -663,7 +787,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
       'Replace the current walls? Manual wall adjustments and doors attached to those walls will be removed.'
     )) return;
     const nextRoom: RoomConfig = { ...selectedRoom, roomShell: { points }, doors: [] };
-    setRooms((prev) => prev.map((room) => room.id === selectedRoom.id ? nextRoom : room));
+    commitRoom(nextRoom);
     stopDrawing();
     setIsDoorPlacementMode(false);
     setSelectedSegment(null);
@@ -690,8 +814,8 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
       stopDrawing();
       return;
     }
-    // Clearing removes every wall at once and cannot be undone with Undo (Del),
-    // so ask first.
+    // Clearing removes every wall at once, so ask first even though Undo can
+    // now bring them back within this session.
     setShowClearConfirm(true);
   };
 
@@ -764,12 +888,30 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     const handler = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName?.toLowerCase();
-      const isEditable =
+      const isTextEntry =
         target?.isContentEditable ||
         tag === 'input' ||
         tag === 'textarea' ||
-        tag === 'select' ||
-        tag === 'button';
+        tag === 'select';
+      const isEditable = isTextEntry || tag === 'button';
+
+      // Undo/redo stay available right after clicking a toolbar button, so they
+      // are handled before the "focus is on a control" bail-out. Text fields
+      // keep the browser's own undo.
+      if ((e.ctrlKey || e.metaKey) && !e.altKey) {
+        const key = e.key.toLowerCase();
+        if (key === 'z' || key === 'y') {
+          if (isTextEntry) return;
+          e.preventDefault();
+          if (key === 'y' || e.shiftKey) {
+            handleRedo();
+          } else {
+            handleUndo();
+          }
+          return;
+        }
+      }
+
       if (isEditable) return;
 
       if (e.key === 'Escape') {
@@ -795,12 +937,17 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
       }
       if (e.key === 'Backspace' || e.key === 'Delete') {
         if (!selectedRoom?.roomShell?.points?.length) return;
-        e.preventDefault();
+        // Del is a point-level delete, never a general undo: it removes the
+        // selected wall point, or the point just drawn while drawing is active.
         if (selectedSegment !== null) {
+          e.preventDefault();
           deleteSelectedWallPoint();
           return;
         }
-        removeLastPoint();
+        if (isDrawingWall) {
+          e.preventDefault();
+          removeLastPoint();
+        }
       }
     };
     window.addEventListener('keydown', handler);
@@ -808,6 +955,8 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   }, [
     deleteSelectedWallPoint,
     handleCloseLoop,
+    handleRedo,
+    handleUndo,
     isDrawingWall,
     activeBasicShape,
     removeLastPoint,
@@ -1104,7 +1253,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
       const adjDx = snappedTarget.x - endpointDrag.base[targetIdx].x;
       const adjDy = snappedTarget.y - endpointDrag.base[targetIdx].y;
       next[targetIdx] = { x: endpointDrag.base[targetIdx].x + adjDx, y: endpointDrag.base[targetIdx].y + adjDy };
-      handlePointsChange(next);
+      handlePointsChange(next, { coalesceKey: `points:endpoint-drag:${endpointDrag.segment}:${endpointDrag.endpoint}` });
       return;
     }
 
@@ -1122,7 +1271,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
       const snappedB = snapPointToGrid({ x: segmentDragBase[bIdx].x + dx, y: segmentDragBase[bIdx].y + dy });
       next[aIdx] = snappedA;
       next[bIdx] = snappedB;
-      handlePointsChange(next);
+      handlePointsChange(next, { coalesceKey: `points:segment-drag:${segmentDragIndex}` });
       return;
     }
 
@@ -1211,11 +1360,15 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
       if (saved) {
         setRooms((prev) => prev.map((r) => (r.id === saved.id ? saved : r)));
       }
+      // Discarded edits must not be reachable through Undo afterwards.
+      historyRef.current.delete(selectedRoom.id);
+      endHistoryGesture();
+      syncHistoryAvailability(selectedRoom.id);
     }
     setClearedPoints(null);
     setPendingLeave(null);
     leave(target);
-  }, [leave, pendingLeave, savedRooms, selectedRoom]);
+  }, [endHistoryGesture, leave, pendingLeave, savedRooms, selectedRoom, syncHistoryAvailability]);
 
   // Reloading or closing the tab also discards unsaved room edits - warn first.
   useEffect(() => {
@@ -1432,8 +1585,8 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
               </div>
               <h3 className="text-xl font-bold text-white text-center mb-2">Delete all walls?</h3>
               <p className="text-sm text-slate-300 text-center mb-5">
-                This removes the entire outline of {selectedRoom?.name ?? 'this room'}. Undo (Del) cannot bring it back
-                once cleared - only the saved version on disk can.
+                This removes the entire outline of {selectedRoom?.name ?? 'this room'}. Undo (Ctrl/Cmd+Z) can bring it
+                back while you stay on this page - after a reload, only the saved version on disk can.
               </p>
               <div className="flex gap-3">
                 <button
@@ -1642,7 +1795,8 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
         >
                 <RoomCanvas
                   points={selectedRoom.roomShell?.points ?? []}
-                  onChange={handlePointsChange}
+                  // The canvas emits this while a corner point is being dragged.
+                  onChange={(nextPoints) => handlePointsChange(nextPoints, { coalesceKey: 'points:vertex-drag' })}
                   onAddPoint={undefined}
                   onCanvasClick={handleCanvasClick}
                   onCanvasMove={handleCanvasMove}
@@ -1655,6 +1809,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                     setCursorDelta(null);
                     handleDoorDragEnd();
                     setIsCanvasDragging(false);
+                    endHistoryGesture();
                   }}
                   onDragStateChange={setIsCanvasDragging}
                   lockShell={!!activeBasicShape}
@@ -1938,13 +2093,24 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
               >
                 ✓ Finish (Enter)
               </button>
-              <button
-                className="rounded-xl border border-amber-600/50 bg-amber-600/10 px-4 py-2.5 font-semibold text-amber-100 shadow-lg transition-all hover:bg-amber-600/20 disabled:opacity-40 active:scale-95"
-                onClick={removeLastPoint}
-                disabled={!selectedRoom || !(selectedRoom.roomShell?.points?.length)}
-              >
-                ↶ Undo (Del)
-              </button>
+              <div className="grid grid-cols-2 gap-2">
+                <button
+                  className="rounded-xl border border-amber-600/50 bg-amber-600/10 px-3 py-2.5 font-semibold text-amber-100 shadow-lg transition-all hover:bg-amber-600/20 disabled:opacity-40 active:scale-95"
+                  onClick={handleUndo}
+                  disabled={!canUndo}
+                  title="Undo the last change (Ctrl/Cmd+Z)"
+                >
+                  ↶ Undo
+                </button>
+                <button
+                  className="rounded-xl border border-amber-600/50 bg-amber-600/10 px-3 py-2.5 font-semibold text-amber-100 shadow-lg transition-all hover:bg-amber-600/20 disabled:opacity-40 active:scale-95"
+                  onClick={handleRedo}
+                  disabled={!canRedo}
+                  title="Redo (Ctrl/Cmd+Shift+Z)"
+                >
+                  ↷ Redo
+                </button>
+              </div>
               <button
                 className="rounded-xl border border-rose-600/50 bg-rose-600/10 px-4 py-2.5 font-semibold text-rose-100 shadow-lg transition-all hover:bg-rose-600/20 disabled:opacity-40 active:scale-95"
                 onClick={handleClear}
@@ -2355,7 +2521,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                             onChange={(e) => {
                               if (!selectedRoom) return;
                               const nextRoom: RoomConfig = { ...selectedRoom, roomShellFillMode: e.target.value as 'overlay' | 'material' };
-                              setRooms((prev) => prev.map((r) => (r.id === selectedRoom.id ? nextRoom : r)));
+                              commitRoom(nextRoom);
                             }}
                           >
                             <option value="overlay">Blue Overlay</option>
@@ -2371,7 +2537,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                               onChange={(e) => {
                                 if (!selectedRoom) return;
                                 const nextRoom: RoomConfig = { ...selectedRoom, floorMaterial: e.target.value as any };
-                                setRooms((prev) => prev.map((r) => (r.id === selectedRoom.id ? nextRoom : r)));
+                                commitRoom(nextRoom);
                               }}
                             >
                               {Object.entries(FLOOR_MATERIALS).map(([key, material]) => (
@@ -2496,7 +2662,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                 </button>
               </div>
               <div className="text-[10px] text-slate-500">
-                Tips: Click a wall to edit it, Shift+Click a wall to split it, A to draw, Enter to finish, Esc to cancel, Del to undo or delete the selected wall point
+                Tips: Click a wall to edit it, Shift+Click a wall to split it, A to draw, Enter to finish, Esc to cancel, Ctrl/Cmd+Z to undo (Shift to redo), Del to remove the point just drawn or the selected wall point
               </div>
             </div>
           </div>
@@ -2942,10 +3108,18 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
           <button
             type="button"
             className="rounded-lg border border-amber-600/60 bg-amber-600/20 px-3 py-3 font-semibold text-amber-100 disabled:opacity-40"
-            onClick={removeLastPoint}
-            disabled={!selectedRoom || !(selectedRoom.roomShell?.points?.length)}
+            onClick={handleUndo}
+            disabled={!canUndo}
           >
             Undo
+          </button>
+          <button
+            type="button"
+            className="rounded-lg border border-amber-600/60 bg-amber-600/20 px-3 py-3 font-semibold text-amber-100 disabled:opacity-40"
+            onClick={handleRedo}
+            disabled={!canRedo}
+          >
+            Redo
           </button>
           <button
             type="button"

--- a/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
@@ -827,7 +827,9 @@ export const WizardPage: React.FC<WizardPageProps> = ({
         return;
       }
       if (e.key === 'Backspace' || e.key === 'Delete') {
-        if (selectedRoom?.roomShell?.points?.length) {
+        // Only while drawing: on a finished outline this would delete points the
+        // user never placed in this session.
+        if (isDrawingWall && selectedRoom?.roomShell?.points?.length) {
           e.preventDefault();
           removeLastPoint();
         }
@@ -2036,9 +2038,10 @@ export const WizardPage: React.FC<WizardPageProps> = ({
               <button
                 className="rounded-xl border border-amber-600/50 bg-amber-600/10 px-4 py-2.5 text-sm font-semibold text-amber-100 shadow-lg transition-all hover:bg-amber-600/20 disabled:opacity-40 active:scale-95"
                 onClick={removeLastPoint}
-                disabled={!selectedRoom || !(selectedRoom.roomShell?.points?.length)}
+                title="Remove the point you just drew"
+                disabled={!selectedRoom || !isDrawingWall || !(selectedRoom.roomShell?.points?.length)}
               >
-                ↶ Undo (Del)
+                ⤺ Remove last point (Del)
               </button>
               <button
                 className="rounded-xl border border-rose-600/50 bg-rose-600/10 px-4 py-2.5 text-sm font-semibold text-rose-100 shadow-lg transition-all hover:bg-rose-600/20 disabled:opacity-40 active:scale-95"
@@ -2383,9 +2386,9 @@ export const WizardPage: React.FC<WizardPageProps> = ({
                     <button
                       className="rounded-lg border border-amber-600/50 bg-amber-600/20 px-3 py-3 text-sm font-semibold text-amber-100 disabled:opacity-40"
                       onClick={removeLastPoint}
-                      disabled={!selectedRoom || !(selectedRoom.roomShell?.points?.length)}
+                      disabled={!selectedRoom || !isDrawingWall || !(selectedRoom.roomShell?.points?.length)}
                     >
-                      Undo
+                      Remove point
                     </button>
                     <button
                       className="rounded-lg border border-rose-600/50 bg-rose-600/20 px-3 py-3 text-sm font-semibold text-rose-100 disabled:opacity-40"

--- a/everything-presence-mmwave-configurator/frontend/src/utils/roomHistory.test.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/roomHistory.test.ts
@@ -1,0 +1,118 @@
+// @ts-nocheck -- Node's built-in runner supplies these modules; frontend production types stay dependency-free.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  ROOM_HISTORY_LIMIT,
+  applyRoomSnapshot,
+  createRoomHistory,
+  pushRoomHistory,
+  redoRoomHistory,
+  snapshotRoom,
+  snapshotsEqual,
+  undoRoomHistory,
+} from './roomHistory.ts';
+
+const room = () => ({
+  id: 'room-1',
+  name: 'Lounge',
+  units: 'metric',
+  zones: [{ id: 'zone-1', name: 'Zone 1', x: 0, y: 0, width: 100, height: 100 }],
+  entityMappings: { installationAngleEntity: 'number.angle' },
+  roomShell: { points: [{ x: 0, y: 0 }, { x: 1000, y: 0 }, { x: 1000, y: 1000 }] },
+  furniture: [{ id: 'f1', typeId: 'sofa', x: 0, y: 0, width: 1000, depth: 500, height: 400, rotationDeg: 0 }],
+  doors: [{ id: 'd1', segmentIndex: 0, positionOnSegment: 0.5, widthMm: 800 }],
+  devicePlacement: { x: 0, y: 0, rotationDeg: 0 },
+});
+
+test('snapshots only the room-builder subset and deep copies it', () => {
+  const original = room();
+  const snapshot = snapshotRoom(original);
+
+  assert.deepEqual(Object.keys(snapshot).sort(), [
+    'devicePlacement',
+    'doors',
+    'floorMaterial',
+    'furniture',
+    'roomShell',
+    'roomShellFillMode',
+  ]);
+
+  original.roomShell.points[0].x = 999;
+  original.furniture[0].x = 999;
+  assert.equal(snapshot.roomShell.points[0].x, 0);
+  assert.equal(snapshot.furniture[0].x, 0);
+});
+
+test('applying a snapshot restores the outline without touching zones', () => {
+  const before = snapshotRoom(room());
+  const edited = { ...room(), roomShell: { points: [] }, zones: [] };
+  const restored = applyRoomSnapshot(edited, before);
+
+  assert.deepEqual(restored.roomShell.points.length, 3);
+  assert.deepEqual(restored.zones, []); // zones stay as the caller had them
+  assert.equal(restored.id, 'room-1');
+});
+
+test('undo returns the previous snapshot and redo returns the newer one', () => {
+  const first = snapshotRoom(room());
+  const second = snapshotRoom({ ...room(), doors: [] });
+
+  const history = pushRoomHistory(createRoomHistory(), first);
+  const undone = undoRoomHistory(history, second);
+  assert.ok(undone);
+  assert.equal(undone.snapshot.doors.length, 1);
+
+  const redone = redoRoomHistory(undone.history, undone.snapshot);
+  assert.ok(redone);
+  assert.equal(redone.snapshot.doors.length, 0);
+  assert.equal(redone.history.future.length, 0);
+});
+
+test('undo and redo are no-ops on empty stacks', () => {
+  const current = snapshotRoom(room());
+  assert.equal(undoRoomHistory(createRoomHistory(), current), null);
+  assert.equal(redoRoomHistory(createRoomHistory(), current), null);
+});
+
+test('a gesture that fires many times collapses into one undo step', () => {
+  const base = snapshotRoom(room());
+  let history = createRoomHistory();
+  for (let step = 0; step < 200; step += 1) {
+    history = pushRoomHistory(history, snapshotRoom({ ...room(), furniture: [{ ...room().furniture[0], x: step }] }), {
+      coalesceKey: 'furniture:f1',
+      activeCoalesceKey: history.past.length ? 'furniture:f1' : null,
+    });
+  }
+  assert.equal(history.past.length, 1);
+  assert.equal(history.past[0].snapshot.furniture[0].x, 0);
+
+  // Pointer-up clears the active key, so the next drag is its own step.
+  history = pushRoomHistory(history, base, { coalesceKey: 'furniture:f1', activeCoalesceKey: null });
+  assert.equal(history.past.length, 2);
+});
+
+test('pushing a new edit drops the redo stack', () => {
+  const snapshot = snapshotRoom(room());
+  const history = { past: [{ snapshot }], future: [{ snapshot }] };
+  assert.equal(pushRoomHistory(history, snapshot).future.length, 0);
+  assert.equal(
+    pushRoomHistory(history, snapshot, { coalesceKey: 'k', activeCoalesceKey: 'k' }).future.length,
+    0,
+  );
+});
+
+test('history depth stays bounded, dropping the oldest steps', () => {
+  let history = createRoomHistory();
+  for (let step = 0; step < ROOM_HISTORY_LIMIT + 25; step += 1) {
+    history = pushRoomHistory(history, snapshotRoom({ ...room(), roomShellFillMode: `mode-${step}` }));
+  }
+  assert.equal(history.past.length, ROOM_HISTORY_LIMIT);
+  assert.equal(history.past[0].snapshot.roomShellFillMode, 'mode-25');
+});
+
+test('snapshot equality ignores key order', () => {
+  const a = snapshotRoom(room());
+  const b = { ...a };
+  assert.equal(snapshotsEqual(a, b), true);
+  assert.equal(snapshotsEqual(a, snapshotRoom({ ...room(), doors: [] })), false);
+});

--- a/everything-presence-mmwave-configurator/frontend/src/utils/roomHistory.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/roomHistory.ts
@@ -1,0 +1,128 @@
+import type { RoomConfig } from '../api/types';
+// Explicit extension so Node's built-in test runner can resolve it too.
+import { stableStringify } from './stableStringify.ts';
+
+/**
+ * Session-only undo/redo for the Room Builder.
+ *
+ * The stack lives in component state (a ref in RoomBuilderPage), so it dies on
+ * unmount or reload and never reaches the backend. Only the parts of a room the
+ * builder can edit are snapshotted - zones, entity mappings and metadata are
+ * owned by other screens and must survive an undo untouched.
+ */
+
+/** Bounded so a long editing session cannot grow memory without limit. */
+export const ROOM_HISTORY_LIMIT = 50;
+
+export type RoomSnapshot = Pick<
+  RoomConfig,
+  'roomShell' | 'roomShellFillMode' | 'floorMaterial' | 'devicePlacement' | 'furniture' | 'doors'
+>;
+
+export interface RoomHistoryEntry {
+  snapshot: RoomSnapshot;
+  /**
+   * Identifies the gesture that produced the edit (a furniture drag, a slider
+   * sweep, ...). Consecutive commits sharing a key collapse into this entry so
+   * one gesture is one undo step, not one step per pointer-move event.
+   */
+  coalesceKey?: string | null;
+}
+
+export interface RoomHistory {
+  past: RoomHistoryEntry[];
+  future: RoomHistoryEntry[];
+}
+
+export const createRoomHistory = (): RoomHistory => ({ past: [], future: [] });
+
+/** Copy the editable subset of a room, deeply enough that later edits cannot mutate it. */
+export const snapshotRoom = (room: RoomConfig): RoomSnapshot => ({
+  roomShell: room.roomShell
+    ? { ...room.roomShell, points: (room.roomShell.points ?? []).map((point) => ({ ...point })) }
+    : room.roomShell,
+  roomShellFillMode: room.roomShellFillMode,
+  floorMaterial: room.floorMaterial,
+  devicePlacement: room.devicePlacement ? { ...room.devicePlacement } : room.devicePlacement,
+  furniture: room.furniture ? room.furniture.map((item) => ({ ...item })) : room.furniture,
+  doors: room.doors ? room.doors.map((door) => ({ ...door })) : room.doors,
+});
+
+/** Put a snapshot back on a room, leaving every non-builder field as it is now. */
+export const applyRoomSnapshot = (room: RoomConfig, snapshot: RoomSnapshot): RoomConfig => ({
+  ...room,
+  ...snapshotRoom({ ...room, ...snapshot }),
+});
+
+export const roomSnapshotSignature = (snapshot: RoomSnapshot): string => stableStringify(snapshot);
+
+export const snapshotsEqual = (a: RoomSnapshot, b: RoomSnapshot): boolean =>
+  roomSnapshotSignature(a) === roomSnapshotSignature(b);
+
+export interface PushRoomHistoryOptions {
+  /** Gesture key for the edit being committed, if any. */
+  coalesceKey?: string | null;
+  /** Gesture key that is still in progress (cleared on pointer-up / blur). */
+  activeCoalesceKey?: string | null;
+  limit?: number;
+}
+
+/**
+ * Record `snapshot` (the state *before* the edit) as the next undo step.
+ * Redo is dropped, because the timeline just branched.
+ */
+export function pushRoomHistory(
+  history: RoomHistory,
+  snapshot: RoomSnapshot,
+  options: PushRoomHistoryOptions = {},
+): RoomHistory {
+  const { coalesceKey = null, activeCoalesceKey = null, limit = ROOM_HISTORY_LIMIT } = options;
+
+  // Mid-gesture: the first snapshot of the gesture is the one worth keeping.
+  if (coalesceKey && coalesceKey === activeCoalesceKey && history.past.length > 0) {
+    return { past: history.past, future: [] };
+  }
+
+  const past = [...history.past, { snapshot, coalesceKey }];
+  return {
+    past: past.length > limit ? past.slice(past.length - limit) : past,
+    future: [],
+  };
+}
+
+export interface RoomHistoryStep {
+  history: RoomHistory;
+  snapshot: RoomSnapshot;
+}
+
+/** Pop the last undo step, pushing `current` onto the redo stack. */
+export function undoRoomHistory(history: RoomHistory, current: RoomSnapshot): RoomHistoryStep | null {
+  if (!history.past.length) return null;
+  const entry = history.past[history.past.length - 1];
+  return {
+    history: {
+      past: history.past.slice(0, -1),
+      future: [...history.future, { snapshot: current }],
+    },
+    snapshot: entry.snapshot,
+  };
+}
+
+/** Pop the last redo step, pushing `current` back onto the undo stack. */
+export function redoRoomHistory(history: RoomHistory, current: RoomSnapshot): RoomHistoryStep | null {
+  if (!history.future.length) return null;
+  const entry = history.future[history.future.length - 1];
+  return {
+    history: {
+      past: [...history.past, { snapshot: current }],
+      future: history.future.slice(0, -1),
+    },
+    snapshot: entry.snapshot,
+  };
+}
+
+export const canUndoRoomHistory = (history: RoomHistory | undefined | null): boolean =>
+  !!history?.past.length;
+
+export const canRedoRoomHistory = (history: RoomHistory | undefined | null): boolean =>
+  !!history?.future.length;

--- a/everything-presence-mmwave-configurator/frontend/src/utils/stableStringify.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/stableStringify.ts
@@ -1,0 +1,18 @@
+/**
+ * Stable, key-order independent stringify so a value reserialised by the
+ * backend compares equal to the identical value held in local state.
+ * Used for "do I have unsaved changes?" checks and for undo history dedupe.
+ */
+export const stableStringify = (value: unknown): string => {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value ?? null) ?? 'null';
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`);
+  return `{${entries.join(',')}}`;
+};


### PR DESCRIPTION
## Summary
Gave the Room Builder a real session-scoped undo/redo stack so the "Undo" control reverses the last edit instead of eating another outline vertex.
New `frontend/src/utils/roomHistory.ts` holds the pure history logic: `snapshotRoom` copies only the builder-owned subset of a room (roomShell, roomShellFillMode, floorMaterial, devicePlacement, furniture, doors - zones/entityMappings/metadata are left alone), `applyRoomSnapshot` puts one back, and `pushRoomHistory`/`undoRoomHistory`/`redoRoomHistory` maintain a past/future pair bounded at ROOM_HISTORY_LIMIT (50). `pushRoomHistory` takes a `coalesceKey` plus the currently active key, so consecutive commits from one gesture collapse onto the first snapshot. The key-order-independent stringify used for dirty tracking moved to `frontend/src/utils/stableStringify.ts` and is now shared.
In RoomBuilderPage, history lives in a `useRef<Map<roomId, RoomHistory>>` (per room, session only, never persisted or sent to the backend); only `{canUndo, canRedo}` is mirrored in state for button enablement. All twelve user-edit sites now funnel through one `commitRoom(nextRoom, {coalesceKey?})` choke point, which snapshots the pre-edit room and then applies the change. Continuous input is coalesced: furniture drag/resize/rotate and its sliders (`furniture:<id>`), door drag/edit (`door:<id>`), device placement drag and fields (`device:placement`), wall segment/endpoint/vertex drags (`points:*`).

## Verification
CI/owner: run `npm test` in everything-presence-mmwave-configurator/frontend - it now also runs src/utils/roomHistory.test.ts (snapshot isolation, undo/redo round-trip, 200 coalesced gesture events collapsing to one step, redo invalidation, 50-entry cap). `npm run build` and `npm run lint` cover compilation/lint.
Manual checks against a deployed preview (never run by me):
1. Room Builder > select a room with an outline, add a furniture item, then press the Undo button. Expected: the furniture item disappears and the outline is untouched; Redo brings it back.
2. Select a furniture item and delete it, then press Ctrl/Cmd+Z. Expected: the deleted item reappears with the same position, size and rotation.
3. Place a door, delete it, press Ctrl/Cmd+Z. Expected: the door returns on the same wall segment.
4. Drag a furniture item across the room in one continuous drag, release, then press Undo once. Expected: it jumps back to where the drag started - not one pixel step back.
5. Drag a wall segment or a corner point, release, press Undo once. Expected: the whole drag is reverted in one step.
6. Clear all walls (confirm the dialog), then press Ctrl/Cmd+Z. Expected: the full outline returns; the modal now says Undo can bring it back until reload.
7. With a finished outline and nothing selected, press Del repeatedly. Expected: nothing is deleted (previously each press removed a vertex). Click "Add wall" first, place two points, then press Del. Expected: only the point just drawn is removed.
8. Press Undo repeatedly until the button greys out, then press Redo repeatedly. Expected: the room walks back to its state at page load and forward again; when it matches the last saved state the "Unsaved changes" badge disappears.
9. Undo, then leave the page and return / reload. Expected: undo history is empty again (session-only) and unsaved-change prompts behave as before.
10. Wizard outline step: the amber button reads "Remove last point (Del)" and is disabled unless drawing is active.

Fixes #383