### PR TITLE
Bug: Cannot change rooms in the room builder

### DIFF
--- a/everything-presence-mmwave-configurator/frontend/package.json
+++ b/everything-presence-mmwave-configurator/frontend/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",
-		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts src/utils/polygonVertices.test.ts src/utils/roomHistory.test.ts",
+		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts src/utils/polygonVertices.test.ts src/utils/roomHistory.test.ts src/utils/roomSelection.test.ts",
 		"preview": "vite preview",
 		"format": "npx @biomejs/biome format",
 		"format:fix": "npx @biomejs/biome format --write",

--- a/everything-presence-mmwave-configurator/frontend/src/App.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/App.tsx
@@ -723,6 +723,10 @@ function App() {
             }}
             initialRoomId={selectedRoomId}
             initialProfileId={selectedProfileId}
+            onRoomChange={(roomId, profileId) => {
+              setSelectedRoomId(roomId);
+              setSelectedProfileId(profileId);
+            }}
             onWizardProgress={(p) => {
               if (p.outlineDone) {
                 setWizardOutlineDone(true);

--- a/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
@@ -31,6 +31,7 @@ import {
   getCeilingSlicePosition,
   normalizeCeilingSliceConfig,
 } from '../utils/ceilingSlices';
+import { resolveLoadedRoomSelection } from '../utils/roomSelection';
 import { stableStringify } from '../utils/stableStringify';
 import {
   ROOM_HISTORY_LIMIT,
@@ -51,6 +52,7 @@ interface RoomBuilderPageProps {
   onNavigate?: (view: 'wizard' | 'zoneEditor' | 'roomBuilder' | 'settings' | 'liveDashboard') => void;
   initialRoomId?: string | null;
   initialProfileId?: string | null;
+  onRoomChange?: (roomId: string | null, profileId: string | null) => void;
   onWizardProgress?: (progress: { outlineDone?: boolean; placementDone?: boolean }) => void;
   liveState?: LiveState | null;
   targetPositions?: Array<{
@@ -81,6 +83,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   onNavigate,
   initialRoomId,
   initialProfileId,
+  onRoomChange,
   onWizardProgress,
   liveState,
   targetPositions,
@@ -168,6 +171,15 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   const wallEditorDragPointerRef = useRef<number | null>(null);
   const wallEditorDragStartRef = useRef<{ x: number; y: number; offsetX: number; offsetY: number } | null>(null);
   const canvasViewportRef = useRef<HTMLDivElement | null>(null);
+  // Mirrors of the current selection, so the one-shot loader can consult them
+  // without depending on (and therefore re-running off) its own state.
+  const selectedRoomIdRef = useRef(selectedRoomId);
+  const selectedProfileIdRef = useRef(selectedProfileId);
+  selectedRoomIdRef.current = selectedRoomId;
+  selectedProfileIdRef.current = selectedProfileId;
+  // Last `initialRoomId` we acted on, so the sync effect below can tell an actual
+  // prop change from a re-render.
+  const lastInitialRoomIdRef = useRef<string | null>(initialRoomId ?? null);
   const CANVAS_SIZE = 700;
   const HALF = CANVAS_SIZE / 2;
   const WALL_EDITOR_WIDTH = 280;
@@ -747,21 +759,46 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
         setRooms(roomRes.rooms);
         setSavedRooms(Object.fromEntries(roomRes.rooms.map((room) => [room.id, room])));
 
-        const initialRoom =
-          (initialRoomId && roomRes.rooms.find((r) => r.id === initialRoomId)) || roomRes.rooms[0] || null;
-        if (initialRoom) {
-          setSelectedRoomId(initialRoom.id);
-          if (initialRoom.profileId) setSelectedProfileId(initialRoom.profileId);
+        // A room the user already picked wins over the incoming prop - the fetch
+        // can resolve after they used the header dropdown.
+        const initialRoom = resolveLoadedRoomSelection(roomRes.rooms, initialRoomId, selectedRoomIdRef.current);
+        let profileId = initialRoom?.profileId ?? selectedProfileIdRef.current ?? null;
+        if (!profileId && profileRes.profiles.length > 0) {
+          profileId = initialProfileId ?? profileRes.profiles[0].id;
         }
-        if (!initialRoom?.profileId && !selectedProfileId && profileRes.profiles.length > 0) {
-          setSelectedProfileId(initialProfileId ?? profileRes.profiles[0].id);
+
+        if (initialRoom) setSelectedRoomId(initialRoom.id);
+        if (profileId) setSelectedProfileId(profileId);
+        // Tell the app what we landed on, so `initialRoomId` tracks the builder
+        // instead of pulling it somewhere else later.
+        if (initialRoom || profileId) {
+          onRoomChange?.(initialRoom?.id ?? selectedRoomIdRef.current ?? null, profileId);
         }
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load data');
       }
     };
     load();
-  }, [initialProfileId, initialRoomId, selectedProfileId]);
+    // Initialisation only: this effect writes `rooms`/`savedRooms` and the
+    // selection, so depending on any of them would refetch mid-edit and snap the
+    // user back to `initialRoomId`. External room changes are handled by the
+    // sync effect below.
+  }, []);
+
+  useEffect(() => {
+    // Follow the parent only when it actually points somewhere new, and without
+    // refetching: the builder owns the selection while it is open, so a prop
+    // that simply lags behind must never override the user's own pick.
+    const nextRoomId = initialRoomId ?? null;
+    if (!rooms.length) return; // wait for the load; the prop is handled there
+    const changed = nextRoomId !== lastInitialRoomIdRef.current;
+    lastInitialRoomIdRef.current = nextRoomId;
+    if (!changed || !nextRoomId || nextRoomId === selectedRoomId) return;
+    const room = rooms.find((r) => r.id === nextRoomId);
+    if (!room) return;
+    setSelectedRoomId(room.id);
+    if (room.profileId) setSelectedProfileId(room.profileId);
+  }, [initialRoomId, rooms, selectedRoomId]);
 
   useEffect(() => {
     // reset pan when switching rooms
@@ -1425,7 +1462,10 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     setSelectedRoomId(roomId);
     const room = rooms.find((candidate) => candidate.id === roomId);
     if (room?.profileId) setSelectedProfileId(room.profileId);
-  }, [rooms]);
+    // Keep the rest of the app on the same room, so `initialRoomId` cannot pull
+    // the builder back and the choice survives navigating away and back.
+    onRoomChange?.(roomId, room?.profileId ?? selectedProfileId);
+  }, [onRoomChange, rooms, selectedProfileId]);
 
   const toggleMobileToolsSheet = () => {
     setShowSettings(false);

--- a/everything-presence-mmwave-configurator/frontend/src/utils/roomSelection.test.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/roomSelection.test.ts
@@ -1,0 +1,36 @@
+// @ts-nocheck -- Node's built-in runner supplies these modules; frontend production types stay dependency-free.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { resolveLoadedRoomSelection } from './roomSelection.ts';
+
+const rooms = [
+  { id: 'room-1', profileId: 'profile-a' },
+  { id: 'room-2', profileId: 'profile-b' },
+  { id: 'room-3', profileId: 'profile-a' },
+];
+
+test('falls back to the incoming room on first load', () => {
+  assert.equal(resolveLoadedRoomSelection(rooms, 'room-2', null)?.id, 'room-2');
+});
+
+test('falls back to the first room when nothing is selected or handed in', () => {
+  assert.equal(resolveLoadedRoomSelection(rooms, null, null)?.id, 'room-1');
+});
+
+test('keeps the room the user picked even when the parent still points elsewhere', () => {
+  // Regression: the builder used to re-select `initialRoomId` whenever its load
+  // effect re-ran, so picking a room whose profile differed snapped straight back.
+  assert.equal(resolveLoadedRoomSelection(rooms, 'room-1', 'room-2')?.id, 'room-2');
+});
+
+test('ignores a stale selection that no longer exists on the server', () => {
+  assert.equal(resolveLoadedRoomSelection(rooms, 'room-3', 'deleted-room')?.id, 'room-3');
+});
+
+test('ignores an unknown incoming room', () => {
+  assert.equal(resolveLoadedRoomSelection(rooms, 'deleted-room', null)?.id, 'room-1');
+});
+
+test('returns null when there are no rooms', () => {
+  assert.equal(resolveLoadedRoomSelection([], 'room-1', 'room-2'), null);
+});

--- a/everything-presence-mmwave-configurator/frontend/src/utils/roomSelection.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/roomSelection.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared rule for "which room should a page show once its rooms have loaded?".
+ *
+ * The page owns the selection while it is open: a fetch that resolves after the
+ * user already picked a room from the header dropdown must not yank them back to
+ * the room the parent handed in as `initialRoomId`. Only when the current
+ * selection is missing (first load) or no longer exists on the server do we fall
+ * back to the incoming room, and then to the first room available.
+ */
+export interface SelectableRoom {
+  id: string;
+}
+
+export const resolveLoadedRoomSelection = <T extends SelectableRoom>(
+  rooms: T[],
+  initialRoomId?: string | null,
+  currentRoomId?: string | null,
+): T | null => {
+  const current = currentRoomId ? rooms.find((room) => room.id === currentRoomId) : undefined;
+  if (current) return current;
+
+  const initial = initialRoomId ? rooms.find((room) => room.id === initialRoomId) : undefined;
+  if (initial) return initial;
+
+  return rooms[0] ?? null;
+};


### PR DESCRIPTION
## Summary
Fixed the Room Builder snapping back to the previous room after a dropdown selection, and made the builder's room choice propagate to the rest of the app.
1. RoomBuilderPage's data-load effect no longer re-runs off its own state. It previously depended on `selectedProfileId` while also writing it and force-selecting `initialRoomId`, so picking a room whose profile differed re-triggered the fetch and immediately restored the old room (and clobbered `rooms`/`savedRooms`, discarding unsaved edits). The effect now runs once on mount (`[]`, matching LiveTrackingPage), reads the current selection through new `selectedRoomIdRef`/`selectedProfileIdRef` mirrors instead of depending on state, and resolves which room to show through a new pure helper `resolveLoadedRoomSelection(rooms, initialRoomId, currentRoomId)` that prefers a room the user already picked over the incoming prop. Profile resolution was folded into one computation so the parent is notified once with the final profile id.
2. A separate sync effect follows the parent only when `initialRoomId` genuinely changes (tracked via `lastInitialRoomIdRef`, ignoring re-renders and the pre-load window) and only switches selection — it never refetches, so in-progress edits survive.
3.

## Verification
CI/local: run `npm test` in `everything-presence-mmwave-configurator/frontend` (now includes `src/utils/roomSelection.test.ts`) and `npm run build` for a TypeScript/Vite check.
Manual test steps against a deployed preview:
1. Action: Create/have at least two rooms whose devices resolve to different profiles (e.g. an EP1 room and an EP2 room). Open the Room Builder and note the room shown in the header dropdown. Expected: the builder loads that room's canvas.
2. Action: Pick the other room from the Room Builder's header dropdown. Expected: the canvas switches to that room and stays there (no flicker back to the previous room), and the dropdown keeps showing the newly picked room.
3. Action: Repeat step 2 on a narrow/mobile viewport using the room selector in the mobile navigation sheet. Expected: same result.
4. Action: With the new room selected, navigate to the Dashboard or Zone Editor. Expected: those pages open on the room just chosen in the builder, not the old one.
5. Action: Return to the Room Builder. Expected: it opens on the same room (selection persists across navigation).
6. Action: Draw or move a wall so the Save button shows the unsaved dot, then switch rooms via the dropdown and switch back. Expected: the unsaved edits are still present (they are no longer replaced by a background refetch).
7. Action: Change room on the Dashboard, then open the Room Builder. Expected: the builder opens on the room selected on the Dashboard.

Fixes #380