### PR TITLE
v2 Feature Request: Lock walls, rooms, furniture, etc

### DIFF
--- a/everything-presence-mmwave-configurator/backend/src/domain/types.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/types.ts
@@ -38,6 +38,10 @@ export function isZoneRect(zone: Zone): zone is ZoneRect {
 
 export interface RoomShell {
   points: Array<{ x: number; y: number }>;
+  /** Locks the whole outline: no wall is selectable or draggable in the builder. */
+  locked?: boolean;
+  /** Indices of individually locked wall segments (`points[i] -> points[i + 1]`). */
+  lockedSegments?: number[];
 }
 
 export interface DevicePlacement {
@@ -50,6 +54,8 @@ export interface DevicePlacement {
   coveragePresetId?: string;
   horizontalFovDeg?: number;
   verticalFovDeg?: number;
+  /** Pins the device's position only; rotation and coverage stay editable. */
+  locked?: boolean;
 }
 
 export interface FurnitureInstance {
@@ -62,6 +68,7 @@ export interface FurnitureInstance {
   height: number;
   rotationDeg: number;
   aspectRatioLocked: boolean;
+  locked?: boolean;
 }
 
 export interface Door {
@@ -71,6 +78,7 @@ export interface Door {
   widthMm: number;
   swingDirection: 'in' | 'out';
   swingSide: 'left' | 'right';
+  locked?: boolean;
 }
 
 // ─────────────────────────────────────────────────────────────────

--- a/everything-presence-mmwave-configurator/backend/src/routes/rooms.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/rooms.ts
@@ -28,7 +28,23 @@ export const createRoomsRouter = (): Router => {
         y: Number(p?.y ?? 0),
       }))
       .filter((p: any) => Number.isFinite(p.x) && Number.isFinite(p.y));
-    return points.length ? { points } : undefined;
+    if (!points.length) return undefined;
+    // Locked wall segments are stored by index, so anything out of range for the
+    // stored outline is dropped rather than resurrected later against a different wall.
+    const lockedSegments = Array.isArray(shell.lockedSegments)
+      ? (Array.from(
+        new Set(
+          shell.lockedSegments
+            .map((value: any) => Number(value))
+            .filter((value: number) => Number.isInteger(value) && value >= 0 && value < points.length),
+        ),
+      ) as number[]).sort((a, b) => a - b)
+      : undefined;
+    return {
+      points,
+      locked: shell.locked !== undefined ? Boolean(shell.locked) : undefined,
+      lockedSegments: lockedSegments?.length ? lockedSegments : undefined,
+    };
   };
 
   const parseDevicePlacement = (placement: any): DevicePlacement | undefined => {
@@ -55,6 +71,7 @@ export const createRoomsRouter = (): Router => {
       coveragePresetId,
       horizontalFovDeg: Number.isFinite(horizontalFovDeg) ? horizontalFovDeg : undefined,
       verticalFovDeg: Number.isFinite(verticalFovDeg) ? verticalFovDeg : undefined,
+      locked: placement?.locked !== undefined ? Boolean(placement.locked) : undefined,
     };
   };
 
@@ -84,6 +101,7 @@ export const createRoomsRouter = (): Router => {
       height,
       rotationDeg,
       aspectRatioLocked,
+      locked: furniture?.locked !== undefined ? Boolean(furniture.locked) : undefined,
     };
   };
 
@@ -108,6 +126,7 @@ export const createRoomsRouter = (): Router => {
       widthMm,
       swingDirection,
       swingSide,
+      locked: door?.locked !== undefined ? Boolean(door.locked) : undefined,
     };
   };
 

--- a/everything-presence-mmwave-configurator/frontend/package.json
+++ b/everything-presence-mmwave-configurator/frontend/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",
-		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts src/utils/polygonVertices.test.ts src/utils/roomHistory.test.ts src/utils/roomSelection.test.ts",
+		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts src/utils/polygonVertices.test.ts src/utils/roomHistory.test.ts src/utils/roomSelection.test.ts src/utils/lockState.test.ts",
 		"preview": "vite preview",
 		"format": "npx @biomejs/biome format",
 		"format:fix": "npx @biomejs/biome format --write",

--- a/everything-presence-mmwave-configurator/frontend/src/api/types.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/api/types.ts
@@ -143,6 +143,13 @@ export interface ZoneBackup {
 
 export interface RoomShell {
   points: Array<{ x: number; y: number }>;
+  /** Locks the whole outline: no wall is selectable or draggable. */
+  locked?: boolean;
+  /**
+   * Indices of individually locked wall segments. Segment `i` spans
+   * `points[i] -> points[(i + 1) % points.length]`, matching `Door.segmentIndex`.
+   */
+  lockedSegments?: number[];
 }
 
 export interface DevicePlacement {
@@ -155,6 +162,12 @@ export interface DevicePlacement {
   coveragePresetId?: string;
   horizontalFovDeg?: number;
   verticalFovDeg?: number;
+  /**
+   * Pins the device's position only. Rotation, mounting and coverage stay
+   * editable, because aiming a mounted sensor is the common adjustment while
+   * its physical position is the thing you do not want nudged.
+   */
+  locked?: boolean;
 }
 
 export interface FurnitureType {
@@ -178,6 +191,7 @@ export interface FurnitureInstance {
   height: number; // Vertical height in mm (for future use)
   rotationDeg: number; // 0-360 degrees
   aspectRatioLocked: boolean; // Whether aspect ratio is locked during resize
+  locked?: boolean; // Pinned in place: not selectable or draggable on the canvas
 }
 
 export interface Door {
@@ -187,6 +201,7 @@ export interface Door {
   widthMm: number; // Door width in millimeters (typically 800-900mm)
   swingDirection: 'in' | 'out'; // Door swing direction relative to room
   swingSide: 'left' | 'right'; // Which side the hinge is on
+  locked?: boolean; // Pinned in place: not selectable or draggable on the canvas
 }
 
 // ─────────────────────────────────────────────────────────────────

--- a/everything-presence-mmwave-configurator/frontend/src/components/DoorEditor.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/DoorEditor.tsx
@@ -6,6 +6,8 @@ interface DoorEditorProps {
   onChange: (door: Door) => void;
   onDelete: () => void;
   onClose?: () => void;
+  /** Pins this door so it can no longer be selected or dragged on the canvas. */
+  onToggleLock?: () => void;
   maxSegmentIndex: number; // Number of wall segments - 1
   validation?: {
     overlaps: boolean;
@@ -20,9 +22,11 @@ export const DoorEditor: React.FC<DoorEditorProps> = ({
   onChange,
   onDelete,
   onClose,
+  onToggleLock,
   maxSegmentIndex,
   validation,
 }) => {
+  const isLocked = !!door.locked;
   const handleChange = (updates: Partial<Door>) => {
     onChange({ ...door, ...updates });
   };
@@ -71,22 +75,51 @@ export const DoorEditor: React.FC<DoorEditorProps> = ({
           </div>
           <h2 className="text-lg font-semibold text-white">Door</h2>
         </div>
-        {onClose && (
-          <button
-            onClick={onClose}
-            className="text-slate-400 hover:text-white transition-colors"
-            aria-label="Close"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        )}
+        <div className="flex items-center gap-2">
+          {onToggleLock && (
+            <button
+              onClick={onToggleLock}
+              className={`transition-colors ${isLocked ? 'text-amber-400 hover:text-amber-300' : 'text-slate-400 hover:text-amber-300'}`}
+              aria-label={isLocked ? 'Unlock door' : 'Lock door'}
+              aria-pressed={isLocked}
+              title={isLocked ? 'Unlock this door' : 'Lock this door so it cannot be selected or moved'}
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={1.8} viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d={isLocked
+                    ? 'M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75M6.75 10.5h10.5a2.25 2.25 0 012.25 2.25v6a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 18.75v-6a2.25 2.25 0 012.25-2.25z'
+                    : 'M13.5 10.5V6.75a4.5 4.5 0 119 0v3.75M3.75 10.5h10.5a2.25 2.25 0 012.25 2.25v6a2.25 2.25 0 01-2.25 2.25H3.75A2.25 2.25 0 011.5 18.75v-6a2.25 2.25 0 012.25-2.25z'}
+                />
+              </svg>
+            </button>
+          )}
+          {onClose && (
+            <button
+              onClick={onClose}
+              className="text-slate-400 hover:text-white transition-colors"
+              aria-label="Close"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+        </div>
       </div>
 
-      {/* Content */}
+      {isLocked && (
+        <div className="border-b border-amber-500/30 bg-amber-500/10 px-6 py-2 text-xs text-amber-200">
+          <span className="font-semibold">Locked.</span> This door is pinned in place, so it cannot be
+          moved, resized or deleted. Use the padlock above to unlock it first.
+        </div>
+      )}
+
+      {/* Content - inert while locked, so the padlock above is the only way forward */}
       <div
-        className="flex-1 overflow-y-auto px-6 py-4 space-y-6"
+        className={`flex-1 overflow-y-auto px-6 py-4 space-y-6 ${isLocked ? 'pointer-events-none opacity-50' : ''}`}
+        aria-disabled={isLocked || undefined}
         onWheelCapture={(e) => e.stopPropagation()}
       >
         {/* Validation Warnings */}
@@ -287,7 +320,9 @@ export const DoorEditor: React.FC<DoorEditorProps> = ({
       <div className="px-6 py-4 border-t border-slate-700">
         <button
           onClick={onDelete}
-          className="w-full px-4 py-2.5 bg-red-600/20 hover:bg-red-600/30 border border-red-600/50 rounded-lg text-red-200 font-semibold transition-colors"
+          disabled={isLocked}
+          title={isLocked ? 'Unlock this door before deleting it' : undefined}
+          className="w-full px-4 py-2.5 bg-red-600/20 hover:bg-red-600/30 border border-red-600/50 rounded-lg text-red-200 font-semibold transition-colors disabled:opacity-40 disabled:hover:bg-red-600/20"
         >
           Delete Door
         </button>

--- a/everything-presence-mmwave-configurator/frontend/src/components/FurnitureEditor.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/FurnitureEditor.tsx
@@ -8,6 +8,8 @@ interface FurnitureEditorProps {
   onChange: (furniture: FurnitureInstance) => void;
   onDelete: () => void;
   onClose?: () => void;
+  /** Pins this item so it can no longer be selected or dragged on the canvas. */
+  onToggleLock?: () => void;
 }
 
 export const FurnitureEditor: React.FC<FurnitureEditorProps> = ({
@@ -15,9 +17,11 @@ export const FurnitureEditor: React.FC<FurnitureEditorProps> = ({
   onChange,
   onDelete,
   onClose,
+  onToggleLock,
 }) => {
   const furnitureType = getFurnitureType(furniture.typeId);
   const Icon = getFurnitureIcon(furniture.typeId);
+  const isLocked = !!furniture.locked;
 
   const handleChange = (updates: Partial<FurnitureInstance>) => {
     onChange({ ...furniture, ...updates });
@@ -35,22 +39,51 @@ export const FurnitureEditor: React.FC<FurnitureEditorProps> = ({
           )}
           <h2 className="text-lg font-semibold text-white">{furnitureType?.label || 'Furniture'}</h2>
         </div>
-        {onClose && (
-          <button
-            onClick={onClose}
-            className="text-slate-400 hover:text-white transition-colors"
-            aria-label="Close"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        )}
+        <div className="flex items-center gap-2">
+          {onToggleLock && (
+            <button
+              onClick={onToggleLock}
+              className={`transition-colors ${isLocked ? 'text-amber-400 hover:text-amber-300' : 'text-slate-400 hover:text-amber-300'}`}
+              aria-label={isLocked ? 'Unlock furniture' : 'Lock furniture'}
+              aria-pressed={isLocked}
+              title={isLocked ? 'Unlock this item' : 'Lock this item so it cannot be selected or moved'}
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={1.8} viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d={isLocked
+                    ? 'M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75M6.75 10.5h10.5a2.25 2.25 0 012.25 2.25v6a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 18.75v-6a2.25 2.25 0 012.25-2.25z'
+                    : 'M13.5 10.5V6.75a4.5 4.5 0 119 0v3.75M3.75 10.5h10.5a2.25 2.25 0 012.25 2.25v6a2.25 2.25 0 01-2.25 2.25H3.75A2.25 2.25 0 011.5 18.75v-6a2.25 2.25 0 012.25-2.25z'}
+                />
+              </svg>
+            </button>
+          )}
+          {onClose && (
+            <button
+              onClick={onClose}
+              className="text-slate-400 hover:text-white transition-colors"
+              aria-label="Close"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+        </div>
       </div>
 
-      {/* Content */}
+      {isLocked && (
+        <div className="border-b border-amber-500/30 bg-amber-500/10 px-6 py-2 text-xs text-amber-200">
+          <span className="font-semibold">Locked.</span> This item is pinned in place, so it cannot be
+          dragged, resized or deleted. Use the padlock above to unlock it first.
+        </div>
+      )}
+
+      {/* Content - inert while locked, so the padlock above is the only way forward */}
       <div
-        className="flex-1 overflow-y-auto px-6 py-4 space-y-6"
+        className={`flex-1 overflow-y-auto px-6 py-4 space-y-6 ${isLocked ? 'pointer-events-none opacity-50' : ''}`}
+        aria-disabled={isLocked || undefined}
         onWheelCapture={(e) => e.stopPropagation()}
       >
         {/* Position */}
@@ -172,7 +205,9 @@ export const FurnitureEditor: React.FC<FurnitureEditorProps> = ({
       <div className="px-6 py-4 border-t border-slate-700 space-y-2">
         <button
           onClick={onDelete}
-          className="w-full px-4 py-2.5 rounded-lg bg-rose-600/10 border border-rose-600/50 text-rose-100 font-semibold hover:bg-rose-600/20 transition-all active:scale-95"
+          disabled={isLocked}
+          title={isLocked ? 'Unlock this item before deleting it' : undefined}
+          className="w-full px-4 py-2.5 rounded-lg bg-rose-600/10 border border-rose-600/50 text-rose-100 font-semibold hover:bg-rose-600/20 transition-all active:scale-95 disabled:opacity-40 disabled:hover:bg-rose-600/10 disabled:active:scale-100"
         >
           Delete Furniture
         </button>

--- a/everything-presence-mmwave-configurator/frontend/src/components/RoomCanvas.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/RoomCanvas.tsx
@@ -22,6 +22,8 @@ export interface DevicePlacement {
   coveragePresetId?: string;
   horizontalFovDeg?: number;
   verticalFovDeg?: number;
+  /** Position-only lock: the icon cannot be dragged, but rotation still applies. */
+  locked?: boolean;
 }
 
 interface RoomCanvasProps {
@@ -39,6 +41,8 @@ interface RoomCanvasProps {
   zoom?: number;
   devicePlacement?: DevicePlacement;
   onDeviceChange?: (placement: DevicePlacement) => void;
+  /** Fired on a click that did not turn into a drag - opens the device settings. */
+  onDeviceClick?: () => void;
   fieldOfViewDeg?: number;
   maxRangeMeters?: number;
   deviceIconUrl?: string;
@@ -81,6 +85,18 @@ interface RoomCanvasProps {
     deviceElement?: React.ReactNode;
   }) => React.ReactNode;
   lockShell?: boolean;
+  /**
+   * Individually locked wall segments. A locked wall is removed from hit-testing
+   * entirely, so a click near it falls through to the next unlocked object
+   * instead of selecting it.
+   */
+  lockedSegments?: number[];
+  /**
+   * Draw padlocks and amber outlines on locked objects. Off by default: a lock
+   * is an editing affordance, so it belongs to the Room Builder and must not
+   * bleed into read-only views like the Live Dashboard or the Zone Editor.
+   */
+  showLockIndicators?: boolean;
   showAllWallLengthLabels?: boolean;
   onWallLengthChange?: (segmentIndex: number, lengthMm: number) => void;
   furniture?: FurnitureInstance[];
@@ -512,6 +528,30 @@ const lineIntersection = (
   return null;
 };
 
+/**
+ * Padlock drawn on a locked object. Purely an indicator: it never takes a
+ * click, so it can never swallow the click that selects the object. Unlocking
+ * happens in the editor panel that selecting it opens.
+ */
+const LockBadge: React.FC<{
+  x: number;
+  y: number;
+  label: string;
+}> = ({ x, y, label }) => (
+  <g transform={`translate(${x}, ${y})`} style={{ pointerEvents: 'none' }}>
+    <title>{label}</title>
+    <circle r={9} fill="#0f172acc" stroke="#fbbf24" strokeWidth={1.5} vectorEffect="non-scaling-stroke" />
+    <path
+      d="M -3 -1 A 3 3 0 0 1 3 -1"
+      fill="none"
+      stroke="#fbbf24"
+      strokeWidth={1.5}
+      vectorEffect="non-scaling-stroke"
+    />
+    <rect x={-4} y={-1} width={8} height={6} rx={1.5} fill="#fbbf24" />
+  </g>
+);
+
 export const RoomCanvas: React.FC<RoomCanvasProps> = ({
   points,
   onChange,
@@ -527,6 +567,7 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
   zoom = 1,
   devicePlacement,
   onDeviceChange,
+  onDeviceClick,
   fieldOfViewDeg = 120,
   maxRangeMeters = 6,
   deviceIconUrl,
@@ -549,6 +590,8 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
   onSegmentInsert,
   renderOverlay,
   lockShell = false,
+  lockedSegments,
+  showLockIndicators = false,
   showAllWallLengthLabels = false,
   onWallLengthChange,
   furniture = [],
@@ -573,6 +616,18 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
   deviceInteractive = true,
 }) => {
   const safePoints = Array.isArray(points) ? points : [];
+  // Locked walls are dropped from every hit-test below, so a click near one
+  // falls through to whatever is behind it rather than grabbing the locked wall.
+  const lockedSegmentSet = useMemo(
+    () => new Set(Array.isArray(lockedSegments) ? lockedSegments : []),
+    [lockedSegments],
+  );
+  const isSegmentPinned = (index: number) => lockShell || lockedSegmentSet.has(index);
+  // A corner belongs to two walls; dragging it would move both.
+  const isVertexPinned = (index: number) =>
+    lockShell ||
+    (safePoints.length > 0 &&
+      (lockedSegmentSet.has(index) || lockedSegmentSet.has((index - 1 + safePoints.length) % safePoints.length)));
   const safePlacement: DevicePlacement = {
     x: Number.isFinite(devicePlacement?.x) ? (devicePlacement as DevicePlacement).x : 0,
     y: Number.isFinite(devicePlacement?.y) ? (devicePlacement as DevicePlacement).y : 0,
@@ -582,7 +637,10 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
     pitchDeg: Number.isFinite(devicePlacement?.pitchDeg) ? devicePlacement?.pitchDeg : undefined,
     horizontalFovDeg: Number.isFinite(devicePlacement?.horizontalFovDeg) ? devicePlacement?.horizontalFovDeg : undefined,
     verticalFovDeg: Number.isFinite(devicePlacement?.verticalFovDeg) ? devicePlacement?.verticalFovDeg : undefined,
+    locked: devicePlacement?.locked ? true : undefined,
   };
+  // Position-only: the icon stops being draggable, but rotation is untouched.
+  const devicePositionLocked = !!devicePlacement?.locked;
 
   // Theme-aware colors for canvas
   const { isDark } = useThemeContext();
@@ -599,6 +657,10 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
   const [editingWallLength, setEditingWallLength] = useState<number | null>(null);
   const [wallLengthDraft, setWallLengthDraft] = useState('');
   const [dragDevice, setDragDevice] = useState<boolean>(false);
+  // A press on the device that never really travels is a click, not a drag, so
+  // it opens the device settings instead of nudging the sensor by a pixel.
+  const devicePressRef = useRef<{ x: number; y: number } | null>(null);
+  const deviceMovedRef = useRef(false);
   const [panDrag, setPanDrag] = useState<{ start: Point; base: { x: number; y: number } } | null>(null);
   const [furnitureDrag, setFurnitureDrag] = useState<{ id: string; start: Point; basePos: Point; currentPos?: Point } | null>(null);
   const [furnitureResize, setFurnitureResize] = useState<{
@@ -976,16 +1038,50 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
       const next = [...safePoints];
       next[dragIdx] = snapPoint(pt);
       onChange(next);
-    } else if (dragDevice && onDeviceChange) {
+    } else if (dragDevice && onDeviceChange && !devicePositionLocked) {
       const snapped = snapPoint(pt);
       // Only allow device placement inside the room outline
       if (isPointInPolygon(snapped, safePoints)) {
+        deviceMovedRef.current = true;
         onDeviceChange({
           ...safePlacement,
           ...snapped,
         });
       }
     }
+  };
+
+  /**
+   * Shared by both device icon variants. A locked device still swallows the
+   * gesture (so nothing behind it reacts) but never begins a move; either way
+   * the press is remembered so pointer-up can tell a click from a drag.
+   */
+  const handleDevicePointerDown = (e: React.PointerEvent<SVGElement>) => {
+    if (e.button !== 0) return;
+    e.stopPropagation();
+    if (e.cancelable) e.preventDefault();
+    devicePressRef.current = { x: e.clientX, y: e.clientY };
+    deviceMovedRef.current = false;
+    // Never let the canvas treat this as a click on empty space.
+    suppressClickRef.current = true;
+    if (devicePositionLocked) return;
+    capturePointer(e);
+    setDragDevice(true);
+    onDragStateChange?.(true);
+  };
+
+  /**
+   * Deliberately does not stop propagation: the canvas-level pointer-up still
+   * has to run to clear the drag state.
+   */
+  const handleDevicePointerUp = (e: React.PointerEvent<SVGElement>) => {
+    const press = devicePressRef.current;
+    devicePressRef.current = null;
+    if (!press || !onDeviceClick) return;
+    if (deviceMovedRef.current) return;
+    // A few pixels of travel is still a click, not a reposition.
+    if (Math.hypot(e.clientX - press.x, e.clientY - press.y) > 4) return;
+    onDeviceClick();
   };
 
   const handlePointerDown = (e: React.PointerEvent<SVGSVGElement>) => {
@@ -1020,9 +1116,15 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
     const cx = svgPoint.x - HALF;
     const cy = svgPoint.y - HALF;
     const world = fromCanvasCoord(cx, cy);
+    // Unlocked walls are scored separately from locked ones so an unlocked
+    // neighbour always wins: editing the wall next to a locked one still works.
+    // A click that only lands on a locked wall still selects it, so the click
+    // visibly does something and the wall panel can explain the lock.
     let best: number | null = null;
     let bestDist = 250;
     let bestProj: Point | null = null;
+    let lockedBest: number | null = null;
+    let lockedBestDist = 250;
     safePoints.forEach((p, idx) => {
       const next = safePoints[(idx + 1) % safePoints.length];
       const dx = next.x - p.x;
@@ -1032,12 +1134,22 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
       const projX = p.x + t * dx;
       const projY = p.y + t * dy;
       const dist = Math.hypot(world.x - projX, world.y - projY);
+      if (isSegmentPinned(idx)) {
+        if (dist < lockedBestDist) {
+          lockedBestDist = dist;
+          lockedBest = idx;
+        }
+        return;
+      }
       if (dist < bestDist) {
         bestDist = dist;
         best = idx;
         bestProj = { x: projX, y: projY };
       }
     });
+    const picked = best ?? lockedBest;
+    // Splitting and dragging stay off limits for a locked wall; only selection
+    // falls through to it.
     if (!isDoorPlacementMode && e.shiftKey && onSegmentInsert && best !== null && bestProj) {
       e.preventDefault();
       e.stopPropagation();
@@ -1045,11 +1157,16 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
       suppressClickRef.current = true;
       return;
     }
-    onSegmentSelect?.(best);
+    onSegmentSelect?.(picked);
     if (best !== null && onSegmentDragStart) {
       onSegmentDragStart(best, world);
       suppressClickRef.current = true;
       onDragStateChange?.(true);
+    } else if (picked !== null) {
+      // Selecting a locked wall starts no drag, so without this the click that
+      // follows reaches the canvas as a "clicked empty space" deselect and the
+      // panel vanishes the moment the button comes back up.
+      suppressClickRef.current = true;
     }
   };
 
@@ -1079,6 +1196,7 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
           let best: number | null = null;
           let bestDist = 250; // mm
           safePoints.forEach((p, idx) => {
+            if (isSegmentPinned(idx)) return;
             const next = safePoints[(idx + 1) % safePoints.length];
             const dx = next.x - p.x;
             const dy = next.y - p.y;
@@ -1159,6 +1277,8 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
             })()}
             {!lockShell &&
               safePoints.map((p, idx) => {
+                // A corner shared with a locked wall would drag that wall too.
+                if (isVertexPinned(idx)) return null;
                 const { x: cx, y: cy } = toCanvasCoord(p);
                 return (
                   <g key={`pt-${idx}`}>
@@ -1171,6 +1291,35 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                       strokeWidth={handleStrokeWidth}
                       vectorEffect="non-scaling-stroke"
                       onPointerDown={handleDragStart(idx)}
+                    />
+                  </g>
+                );
+              })}
+            {/* Locked walls: drawn amber so the pin is visible while editing. */}
+            {showWalls && showLockIndicators &&
+              safePoints.map((p, idx) => {
+                if (!lockedSegmentSet.has(idx)) return null;
+                const next = safePoints[(idx + 1) % safePoints.length];
+                if (!next) return null;
+                const { x: x1, y: y1 } = toCanvasCoord(p);
+                const { x: x2, y: y2 } = toCanvasCoord(next);
+                return (
+                  <g key={`locked-seg-${idx}`}>
+                    <line
+                      x1={x1}
+                      y1={y1}
+                      x2={x2}
+                      y2={y2}
+                      stroke="#fbbf24"
+                      strokeWidth={selectedSegment === idx ? 5 : 3}
+                      strokeOpacity={selectedSegment === idx ? 1 : 0.75}
+                      vectorEffect="non-scaling-stroke"
+                      style={{ pointerEvents: 'none' }}
+                    />
+                    <LockBadge
+                      x={(x1 + x2) / 2}
+                      y={(y1 + y2) / 2}
+                      label={`Wall ${idx + 1} is locked - select it to unlock`}
                     />
                   </g>
                 );
@@ -1241,6 +1390,8 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                 const isHovered = hoveredSegment === idx;
                 const isSelected = selectedSegment === idx;
                 if (!isHovered && !isSelected) return null;
+                // A stale hover/selection must not survive the wall being locked.
+                if (isSegmentPinned(idx)) return null;
                 const midX = (x1 + x2) / 2;
                 const midY = (y1 + y2) / 2;
                 const lenLabel = formatLength(Math.hypot(next.x - p.x, next.y - p.y));
@@ -1274,6 +1425,8 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
             {/* Clickable wall segments for door placement */}
             {isDoorPlacementMode &&
               safePoints.map((p, idx) => {
+                // No new doors on a locked wall.
+                if (isSegmentPinned(idx)) return null;
                 const next = safePoints[(idx + 1) % safePoints.length];
                 const { x: x1, y: y1 } = toCanvasCoord(p);
                 const { x: x2, y: y2 } = toCanvasCoord(next);
@@ -1313,6 +1466,8 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
               })}
             {!lockShell &&
               selectedSegment !== null &&
+              selectedSegment !== undefined &&
+              !isSegmentPinned(selectedSegment) &&
               (() => {
                 const p = safePoints[selectedSegment];
                 const next = safePoints[(selectedSegment + 1) % safePoints.length];
@@ -1427,6 +1582,11 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
           // Make swing radius same as door width in world coordinates (so it's proportional)
           const swingRadius = canvasDoorWidth;
 
+          // The lock still blocks dragging everywhere; only its decoration is
+          // limited to the builder, so read-only views look untouched.
+          const isLockedDoor = !!door.locked;
+          const showDoorLock = isLockedDoor && showLockIndicators;
+          // Same as furniture: a locked door still selects, it just never moves.
           const isSelected = selectedDoorId === door.id;
 
           // Calculate hinge position and swing direction
@@ -1467,8 +1627,8 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                     y={Math.min(-15, arcEndY - 15)}
                     width={canvasDoorWidth + 20}
                     height={Math.abs(arcEndY) + 30}
-                    fill="rgba(6, 182, 212, 0.1)"
-                    stroke="#06b6d4"
+                    fill={showDoorLock ? 'rgba(251, 191, 36, 0.1)' : 'rgba(6, 182, 212, 0.1)'}
+                    stroke={showDoorLock ? '#fbbf24' : '#06b6d4'}
                     strokeWidth={2}
                     strokeDasharray="4 4"
                     rx={4}
@@ -1483,13 +1643,24 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                   width={canvasDoorWidth + 20}
                   height={Math.abs(arcEndY) + 30}
                   fill="transparent"
-                  style={{ cursor: isSelected ? 'grab' : 'pointer' }}
+                  style={{
+                    cursor: isLockedDoor ? 'not-allowed' : isSelected ? 'grab' : 'pointer',
+                    pointerEvents: 'all',
+                  }}
                   onPointerDown={(e) => {
                     if (e.button !== 0) return;
                     e.stopPropagation();
                     if (e.cancelable) e.preventDefault();
-                    capturePointer(e);
                     suppressClickRef.current = true;
+
+                    // Locked: select it so the panel opens and says why, but do
+                    // not capture the pointer or begin a drag.
+                    if (isLockedDoor) {
+                      onDoorSelect?.(door.id);
+                      return;
+                    }
+
+                    capturePointer(e);
 
                     // Select the door
                     onDoorSelect?.(door.id);
@@ -1550,6 +1721,13 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                   style={{ pointerEvents: 'none' }}
                 />
               </g>
+              {showDoorLock && (
+                <LockBadge
+                  x={canvasDoorPos.x}
+                  y={canvasDoorPos.y}
+                  label="Door is locked - select it to unlock"
+                />
+              )}
             </g>
           );
         })}
@@ -1584,6 +1762,11 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
           const canvasPos = toCanvasCoord({ x: displayX, y: displayY });
           const canvasWidth = toCanvas(displayWidth, effectiveRangeMm);
           const canvasHeight = toCanvas(displayDepth, effectiveRangeMm);
+          const isLockedItem = !!item.locked;
+          const showItemLock = isLockedItem && showLockIndicators;
+          // A locked item still selects, so a left click always visibly does
+          // something and the editor panel can explain the lock. It just never
+          // starts a move.
           const isSelected = selectedFurnitureId === item.id;
           const Icon = getFurnitureIcon(item.typeId);
           const customType = getCustomFurnitureType(customFurniture, item.typeId);
@@ -1626,18 +1809,27 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                   width={canvasWidth}
                   height={canvasHeight}
                   fill="transparent"
-                  stroke={isSelected ? '#0ea5e9' : 'transparent'}
-                  strokeWidth={isSelected ? 2 : 0}
-                  strokeDasharray={isSelected ? '4 2' : undefined}
+                  stroke={showItemLock ? '#fbbf24' : isSelected ? '#0ea5e9' : 'transparent'}
+                  strokeWidth={showItemLock ? (isSelected ? 2.5 : 2) : isSelected ? 2 : 0}
+                  strokeDasharray={isSelected || showItemLock ? '4 2' : undefined}
                   rx={3}
-                  style={{ cursor: isDragging ? 'grabbing' : 'grab' }}
+                  style={{
+                    cursor: isLockedItem ? 'not-allowed' : isDragging ? 'grabbing' : 'grab',
+                    pointerEvents: 'all',
+                  }}
                   onPointerDown={(e) => {
                     e.stopPropagation();
                     if (e.cancelable) e.preventDefault();
+                    suppressClickRef.current = true;
+                    // Locked: select it so the panel opens and says why, but do
+                    // not capture the pointer or begin a drag.
+                    if (isLockedItem) {
+                      onFurnitureSelect?.(item.id);
+                      return;
+                    }
                     capturePointer(e);
                     const worldPos = toWorldFromEvent(e as any);
                     if (!worldPos) return;
-                    suppressClickRef.current = true;
                     setFurnitureDrag({ id: item.id, start: worldPos, basePos: { x: item.x, y: item.y } });
                     onDragStateChange?.(true);
                     onFurnitureSelect?.(item.id);
@@ -1648,8 +1840,16 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                 />
               </g>
 
-              {/* Resize handles (only when selected and not dragging/rotating) */}
-              {isSelected && !isDragging && !isResizing && !isRotating && (() => {
+              {showItemLock && (
+                <LockBadge
+                  x={canvasPos.x}
+                  y={canvasPos.y}
+                  label="Furniture is locked - select it to unlock"
+                />
+              )}
+
+              {/* Resize handles (only when selected, unlocked and not dragging/rotating) */}
+              {isSelected && !isLockedItem && !isDragging && !isResizing && !isRotating && (() => {
                 const handleSize = 14;
                 const handles: Array<{ corner: 'nw' | 'ne' | 'sw' | 'se'; x: number; y: number; cursor: string }> = [
                   { corner: 'nw', x: -canvasWidth / 2, y: -canvasHeight / 2, cursor: 'nwse-resize' },
@@ -2107,16 +2307,12 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                       y={-iconSize / 2}
                       width={iconSize}
                       height={iconSize}
-                      style={{ cursor: 'grab', pointerEvents: 'all' }}
-                      onPointerDown={(e) => {
-                        if (e.button !== 0) return;
-                        e.stopPropagation();
-                        if (e.cancelable) e.preventDefault();
-                        capturePointer(e);
-                        suppressClickRef.current = true;
-                        setDragDevice(true);
-                        onDragStateChange?.(true);
+                      style={{
+                        cursor: devicePositionLocked ? (onDeviceClick ? 'pointer' : 'not-allowed') : 'grab',
+                        pointerEvents: 'all',
                       }}
+                      onPointerDown={handleDevicePointerDown}
+                      onPointerUp={handleDevicePointerUp}
                     />
                   </g>
                 ) : (
@@ -2128,16 +2324,11 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                       fill="#3b82f6"
                       stroke="#1d4ed8"
                       strokeWidth={2}
-                      onPointerDown={(e) => {
-                        if (e.button !== 0) return;
-                        e.stopPropagation();
-                        if (e.cancelable) e.preventDefault();
-                        capturePointer(e);
-                        suppressClickRef.current = true;
-                        setDragDevice(true);
-                        onDragStateChange?.(true);
+                      onPointerDown={handleDevicePointerDown}
+                      onPointerUp={handleDevicePointerUp}
+                      style={{
+                        cursor: devicePositionLocked ? (onDeviceClick ? 'pointer' : 'not-allowed') : 'grab',
                       }}
-                      style={{ cursor: 'grab' }}
                     />
                     <line
                       x1={px}
@@ -2147,8 +2338,17 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                       stroke="#ffffff"
                       strokeWidth={3}
                       strokeLinecap="round"
+                      // Drawn over the icon, so it must not steal its clicks.
+                      style={{ pointerEvents: 'none' }}
                     />
                   </>
+                )}
+                {devicePositionLocked && showLockIndicators && (
+                  <LockBadge
+                    x={px + iconSize / 2}
+                    y={py - iconSize / 2}
+                    label="Device position is locked - rotation is still adjustable"
+                  />
                 )}
               </g>
             );

--- a/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
@@ -32,6 +32,26 @@ import {
   normalizeCeilingSliceConfig,
 } from '../utils/ceilingSlices';
 import { resolveLoadedRoomSelection } from '../utils/roomSelection';
+import {
+  applyDevicePlacementUpdate,
+  areAllItemsLocked,
+  areAllSegmentsLocked,
+  countLockedObjects,
+  getLockedSegments,
+  isDevicePositionLocked,
+  isSegmentLocked,
+  isShellLocked,
+  isVertexLocked,
+  normalizeLockedSegments,
+  remapDoorsForPointRemoval,
+  remapDoorsForSplit,
+  remapLockedSegmentsForPointRemoval,
+  remapLockedSegmentsForSplit,
+  resolveLockedUpdate,
+  setItemsLocked,
+  setShellLocked,
+  toggleSegmentLock,
+} from '../utils/lockState';
 import { stableStringify } from '../utils/stableStringify';
 import {
   ROOM_HISTORY_LIMIT,
@@ -77,6 +97,16 @@ const roomSignature = (room: RoomConfig | null | undefined): string => (room ? s
 // move, so those commits share a key and collapse onto the first snapshot until
 // the gesture ends.
 type CommitRoomOptions = { coalesceKey?: string };
+
+/**
+ * A points edit normally carries the outline's locks through untouched.
+ * `lockedSegments` and `doors` are only passed by the two edits that renumber
+ * walls (splitting one, deleting a corner), which have to remap them.
+ */
+type PointsChangeOptions = CommitRoomOptions & {
+  lockedSegments?: number[];
+  doors?: Door[];
+};
 
 export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   onBack,
@@ -303,7 +333,9 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   const updateDevicePlacement = useCallback((updates: Partial<DevicePlacement>) => {
     if (!selectedRoom) return;
     const base: DevicePlacement = selectedRoom.devicePlacement ?? { x: 0, y: 0, rotationDeg: 0 };
-    const nextPlacement: DevicePlacement = { ...base, ...updates };
+    // A locked device keeps its coordinates; rotation, mounting and coverage
+    // all still apply, so aiming the sensor is unaffected.
+    const nextPlacement: DevicePlacement = applyDevicePlacementUpdate(base, updates);
     const nextRoom: RoomConfig = { ...selectedRoom, devicePlacement: nextPlacement };
     commitRoom(nextRoom, { coalesceKey: 'device:placement' });
   }, [commitRoom, selectedRoom]);
@@ -439,10 +471,96 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     }
   }, [selectedRoom?.deviceId, rotationSuggestion, resolveInstallationAngleEntityId]);
 
-  const handlePointsChange = useCallback((nextPoints: { x: number; y: number }[], options?: CommitRoomOptions) => {
+  const handlePointsChange = useCallback((nextPoints: { x: number; y: number }[], options?: PointsChangeOptions) => {
     if (!selectedRoom) return;
-    const updated: RoomConfig = { ...selectedRoom, roomShell: { points: nextPoints } };
+    const previousShell = selectedRoom.roomShell;
+    // Locks are part of the outline, so rebuilding `roomShell` here has to carry
+    // them over or every wall edit would silently unlock the room.
+    const lockedSegments = normalizeLockedSegments(
+      options?.lockedSegments ?? previousShell?.lockedSegments,
+      nextPoints.length,
+    );
+    const updated: RoomConfig = {
+      ...selectedRoom,
+      roomShell: {
+        ...previousShell,
+        points: nextPoints,
+        locked: previousShell?.locked ? true : undefined,
+        lockedSegments: lockedSegments.length ? lockedSegments : undefined,
+      },
+      ...(options?.doors?.length ? { doors: options.doors } : {}),
+    };
     commitRoom(updated, options);
+  }, [commitRoom, selectedRoom]);
+
+  // ── Object locking ────────────────────────────────────────────────────────
+  // A locked object is pinned: the canvas drops it from hit-testing so it can no
+  // longer be selected or dragged by accident, and the mutation handlers below
+  // refuse every edit except the one that unlocks it again.
+  const activeShell = selectedRoom?.roomShell;
+  const shellPointCount = activeShell?.points?.length ?? 0;
+  const lockedWallSegments = useMemo(
+    () => getLockedSegments(activeShell, shellPointCount),
+    [activeShell, shellPointCount],
+  );
+  const wholeRoomLocked = isShellLocked(activeShell);
+  const allWallsLocked = areAllSegmentsLocked(activeShell);
+  const allFurnitureLocked = areAllItemsLocked(selectedRoom?.furniture);
+  const allDoorsLocked = areAllItemsLocked(selectedRoom?.doors);
+  const selectedSegmentLocked = isSegmentLocked(activeShell, selectedSegment);
+  const devicePositionLocked = isDevicePositionLocked(selectedRoom?.devicePlacement);
+  const lockedObjectCount = countLockedObjects(selectedRoom) + (devicePositionLocked ? 1 : 0);
+
+  /**
+   * Locking never closes the object's editor panel: the panel is where the lock
+   * was turned on, so it has to stay put as the way to turn it off again. Its
+   * controls go inert instead, and the canvas stops hit-testing the object.
+   */
+  const handleSegmentLockToggle = useCallback((index: number) => {
+    const shell = selectedRoom?.roomShell;
+    if (!selectedRoom || !shell?.points?.length) return;
+    commitRoom({ ...selectedRoom, roomShell: toggleSegmentLock(shell, index) });
+    setHoveredSegment(null);
+  }, [commitRoom, selectedRoom]);
+
+  const handleShellLockChange = useCallback((locked: boolean) => {
+    const shell = selectedRoom?.roomShell;
+    if (!selectedRoom || !shell?.points?.length) return;
+    commitRoom({ ...selectedRoom, roomShell: setShellLocked(shell, locked) });
+    setHoveredSegment(null);
+  }, [commitRoom, selectedRoom]);
+
+  const handleFurnitureLockToggle = useCallback((id: string) => {
+    if (!selectedRoom) return;
+    const existing = (selectedRoom.furniture ?? []).find((f) => f.id === id);
+    if (!existing) return;
+    const locked = !existing.locked;
+    commitRoom({
+      ...selectedRoom,
+      furniture: (selectedRoom.furniture ?? []).map((f) =>
+        (f.id === id ? { ...f, locked: locked ? true : undefined } : f)),
+    });
+  }, [commitRoom, selectedRoom]);
+
+  const handleDoorLockToggle = useCallback((id: string) => {
+    if (!selectedRoom) return;
+    const existing = (selectedRoom.doors ?? []).find((d) => d.id === id);
+    if (!existing) return;
+    const locked = !existing.locked;
+    commitRoom({
+      ...selectedRoom,
+      doors: (selectedRoom.doors ?? []).map((d) => (d.id === id ? { ...d, locked: locked ? true : undefined } : d)),
+    });
+  }, [commitRoom, selectedRoom]);
+
+  const handleLockAllFurniture = useCallback((locked: boolean) => {
+    if (!selectedRoom?.furniture?.length) return;
+    commitRoom({ ...selectedRoom, furniture: setItemsLocked(selectedRoom.furniture, locked) });
+  }, [commitRoom, selectedRoom]);
+
+  const handleLockAllDoors = useCallback((locked: boolean) => {
+    if (!selectedRoom?.doors?.length) return;
+    commitRoom({ ...selectedRoom, doors: setItemsLocked(selectedRoom.doors, locked) });
   }, [commitRoom, selectedRoom]);
 
   const handleAddFurniture = useCallback((furnitureType: FurnitureType) => {
@@ -483,9 +601,14 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
 
   const handleFurnitureChange = useCallback((updatedFurniture: FurnitureInstance) => {
     if (!selectedRoom) return;
+    // Canvas gating alone is not enough: the editor panel writes here too, as
+    // does any drag still in flight. A locked item accepts nothing but unlocking.
+    const existing = (selectedRoom.furniture ?? []).find((f) => f.id === updatedFurniture.id);
+    const nextFurniture = resolveLockedUpdate(existing, updatedFurniture);
+    if (!nextFurniture) return;
     const updated: RoomConfig = {
       ...selectedRoom,
-      furniture: (selectedRoom.furniture ?? []).map((f) => (f.id === updatedFurniture.id ? updatedFurniture : f)),
+      furniture: (selectedRoom.furniture ?? []).map((f) => (f.id === updatedFurniture.id ? nextFurniture : f)),
     };
     // Dragging, resizing, rotating and the sliders all land here per input
     // event - one key per item keeps a whole gesture at one undo step.
@@ -494,6 +617,8 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
 
   const handleFurnitureDelete = useCallback(() => {
     if (!selectedRoom || !selectedFurnitureId) return;
+    // Pinned means pinned: unlock it first.
+    if ((selectedRoom.furniture ?? []).some((f) => f.id === selectedFurnitureId && f.locked)) return;
     const updated: RoomConfig = {
       ...selectedRoom,
       furniture: (selectedRoom.furniture ?? []).filter((f) => f.id !== selectedFurnitureId),
@@ -520,9 +645,14 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
 
   const handleDoorChange = useCallback((updatedDoor: Door) => {
     if (!selectedRoom) return;
+    // Door drags are routed through the host, so the canvas gate alone would
+    // still leave a locked door movable. A locked door accepts only unlocking.
+    const existing = (selectedRoom.doors ?? []).find((d) => d.id === updatedDoor.id);
+    const nextDoor = resolveLockedUpdate(existing, updatedDoor);
+    if (!nextDoor) return;
     const updated: RoomConfig = {
       ...selectedRoom,
-      doors: (selectedRoom.doors ?? []).map((d) => (d.id === updatedDoor.id ? updatedDoor : d)),
+      doors: (selectedRoom.doors ?? []).map((d) => (d.id === updatedDoor.id ? nextDoor : d)),
     };
     // Sliding a door along a wall fires per pointer move; coalesce per door.
     commitRoom(updated, { coalesceKey: `door:${updatedDoor.id}` });
@@ -530,6 +660,8 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
 
   const handleDoorDelete = useCallback(() => {
     if (!selectedRoom || !selectedDoorId) return;
+    // Pinned means pinned: unlock it first.
+    if ((selectedRoom.doors ?? []).some((d) => d.id === selectedDoorId && d.locked)) return;
     const updated: RoomConfig = {
       ...selectedRoom,
       doors: (selectedRoom.doors ?? []).filter((d) => d.id !== selectedDoorId),
@@ -553,6 +685,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
 
   const handleWallSegmentClick = useCallback((segmentIndex: number, positionOnSegment: number) => {
     if (!selectedRoom || !isDoorPlacementMode) return;
+    if (isSegmentLocked(selectedRoom.roomShell, segmentIndex)) return;
 
     const newDoor: Door = {
       id: generateId(),
@@ -573,7 +706,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
 
   const handleDoorDragStart = useCallback((doorId: string, x: number, y: number) => {
     const door = selectedRoom?.doors?.find((d) => d.id === doorId);
-    if (!door) return;
+    if (!door || door.locked) return;
     setDoorDrag({
       doorId,
       startX: x,
@@ -586,7 +719,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     if (!doorDrag || !selectedRoom) return;
 
     const door = selectedRoom.doors?.find((d) => d.id === doorDrag.doorId);
-    if (!door || !selectedRoom.roomShell?.points) return;
+    if (!door || door.locked || !selectedRoom.roomShell?.points) return;
 
     const pts = selectedRoom.roomShell.points;
     if (door.segmentIndex < 0 || door.segmentIndex >= pts.length) return;
@@ -820,6 +953,11 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
 
   const handleApplyBasicShape = (points: RoomShapePoint[], selection: BasicRoomShapeSelection) => {
     if (!selectedRoom) return;
+    // Replacing the outline would take locked walls with it.
+    if (lockedWallSegments.length) {
+      window.alert('Some walls are locked. Unlock them before replacing the room shape.');
+      return;
+    }
     if (selectedRoom.roomShell?.points?.length && !window.confirm(
       'Replace the current walls? Manual wall adjustments and doors attached to those walls will be removed.'
     )) return;
@@ -851,8 +989,12 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
       stopDrawing();
       return;
     }
-    // Clearing removes every wall at once, so ask first even though Undo can
-    // now bring them back within this session.
+    // Clearing removes every wall at once, including any that are pinned.
+    if (lockedWallSegments.length) {
+      window.alert('Some walls are locked. Unlock them before clearing the room outline.');
+      return;
+    }
+    // Ask first even though Undo can now bring them back within this session.
     setShowClearConfirm(true);
   };
 
@@ -913,13 +1055,26 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   const deleteSelectedWallPoint = useCallback(() => {
     const ptsDelete = selectedRoom?.roomShell?.points ?? [];
     if (selectedSegment === null || ptsDelete.length <= 2) return;
+    if (isSegmentLocked(selectedRoom?.roomShell, selectedSegment)) return;
 
     const removeIdx = (selectedSegment + 1) % ptsDelete.length;
+    // Removing a corner merges the two walls that meet at it, so the other one
+    // has to be unlocked too before this is allowed.
+    if (isSegmentLocked(selectedRoom?.roomShell, removeIdx)) return;
     const nextDelete = ptsDelete.filter((_, idx) => idx !== removeIdx);
-    handlePointsChange(nextDelete);
+    // Every later wall is renumbered; locks and doors are anchored by index and
+    // have to follow, or they end up attached to the wrong wall.
+    handlePointsChange(nextDelete, {
+      lockedSegments: remapLockedSegmentsForPointRemoval(
+        selectedRoom?.roomShell?.lockedSegments,
+        removeIdx,
+        ptsDelete.length,
+      ),
+      doors: remapDoorsForPointRemoval(selectedRoom?.doors, removeIdx, ptsDelete.length),
+    });
     setSelectedSegment(null);
     setHoveredSegment(null);
-  }, [handlePointsChange, selectedRoom?.roomShell?.points, selectedSegment]);
+  }, [handlePointsChange, selectedRoom?.doors, selectedRoom?.roomShell, selectedSegment]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -1022,6 +1177,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
 
   const adjustSegmentLength = (meters: number) => {
     if (selectedSegment === null || !selectedRoom?.roomShell?.points) return;
+    if (isSegmentLocked(selectedRoom.roomShell, selectedSegment)) return;
     const pts = selectedRoom.roomShell.points;
     if (pts.length < 2) return;
     const start = pts[selectedSegment];
@@ -1052,6 +1208,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
 
   const offsetSegmentNormal = (meters: number) => {
     if (selectedSegment === null || !selectedRoom?.roomShell?.points) return;
+    if (isSegmentLocked(selectedRoom.roomShell, selectedSegment)) return;
     const pts = selectedRoom.roomShell.points;
     if (pts.length < 2) return;
     const aIdx = selectedSegment;
@@ -1237,6 +1394,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   const insertPointOnSegment = useCallback((segmentIndex: number, point?: { x: number; y: number }) => {
     if (!selectedRoom?.roomShell?.points) return;
     if (isDrawingWall || isDoorPlacementMode) return;
+    if (isSegmentLocked(selectedRoom.roomShell, segmentIndex)) return;
     const pts = selectedRoom.roomShell.points;
     if (pts.length < 2) return;
     const a = pts[segmentIndex];
@@ -1252,7 +1410,14 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     const insertIndex = segmentIndex === pts.length - 1 ? pts.length : segmentIndex + 1;
     const next = [...pts];
     next.splice(insertIndex, 0, snapped);
-    handlePointsChange(next);
+    // Splitting shifts every later wall index up by one, so the index-anchored
+    // locks and doors have to be carried across with it.
+    const segmentLength = Math.hypot(b.x - a.x, b.y - a.y) || 1;
+    const splitRatio = Math.hypot(snapped.x - a.x, snapped.y - a.y) / segmentLength;
+    handlePointsChange(next, {
+      lockedSegments: remapLockedSegmentsForSplit(selectedRoom.roomShell.lockedSegments, segmentIndex),
+      doors: remapDoorsForSplit(selectedRoom.doors, segmentIndex, splitRatio),
+    });
     setSelectedSegment(segmentIndex);
   }, [selectedRoom, isDrawingWall, isDoorPlacementMode, snapPointToGrid, handlePointsChange]);
 
@@ -1853,6 +2018,9 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                   }}
                   onDragStateChange={setIsCanvasDragging}
                   lockShell={!!activeBasicShape}
+                  lockedSegments={lockedWallSegments}
+                  // Padlocks are an editing affordance, so only the builder shows them.
+                  showLockIndicators
                   showAllWallLengthLabels={!!activeBasicShape}
                   onWallLengthChange={activeBasicShape ? (segmentIndex, lengthMm) => {
                     try {
@@ -1884,6 +2052,18 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                     }
                   }
                   onDeviceChange={(placement) => updateDevicePlacement(placement)}
+                  // Clicking the device without moving it is a selection: open its
+                  // settings, the same way clicking furniture opens the furniture panel.
+                  onDeviceClick={() => {
+                    setSelectedFurnitureId(null);
+                    setSelectedDoorId(null);
+                    setSelectedSegment(null);
+                    setHoveredSegment(null);
+                    setShowFurnitureLibrary(false);
+                    setActiveMobileSheet(null);
+                    setSettingsTab('device');
+                    setShowSettings(true);
+                  }}
                   fieldOfViewDeg={coverageFov?.horizontalFovDeg ?? selectedProfile?.limits?.fieldOfViewDegrees}
                   maxRangeMeters={effectiveCoverageMaxRangeMeters}
                   deviceIconUrl={deviceIconUrl}
@@ -1907,6 +2087,13 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                   onSegmentDragStart={(idx, start) => {
                     const pts = selectedRoom?.roomShell?.points ?? [];
                     if (!pts.length) return;
+                    // Dragging a wall moves both of its corners, and with them
+                    // the neighbouring walls - refuse if any of that is locked.
+                    if (
+                      isSegmentLocked(selectedRoom?.roomShell, idx) ||
+                      isVertexLocked(selectedRoom?.roomShell, idx, pts.length) ||
+                      isVertexLocked(selectedRoom?.roomShell, (idx + 1) % pts.length, pts.length)
+                    ) return;
                     setSegmentDragIndex(idx);
                     setSegmentDragStart(start);
                     setSegmentDragBase(pts);
@@ -1915,6 +2102,9 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                   onEndpointDragStart={(segment, endpoint, start) => {
                     const pts = selectedRoom?.roomShell?.points ?? [];
                     if (!pts.length) return;
+                    const cornerIdx = endpoint === 'start' ? segment : (segment + 1) % pts.length;
+                    // The corner is shared with the neighbouring wall.
+                    if (isVertexLocked(selectedRoom?.roomShell, cornerIdx, pts.length)) return;
                     setEndpointDrag({ segment, endpoint, start, base: pts });
                     setSegmentDragIndex(null);
                     setSegmentDragStart(null);
@@ -2315,13 +2505,37 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
 
                       {settingsTab === 'device' && (
                       <div className="space-y-1">
-                        <div className="font-semibold text-slate-200">Device placement</div>
+                        <div className="flex items-center justify-between gap-2">
+                          <div className="font-semibold text-slate-200">Device placement</div>
+                          <button
+                            type="button"
+                            aria-pressed={devicePositionLocked}
+                            title={devicePositionLocked
+                              ? 'Unlock the device position'
+                              : 'Lock the device position. Rotation stays adjustable.'}
+                            onClick={() => updateDevicePlacement({ locked: !devicePositionLocked })}
+                            className={`flex items-center gap-1 rounded-md border px-2 py-1 text-[11px] font-semibold transition ${
+                              devicePositionLocked
+                                ? 'border-amber-400/70 bg-amber-500/10 text-amber-100'
+                                : 'border-slate-700 text-slate-200 hover:border-amber-400'
+                            }`}
+                          >
+                            {devicePositionLocked ? '🔒 Position locked' : '🔓 Lock position'}
+                          </button>
+                        </div>
+                        {devicePositionLocked && (
+                          <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-[11px] text-amber-200">
+                            Position is locked — the device cannot be dragged on the canvas. Rotation,
+                            mounting and coverage are still adjustable.
+                          </div>
+                        )}
                         <div className="grid grid-cols-2 gap-2">
                           <label className="flex items-center gap-2">
                             <span className="w-6">X</span>
                             <input
                               type="number"
-                              className="w-full rounded-md border border-slate-700 bg-slate-800/70 px-2 py-1 text-slate-100 focus:border-aqua-500 focus:ring-1 focus:ring-aqua-500/50 focus:outline-none"
+                              disabled={devicePositionLocked}
+                              className="w-full rounded-md border border-slate-700 bg-slate-800/70 px-2 py-1 text-slate-100 focus:border-aqua-500 focus:ring-1 focus:ring-aqua-500/50 focus:outline-none disabled:opacity-40"
                               value={selectedRoom?.devicePlacement?.x ?? 0}
                               onChange={(e) => {
                                 updateDevicePlacement({ x: Number(e.target.value) || 0 });
@@ -2332,7 +2546,8 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                             <span className="w-6">Y</span>
                             <input
                               type="number"
-                              className="w-full rounded-md border border-slate-700 bg-slate-800/70 px-2 py-1 text-slate-100 focus:border-aqua-500 focus:ring-1 focus:ring-aqua-500/50 focus:outline-none"
+                              disabled={devicePositionLocked}
+                              className="w-full rounded-md border border-slate-700 bg-slate-800/70 px-2 py-1 text-slate-100 focus:border-aqua-500 focus:ring-1 focus:ring-aqua-500/50 focus:outline-none disabled:opacity-40"
                               value={selectedRoom?.devicePlacement?.y ?? 0}
                               onChange={(e) => {
                                 updateDevicePlacement({ y: Number(e.target.value) || 0 });
@@ -2367,7 +2582,8 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                             onClick={() => {
                               updateDevicePlacement({ x: 0, y: 0 });
                             }}
-                            disabled={!selectedRoom}
+                            disabled={!selectedRoom || devicePositionLocked}
+                            title={devicePositionLocked ? 'Unlock the device position first' : undefined}
                           >
                             Center
                           </button>
@@ -2613,6 +2829,75 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                           zoneLabelScale,
                           setZoneLabelScale,
                         }}
+                        extraSections={
+                          <div className="space-y-2 border-t border-slate-700/70 pt-3">
+                            <div className="flex items-center justify-between gap-2">
+                              <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Locking</div>
+                              {lockedObjectCount > 0 && (
+                                <span className="rounded-full border border-amber-400/50 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold text-amber-200">
+                                  {lockedObjectCount} locked
+                                </span>
+                              )}
+                            </div>
+                            <p className="text-[11px] leading-snug text-slate-500">
+                              A locked object can still be clicked to open its panel, but nothing moves it.
+                              Unlock it with the padlock in that panel.
+                            </p>
+                            <button
+                              type="button"
+                              disabled={shellPointCount === 0}
+                              aria-pressed={allWallsLocked}
+                              onClick={() => handleShellLockChange(!allWallsLocked)}
+                              className={`w-full rounded-lg border px-3 py-2 text-left text-sm font-medium transition disabled:opacity-40 ${
+                                allWallsLocked
+                                  ? 'border-amber-400/70 bg-amber-500/10 text-amber-100'
+                                  : 'border-slate-700 bg-slate-800/50 text-slate-200 hover:bg-slate-800/70'
+                              }`}
+                            >
+                              {allWallsLocked ? '🔓 Unlock all walls' : '🔒 Lock all walls'}
+                            </button>
+                            <button
+                              type="button"
+                              disabled={!selectedRoom?.furniture?.length}
+                              aria-pressed={allFurnitureLocked}
+                              onClick={() => handleLockAllFurniture(!allFurnitureLocked)}
+                              className={`w-full rounded-lg border px-3 py-2 text-left text-sm font-medium transition disabled:opacity-40 ${
+                                allFurnitureLocked
+                                  ? 'border-amber-400/70 bg-amber-500/10 text-amber-100'
+                                  : 'border-slate-700 bg-slate-800/50 text-slate-200 hover:bg-slate-800/70'
+                              }`}
+                            >
+                              {allFurnitureLocked ? '🔓 Unlock all furniture' : '🔒 Lock all furniture'}
+                            </button>
+                            <button
+                              type="button"
+                              disabled={!selectedRoom?.doors?.length}
+                              aria-pressed={allDoorsLocked}
+                              onClick={() => handleLockAllDoors(!allDoorsLocked)}
+                              className={`w-full rounded-lg border px-3 py-2 text-left text-sm font-medium transition disabled:opacity-40 ${
+                                allDoorsLocked
+                                  ? 'border-amber-400/70 bg-amber-500/10 text-amber-100'
+                                  : 'border-slate-700 bg-slate-800/50 text-slate-200 hover:bg-slate-800/70'
+                              }`}
+                            >
+                              {allDoorsLocked ? '🔓 Unlock all doors' : '🔒 Lock all doors'}
+                            </button>
+                            <button
+                              type="button"
+                              aria-pressed={devicePositionLocked}
+                              title="Locks where the device sits. Rotation stays adjustable."
+                              onClick={() => updateDevicePlacement({ locked: !devicePositionLocked })}
+                              className={`w-full rounded-lg border px-3 py-2 text-left text-sm font-medium transition disabled:opacity-40 ${
+                                devicePositionLocked
+                                  ? 'border-amber-400/70 bg-amber-500/10 text-amber-100'
+                                  : 'border-slate-700 bg-slate-800/50 text-slate-200 hover:bg-slate-800/70'
+                              }`}
+                            >
+                              {devicePositionLocked ? '🔓 Unlock device position' : '🔒 Lock device position'}
+                              <span className="ml-1 text-[11px] text-slate-500">(rotation stays free)</span>
+                            </button>
+                          </div>
+                        }
                       />
                       )}
                     </div>
@@ -2741,6 +3026,24 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                           <div className="flex items-center gap-1">
                             <button
                               type="button"
+                              className={`rounded-md p-1 transition-colors ${selectedSegmentLocked ? 'text-amber-400 hover:text-amber-300' : 'text-slate-500 hover:text-amber-300'}`}
+                              aria-label={selectedSegmentLocked ? 'Unlock this wall' : 'Lock this wall'}
+                              aria-pressed={selectedSegmentLocked}
+                              title={selectedSegmentLocked ? 'Unlock this wall' : 'Lock this wall so it cannot be selected or moved'}
+                              onClick={() => handleSegmentLockToggle(selectedSegment)}
+                            >
+                              <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={1.8} viewBox="0 0 24 24" aria-hidden="true">
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d={selectedSegmentLocked
+                                    ? 'M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75M6.75 10.5h10.5a2.25 2.25 0 012.25 2.25v6a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 18.75v-6a2.25 2.25 0 012.25-2.25z'
+                                    : 'M13.5 10.5V6.75a4.5 4.5 0 119 0v3.75M3.75 10.5h10.5a2.25 2.25 0 012.25 2.25v6a2.25 2.25 0 01-2.25 2.25H3.75A2.25 2.25 0 011.5 18.75v-6a2.25 2.25 0 012.25-2.25z'}
+                                />
+                              </svg>
+                            </button>
+                            <button
+                              type="button"
                               className={`rounded-md p-1 text-slate-500 transition-colors hover:text-slate-200 ${wallEditorDragging ? 'cursor-grabbing' : 'cursor-grab'}`}
                               aria-label="Move wall editor"
                               title="Move"
@@ -2772,7 +3075,17 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                             </button>
                           </div>
                         </div>
-                        <div className="space-y-3 px-3 py-3" onWheelCapture={(e) => e.stopPropagation()}>
+                        {selectedSegmentLocked && (
+                          <div className="border-b border-amber-500/30 bg-amber-500/10 px-3 py-2 text-[11px] text-amber-200">
+                            <span className="font-semibold">Locked.</span> This wall is pinned, so it cannot be
+                            moved, split or deleted. Use the padlock above to unlock it first.
+                          </div>
+                        )}
+                        <div
+                          className={`space-y-3 px-3 py-3 ${selectedSegmentLocked ? 'pointer-events-none opacity-50' : ''}`}
+                          aria-disabled={selectedSegmentLocked || undefined}
+                          onWheelCapture={(e) => e.stopPropagation()}
+                        >
                           <div>
                             <div className="mb-1 flex items-center justify-between gap-2">
                               <label className="block text-[11px] font-semibold text-slate-300">Length ({lengthUnit})</label>
@@ -2877,6 +3190,20 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                             </button>
                           </div>
                         </div>
+                        {/* Outside the body above, so it stays usable while this wall is locked. */}
+                        <div className="border-t border-slate-800 px-3 py-2">
+                          <button
+                            className={`w-full rounded-lg border px-2.5 py-2 text-[11px] font-semibold transition ${
+                              wholeRoomLocked
+                                ? 'border-amber-400 bg-amber-500/10 text-amber-100'
+                                : 'border-slate-700 text-slate-100 hover:border-amber-400'
+                            }`}
+                            aria-pressed={wholeRoomLocked}
+                            onClick={() => handleShellLockChange(!wholeRoomLocked)}
+                          >
+                            {wholeRoomLocked ? '🔓 Unlock whole room' : '🔒 Lock whole room'}
+                          </button>
+                        </div>
                       </div>
                       </div>
 
@@ -2884,7 +3211,11 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                         <div className="flex items-center justify-between">
                           <div>
                             <div className="font-semibold text-slate-100">Wall</div>
-                            <div className="text-xs text-slate-400">Edit the selected wall segment.</div>
+                            <div className="text-xs text-slate-400">
+                              {selectedSegmentLocked
+                                ? 'Locked — unlock it below before editing.'
+                                : 'Edit the selected wall segment.'}
+                            </div>
                           </div>
                           <button
                             className="rounded-md border border-slate-700 px-2 py-1 hover:border-aqua-500"
@@ -2896,7 +3227,30 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                             Close
                           </button>
                         </div>
-                        <div className="mt-4 space-y-4">
+                        <div className="mt-4 space-y-2">
+                          <button
+                            className={`w-full rounded-lg border px-3 py-2 text-sm font-semibold ${
+                              selectedSegmentLocked ? 'border-amber-400 bg-amber-500/10 text-amber-100' : 'border-slate-700 text-slate-100'
+                            }`}
+                            aria-pressed={selectedSegmentLocked}
+                            onClick={() => handleSegmentLockToggle(selectedSegment)}
+                          >
+                            {selectedSegmentLocked ? '🔓 Unlock this wall' : '🔒 Lock this wall'}
+                          </button>
+                          <button
+                            className={`w-full rounded-lg border px-3 py-2 text-sm font-semibold ${
+                              wholeRoomLocked ? 'border-amber-400 bg-amber-500/10 text-amber-100' : 'border-slate-700 text-slate-100'
+                            }`}
+                            aria-pressed={wholeRoomLocked}
+                            onClick={() => handleShellLockChange(!wholeRoomLocked)}
+                          >
+                            {wholeRoomLocked ? '🔓 Unlock whole room' : '🔒 Lock whole room'}
+                          </button>
+                        </div>
+                        <div
+                          className={`mt-4 space-y-4 ${selectedSegmentLocked ? 'pointer-events-none opacity-50' : ''}`}
+                          aria-disabled={selectedSegmentLocked || undefined}
+                        >
                           <div>
                             <div className="mb-2 flex items-center justify-between gap-2">
                               <label className="block text-sm font-semibold text-slate-300">Length ({lengthUnit})</label>
@@ -3007,6 +3361,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                 onChange={handleFurnitureChange}
                 onDelete={handleFurnitureDelete}
                 onClose={() => setSelectedFurnitureId(null)}
+                onToggleLock={() => handleFurnitureLockToggle(selectedFurniture.id)}
               />
             </div>
           )}
@@ -3018,6 +3373,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
               onChange={handleDoorChange}
               onDelete={handleDoorDelete}
               onClose={() => setSelectedDoorId(null)}
+              onToggleLock={() => handleDoorLockToggle(selectedDoor.id)}
               maxSegmentIndex={(selectedRoom?.roomShell?.points?.length ?? 1) - 1}
               validation={doorValidation}
             />
@@ -3201,14 +3557,37 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                 <div className="font-semibold text-white">Selected furniture</div>
                 <div className="text-xs text-slate-400">{selectedFurniture.typeId}</div>
               </div>
-              <button
-                type="button"
-                className="rounded-md border border-slate-700 px-3 py-2 text-xs font-semibold text-slate-100"
-                onClick={() => setSelectedFurnitureId(null)}
-              >
-                Deselect
-              </button>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  aria-pressed={!!selectedFurniture.locked}
+                  className={`rounded-md border px-3 py-2 text-xs font-semibold ${
+                    selectedFurniture.locked
+                      ? 'border-amber-400/70 bg-amber-500/10 text-amber-100'
+                      : 'border-slate-700 text-slate-100'
+                  }`}
+                  onClick={() => handleFurnitureLockToggle(selectedFurniture.id)}
+                >
+                  {selectedFurniture.locked ? '🔓 Unlock' : '🔒 Lock'}
+                </button>
+                <button
+                  type="button"
+                  className="rounded-md border border-slate-700 px-3 py-2 text-xs font-semibold text-slate-100"
+                  onClick={() => setSelectedFurnitureId(null)}
+                >
+                  Deselect
+                </button>
+              </div>
             </div>
+            {selectedFurniture.locked && (
+              <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+                <span className="font-semibold">Locked.</span> Unlock it above before moving or resizing it.
+              </div>
+            )}
+            <div
+              className={`space-y-3 ${selectedFurniture.locked ? 'pointer-events-none opacity-50' : ''}`}
+              aria-disabled={selectedFurniture.locked || undefined}
+            >
             <label className="block">
               <span className="mb-2 flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-slate-400">
                 <span>Rotation</span>
@@ -3264,6 +3643,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
             >
               Delete Furniture
             </button>
+            </div>
           </div>
         )}
       </CanvasMobileSheet>

--- a/everything-presence-mmwave-configurator/frontend/src/utils/lockState.test.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/lockState.test.ts
@@ -1,0 +1,229 @@
+// @ts-nocheck -- Node's built-in runner supplies these modules; frontend production types stay dependency-free.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  applyDevicePlacementUpdate,
+  areAllItemsLocked,
+  areAllSegmentsLocked,
+  countLockedObjects,
+  isDevicePositionLocked,
+  getLockedSegments,
+  isSegmentLocked,
+  isShellLocked,
+  isVertexLocked,
+  normalizeLockedSegments,
+  remapDoorsForPointRemoval,
+  remapDoorsForSplit,
+  remapLockedSegmentsForPointRemoval,
+  remapLockedSegmentsForSplit,
+  remapSegmentIndexForPointRemoval,
+  resolveLockedUpdate,
+  setItemsLocked,
+  setShellLocked,
+  toggleSegmentLock,
+} from './lockState.ts';
+
+const square = () => ({
+  points: [
+    { x: 0, y: 0 },
+    { x: 1000, y: 0 },
+    { x: 1000, y: 1000 },
+    { x: 0, y: 1000 },
+  ],
+});
+
+test('an outline with no lock fields is entirely unlocked', () => {
+  const shell = square();
+  assert.equal(isShellLocked(shell), false);
+  assert.equal(isSegmentLocked(shell, 0), false);
+  assert.equal(isVertexLocked(shell, 0, 4), false);
+  assert.deepEqual(getLockedSegments(shell, 4), []);
+  assert.equal(areAllSegmentsLocked(shell), false);
+  assert.equal(countLockedObjects({ roomShell: shell }), 0);
+});
+
+test('locking the whole outline locks every wall', () => {
+  const shell = setShellLocked(square(), true);
+  assert.equal(isShellLocked(shell), true);
+  assert.deepEqual(getLockedSegments(shell, 4), [0, 1, 2, 3]);
+  assert.equal(isSegmentLocked(shell, 2), true);
+  assert.equal(areAllSegmentsLocked(shell), true);
+
+  const unlocked = setShellLocked(shell, false);
+  assert.equal(unlocked.locked, undefined);
+  assert.deepEqual(getLockedSegments(unlocked, 4), []);
+});
+
+test('toggling one wall off an outline-wide lock keeps the rest pinned', () => {
+  const shell = toggleSegmentLock(setShellLocked(square(), true), 1);
+  assert.equal(shell.locked, undefined);
+  assert.deepEqual(shell.lockedSegments, [0, 2, 3]);
+  assert.equal(isSegmentLocked(shell, 1), false);
+  assert.equal(isSegmentLocked(shell, 3), true);
+});
+
+test('locking every wall one at a time collapses back to the outline lock', () => {
+  let shell = square();
+  for (const index of [0, 1, 2, 3]) shell = toggleSegmentLock(shell, index);
+  assert.equal(shell.locked, true);
+  assert.equal(shell.lockedSegments, undefined);
+  assert.equal(areAllSegmentsLocked(shell), true);
+});
+
+test('a corner is locked when either wall it joins is locked', () => {
+  const shell = { ...square(), lockedSegments: [1] };
+  // Wall 1 spans corners 1 -> 2, so both of those are pinned.
+  assert.equal(isVertexLocked(shell, 1, 4), true);
+  assert.equal(isVertexLocked(shell, 2, 4), true);
+  assert.equal(isVertexLocked(shell, 0, 4), false);
+  assert.equal(isVertexLocked(shell, 3, 4), false);
+});
+
+test('out-of-range and duplicate wall indices are dropped', () => {
+  assert.deepEqual(normalizeLockedSegments([3, 3, 0, -1, 9, 1.5], 4), [0, 3]);
+  assert.deepEqual(normalizeLockedSegments(undefined, 4), []);
+  assert.deepEqual(normalizeLockedSegments([0], 0), []);
+});
+
+test('splitting a wall shifts later locks up and keeps both halves locked', () => {
+  // Walls 0 and 2 locked; wall 0 is split into 0 and 1.
+  assert.deepEqual(remapLockedSegmentsForSplit([0, 2], 0), [0, 1, 3]);
+  // A split after the locked wall leaves it where it was.
+  assert.deepEqual(remapLockedSegmentsForSplit([0], 2), [0]);
+  assert.deepEqual(remapLockedSegmentsForSplit(undefined, 1), []);
+});
+
+test('splitting a wall moves the doors on it onto the right half', () => {
+  const doors = [
+    { id: 'before', segmentIndex: 0, positionOnSegment: 0.2, widthMm: 800 },
+    { id: 'on-split', segmentIndex: 1, positionOnSegment: 0.25, widthMm: 800 },
+    { id: 'later', segmentIndex: 3, positionOnSegment: 0.5, widthMm: 800 },
+  ];
+  const next = remapDoorsForSplit(doors, 1, 0.5);
+
+  assert.deepEqual(next[0], doors[0]); // untouched: earlier wall
+  // Halfway split, door at 25% of the old wall -> 50% of the first half.
+  assert.equal(next[1].segmentIndex, 1);
+  assert.equal(next[1].positionOnSegment, 0.5);
+  // Everything after the split shifts up one wall.
+  assert.equal(next[2].segmentIndex, 4);
+});
+
+test('a door past the split point moves onto the second half', () => {
+  const doors = [{ id: 'd', segmentIndex: 0, positionOnSegment: 0.75, widthMm: 800 }];
+  const [door] = remapDoorsForSplit(doors, 0, 0.5);
+  assert.equal(door.segmentIndex, 1);
+  assert.equal(door.positionOnSegment, 0.5);
+});
+
+test('deleting a corner merges its two walls', () => {
+  // Square, remove corner 2: walls 1 and 2 merge into wall 1.
+  assert.equal(remapSegmentIndexForPointRemoval(0, 2, 4), 0);
+  assert.equal(remapSegmentIndexForPointRemoval(1, 2, 4), 1);
+  assert.equal(remapSegmentIndexForPointRemoval(2, 2, 4), 1);
+  assert.equal(remapSegmentIndexForPointRemoval(3, 2, 4), 2);
+});
+
+test('deleting corner 0 merges the closing wall with the first one', () => {
+  // Removing corner 0 merges walls 3 and 0 into the new last wall, 2.
+  assert.equal(remapSegmentIndexForPointRemoval(3, 0, 4), 2);
+  assert.equal(remapSegmentIndexForPointRemoval(0, 0, 4), 2);
+  assert.equal(remapSegmentIndexForPointRemoval(1, 0, 4), 0);
+  assert.equal(remapSegmentIndexForPointRemoval(2, 0, 4), 1);
+});
+
+test('locks and doors follow a deleted corner', () => {
+  assert.deepEqual(remapLockedSegmentsForPointRemoval([0, 3], 2, 4), [0, 2]);
+  // Both walls either side of the removed corner were locked - they merge into one.
+  assert.deepEqual(remapLockedSegmentsForPointRemoval([1, 2], 2, 4), [1]);
+  // A two-point outline cannot survive another deletion, so nothing is carried over.
+  assert.deepEqual(remapLockedSegmentsForPointRemoval([0], 1, 2), []);
+
+  const doors = [
+    { id: 'a', segmentIndex: 3, positionOnSegment: 0.5, widthMm: 800 },
+    { id: 'b', segmentIndex: 0, positionOnSegment: 0.5, widthMm: 800 },
+  ];
+  const next = remapDoorsForPointRemoval(doors, 2, 4);
+  assert.equal(next[0].segmentIndex, 2);
+  assert.equal(next[1], doors[1]); // unchanged doors are passed straight through
+});
+
+test('a locked item accepts nothing but being unlocked', () => {
+  const locked = { id: 'f1', x: 0, locked: true };
+
+  // A drag or slider event on a locked item is dropped entirely.
+  assert.equal(resolveLockedUpdate(locked, { ...locked, x: 500 }), null);
+  // Unlocking is the one edit that gets through, and only the unlock applies.
+  assert.deepEqual(resolveLockedUpdate(locked, { ...locked, x: 500, locked: false }), {
+    id: 'f1',
+    x: 0,
+    locked: false,
+  });
+  // Unlocked items are handed straight back.
+  const free = { id: 'f2', x: 0 };
+  const moved = { id: 'f2', x: 500 };
+  assert.equal(resolveLockedUpdate(free, moved), moved);
+  assert.equal(resolveLockedUpdate(undefined, moved), moved);
+});
+
+test('a locked device keeps its position but stays rotatable', () => {
+  const placement = { x: 1000, y: 2000, rotationDeg: 0, locked: true };
+  assert.equal(isDevicePositionLocked(placement), true);
+  assert.equal(isDevicePositionLocked({ x: 0, y: 0 }), false);
+
+  // A drag or an X/Y field cannot move it.
+  const moved = applyDevicePlacementUpdate(placement, { x: 5, y: 5 });
+  assert.equal(moved.x, 1000);
+  assert.equal(moved.y, 2000);
+
+  // Rotation, mounting and coverage all still apply.
+  const aimed = applyDevicePlacementUpdate(placement, { rotationDeg: 45 });
+  assert.equal(aimed.rotationDeg, 45);
+  assert.equal(aimed.x, 1000);
+  const mounted = applyDevicePlacementUpdate(placement, { mountType: 'ceiling', heightMm: 2400 });
+  assert.equal(mounted.mountType, 'ceiling');
+  assert.equal(mounted.heightMm, 2400);
+  assert.equal(mounted.y, 2000);
+});
+
+test('unlocking a device in the same update lets it move again', () => {
+  const placement = { x: 1000, y: 2000, locked: true };
+  const unlockedInPlace = applyDevicePlacementUpdate(placement, { locked: false });
+  assert.equal(unlockedInPlace.locked, false);
+  assert.equal(unlockedInPlace.x, 1000);
+
+  const unlockedAndMoved = applyDevicePlacementUpdate(placement, { locked: false, x: 5, y: 5 });
+  assert.equal(unlockedAndMoved.x, 5);
+  assert.equal(unlockedAndMoved.y, 5);
+});
+
+test('an unlocked device accepts position updates as before', () => {
+  const placement = { x: 0, y: 0, rotationDeg: 0 };
+  const moved = applyDevicePlacementUpdate(placement, { x: 300, y: -400 });
+  assert.equal(moved.x, 300);
+  assert.equal(moved.y, -400);
+});
+
+test('bulk locking marks every item and reports it', () => {
+  const items = [{ id: 'a' }, { id: 'b', locked: true }];
+  assert.equal(areAllItemsLocked(items), false);
+
+  const locked = setItemsLocked(items, true);
+  assert.equal(areAllItemsLocked(locked), true);
+  assert.notEqual(locked[0], items[0]); // copies, never mutates
+
+  const unlocked = setItemsLocked(locked, false);
+  assert.equal(unlocked.every((item) => item.locked === undefined), true);
+  assert.equal(areAllItemsLocked(unlocked), false);
+  assert.equal(areAllItemsLocked([]), false);
+});
+
+test('counts every pinned object in a room', () => {
+  const room = {
+    roomShell: { ...square(), lockedSegments: [0, 2] },
+    furniture: [{ id: 'f1', locked: true }, { id: 'f2' }],
+    doors: [{ id: 'd1', locked: true }],
+  };
+  assert.equal(countLockedObjects(room), 4);
+  assert.equal(countLockedObjects(null), 0);
+});

--- a/everything-presence-mmwave-configurator/frontend/src/utils/lockState.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/lockState.ts
@@ -1,0 +1,252 @@
+import type { DevicePlacement, Door, FurnitureInstance, RoomShell } from '../api/types';
+
+/**
+ * Per-object locking for the Room Builder.
+ *
+ * A locked object is pinned: it cannot be selected, dragged or edited, so
+ * working next to it never picks it up by accident. Locks live on the room
+ * config (`RoomShell.locked` / `RoomShell.lockedSegments`, `FurnitureInstance.locked`,
+ * `Door.locked`), so they survive a reload and are visible to every screen that
+ * renders a room.
+ *
+ * Walls have no identity of their own: segment `i` spans
+ * `points[i] -> points[(i + 1) % points.length]`, exactly like `Door.segmentIndex`.
+ * Splitting a wall or deleting a corner therefore renumbers every later segment,
+ * which is what the remap helpers below exist for.
+ */
+
+/** Anything that carries a lock flag. */
+export interface Lockable {
+  locked?: boolean;
+}
+
+/** True when the whole outline is pinned. */
+export const isShellLocked = (shell: RoomShell | null | undefined): boolean => !!shell?.locked;
+
+/** Wall indices that are valid for an outline of `pointCount` points, de-duplicated and ordered. */
+export const normalizeLockedSegments = (
+  segments: readonly number[] | null | undefined,
+  pointCount: number,
+): number[] => {
+  if (!Array.isArray(segments) || pointCount <= 0) return [];
+  const seen = new Set<number>();
+  for (const value of segments) {
+    if (Number.isInteger(value) && value >= 0 && value < pointCount) seen.add(value);
+  }
+  return [...seen].sort((a, b) => a - b);
+};
+
+/** Every wall index that is currently pinned, whether individually or via the whole-outline lock. */
+export const getLockedSegments = (
+  shell: RoomShell | null | undefined,
+  pointCount: number,
+): number[] => {
+  if (pointCount <= 0) return [];
+  if (isShellLocked(shell)) return Array.from({ length: pointCount }, (_, i) => i);
+  return normalizeLockedSegments(shell?.lockedSegments, pointCount);
+};
+
+export const isSegmentLocked = (
+  shell: RoomShell | null | undefined,
+  index: number | null | undefined,
+): boolean => {
+  if (index === null || index === undefined) return false;
+  if (isShellLocked(shell)) return true;
+  return (shell?.lockedSegments ?? []).includes(index);
+};
+
+/**
+ * A corner belongs to two walls; dragging it moves both, so it is locked as
+ * soon as either neighbour is.
+ */
+export const isVertexLocked = (
+  shell: RoomShell | null | undefined,
+  index: number,
+  pointCount: number,
+): boolean => {
+  if (pointCount <= 0) return false;
+  if (isShellLocked(shell)) return true;
+  const previous = (index - 1 + pointCount) % pointCount;
+  return isSegmentLocked(shell, index) || isSegmentLocked(shell, previous);
+};
+
+/** Flip the lock on one wall, leaving the rest of the outline untouched. */
+export const toggleSegmentLock = (shell: RoomShell, index: number): RoomShell => {
+  const pointCount = shell.points?.length ?? 0;
+  const current = new Set(getLockedSegments(shell, pointCount));
+  if (current.has(index)) {
+    current.delete(index);
+  } else {
+    current.add(index);
+  }
+  const lockedSegments = normalizeLockedSegments([...current], pointCount);
+  const everyWall = pointCount > 0 && lockedSegments.length === pointCount;
+  return {
+    ...shell,
+    // Unlocking one wall has to drop the whole-outline lock, otherwise the
+    // per-wall list below would be shadowed by it.
+    locked: everyWall ? true : undefined,
+    lockedSegments: lockedSegments.length && !everyWall ? lockedSegments : undefined,
+  };
+};
+
+/** Lock or unlock the outline as a whole ("the room"). */
+export const setShellLocked = (shell: RoomShell, locked: boolean): RoomShell => ({
+  ...shell,
+  locked: locked ? true : undefined,
+  lockedSegments: undefined,
+});
+
+/** True when every wall of the outline is pinned. */
+export const areAllSegmentsLocked = (shell: RoomShell | null | undefined): boolean => {
+  const pointCount = shell?.points?.length ?? 0;
+  if (pointCount === 0) return false;
+  return getLockedSegments(shell, pointCount).length === pointCount;
+};
+
+/**
+ * Re-index locked walls after `insertPointOnSegment` splits segment `segmentIndex`
+ * by inserting a corner at `segmentIndex + 1`. Walls after the split shift up by
+ * one; the split wall stays locked on both halves.
+ */
+export const remapLockedSegmentsForSplit = (
+  segments: readonly number[] | null | undefined,
+  segmentIndex: number,
+): number[] => {
+  const next = new Set<number>();
+  for (const value of segments ?? []) {
+    if (value < segmentIndex) next.add(value);
+    else if (value === segmentIndex) {
+      next.add(segmentIndex);
+      next.add(segmentIndex + 1);
+    } else next.add(value + 1);
+  }
+  return [...next].sort((a, b) => a - b);
+};
+
+/**
+ * Where old wall `index` ends up once the corner at `removedIndex` is deleted
+ * from an outline of `pointCount` points. The two walls either side of the
+ * removed corner merge into one.
+ */
+export const remapSegmentIndexForPointRemoval = (
+  index: number,
+  removedIndex: number,
+  pointCount: number,
+): number => {
+  const merged = removedIndex === 0 ? pointCount - 2 : removedIndex - 1;
+  if (index === removedIndex) return merged;
+  return index > removedIndex ? index - 1 : index;
+};
+
+/** Re-index locked walls after the corner at `removedIndex` is deleted. */
+export const remapLockedSegmentsForPointRemoval = (
+  segments: readonly number[] | null | undefined,
+  removedIndex: number,
+  pointCount: number,
+): number[] => {
+  if (pointCount <= 2) return [];
+  const next = new Set<number>();
+  for (const value of segments ?? []) {
+    const mapped = remapSegmentIndexForPointRemoval(value, removedIndex, pointCount);
+    if (mapped >= 0 && mapped < pointCount - 1) next.add(mapped);
+  }
+  return [...next].sort((a, b) => a - b);
+};
+
+/**
+ * Doors are anchored to the same wall indices, so a split or a corner deletion
+ * silently moves them onto the wrong wall unless they are remapped too.
+ *
+ * `splitRatio` is where along the wall the new corner landed (0..1): doors
+ * before it stay on the first half, doors after it move to the second, and both
+ * keep their real-world position by rescaling `positionOnSegment`.
+ */
+export const remapDoorsForSplit = (
+  doors: readonly Door[] | null | undefined,
+  segmentIndex: number,
+  splitRatio: number,
+): Door[] => {
+  const ratio = Number.isFinite(splitRatio) ? Math.min(1, Math.max(0, splitRatio)) : 0.5;
+  return (doors ?? []).map((door) => {
+    if (door.segmentIndex < segmentIndex) return door;
+    if (door.segmentIndex > segmentIndex) return { ...door, segmentIndex: door.segmentIndex + 1 };
+    if (ratio <= 0 || ratio >= 1) return door;
+    if (door.positionOnSegment <= ratio) {
+      return { ...door, positionOnSegment: door.positionOnSegment / ratio };
+    }
+    return {
+      ...door,
+      segmentIndex: segmentIndex + 1,
+      positionOnSegment: (door.positionOnSegment - ratio) / (1 - ratio),
+    };
+  });
+};
+
+/** Re-index doors after the corner at `removedIndex` is deleted. */
+export const remapDoorsForPointRemoval = (
+  doors: readonly Door[] | null | undefined,
+  removedIndex: number,
+  pointCount: number,
+): Door[] =>
+  (doors ?? []).map((door) => {
+    const mapped = remapSegmentIndexForPointRemoval(door.segmentIndex, removedIndex, pointCount);
+    return mapped === door.segmentIndex ? door : { ...door, segmentIndex: mapped };
+  });
+
+/**
+ * What a locked item is allowed to accept. Locked means locked: the only edit
+ * that gets through is the one that unlocks it again, and that edit applies
+ * nothing but the unlock.
+ */
+export const resolveLockedUpdate = <T extends Lockable>(
+  previous: T | undefined | null,
+  next: T,
+): T | null => {
+  if (!previous?.locked) return next;
+  // Spreading a generic widens its type, so the cast keeps the caller's shape.
+  return next.locked === false ? ({ ...previous, locked: false } as T) : null;
+};
+
+/**
+ * The device lock is a position-only lock: a mounted sensor's coordinates are
+ * what must not be nudged, while re-aiming it is the routine adjustment. So an
+ * update to a locked device drops `x`/`y` and lets everything else through.
+ */
+export const isDevicePositionLocked = (placement: DevicePlacement | null | undefined): boolean =>
+  !!placement?.locked;
+
+export const applyDevicePlacementUpdate = (
+  previous: DevicePlacement,
+  updates: Partial<DevicePlacement>,
+): DevicePlacement => {
+  // An explicit unlock in the same update wins, so unlocking and moving at once
+  // is still possible from the settings panel.
+  const stillLocked = updates.locked !== undefined ? !!updates.locked : !!previous.locked;
+  const next = { ...previous, ...updates };
+  // Everything else applies; only the coordinates are put back.
+  return stillLocked ? { ...next, x: previous.x, y: previous.y } : next;
+};
+
+export const areAllItemsLocked = (items: readonly Lockable[] | null | undefined): boolean =>
+  !!items?.length && items.every((item) => !!item.locked);
+
+export const setItemsLocked = <T extends Lockable>(
+  items: readonly T[] | null | undefined,
+  locked: boolean,
+): T[] => (items ?? []).map((item) => ({ ...item, locked: locked ? true : undefined } as T));
+
+/** How many objects in the room are currently pinned. */
+export const countLockedObjects = (room: {
+  roomShell?: RoomShell;
+  furniture?: FurnitureInstance[];
+  doors?: Door[];
+} | null | undefined): number => {
+  if (!room) return 0;
+  const pointCount = room.roomShell?.points?.length ?? 0;
+  return (
+    getLockedSegments(room.roomShell, pointCount).length +
+    (room.furniture ?? []).filter((item) => item.locked).length +
+    (room.doors ?? []).filter((door) => door.locked).length
+  );
+};

--- a/everything-presence-mmwave-configurator/frontend/src/utils/roomHistory.test.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/roomHistory.test.ts
@@ -43,6 +43,36 @@ test('snapshots only the room-builder subset and deep copies it', () => {
   assert.equal(snapshot.furniture[0].x, 0);
 });
 
+test('lock state is snapshotted and deep copied', () => {
+  const original = room();
+  original.roomShell.lockedSegments = [0, 2];
+  original.furniture[0].locked = true;
+  original.doors[0].locked = true;
+
+  const snapshot = snapshotRoom(original);
+
+  // Rewriting the live outline's locked walls must not reach into the snapshot.
+  original.roomShell.lockedSegments[0] = 9;
+  original.furniture[0].locked = false;
+  assert.deepEqual(snapshot.roomShell.lockedSegments, [0, 2]);
+  assert.equal(snapshot.furniture[0].locked, true);
+  assert.equal(snapshot.doors[0].locked, true);
+});
+
+test('locking a wall is an undoable change', () => {
+  const before = snapshotRoom(room());
+  const locked = room();
+  locked.roomShell.lockedSegments = [1];
+  const after = snapshotRoom(locked);
+
+  assert.equal(snapshotsEqual(before, after), false);
+
+  const history = pushRoomHistory(createRoomHistory(), before);
+  const undone = undoRoomHistory(history, after);
+  assert.ok(undone);
+  assert.equal(undone.snapshot.roomShell.lockedSegments, undefined);
+});
+
 test('applying a snapshot restores the outline without touching zones', () => {
   const before = snapshotRoom(room());
   const edited = { ...room(), roomShell: { points: [] }, zones: [] };

--- a/everything-presence-mmwave-configurator/frontend/src/utils/roomHistory.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/roomHistory.ts
@@ -39,7 +39,13 @@ export const createRoomHistory = (): RoomHistory => ({ past: [], future: [] });
 /** Copy the editable subset of a room, deeply enough that later edits cannot mutate it. */
 export const snapshotRoom = (room: RoomConfig): RoomSnapshot => ({
   roomShell: room.roomShell
-    ? { ...room.roomShell, points: (room.roomShell.points ?? []).map((point) => ({ ...point })) }
+    ? {
+      ...room.roomShell,
+      points: (room.roomShell.points ?? []).map((point) => ({ ...point })),
+      // Locked wall indices are an array too, so copy it or an undo would hand
+      // back the very array a later edit is about to rewrite.
+      ...(room.roomShell.lockedSegments ? { lockedSegments: [...room.roomShell.lockedSegments] } : {}),
+    }
     : room.roomShell,
   roomShellFillMode: room.roomShellFillMode,
   floorMaterial: room.floorMaterial,


### PR DESCRIPTION
## Summary
Three fixes on the locking preview.
**1. Locked wall panel vanishing on mouse-up.** Root cause: selecting a locked wall starts no drag, and the drag branch was the only place that set `suppressClickRef`. So the `click` that followed pointer-up reached the canvas root, hit `handleSvgClick` -> `onCanvasClick` -> `handleCanvasClick`, which treats a click on empty space as a deselect — the panel appeared on pointer-down and was torn down on release. `handlePointerDown` now also arms `suppressClickRef` when a selection was made without starting a drag, so the locked wall stays selected and its panel stays open. Clicking genuinely empty space still deselects, since `picked` is null there.
**2. Clicking the device opens its settings.** New optional `onDeviceClick` prop on `RoomCanvas`. Both device icon variants now share `handleDevicePointerDown` / `handleDevicePointerUp`, which record the press position and whether a placement was actually committed. On release, a press that moved less than 4px and committed no move is treated as a click and fires `onDeviceClick`; anything else stays a drag, so repositioning is unchanged. `handleDevicePointerUp` deliberately does not stop propagation, because the canvas-level pointer-up still has to clear the drag state. `RoomBuilderPage` responds by clearing other selections and opening Settings on the Device tab, mirroring how clicking furniture opens the furniture panel.

## Verification
CI / owner commands: `npm --prefix frontend test`, `npm --prefix frontend run lint`, `npm --prefix frontend run build`, plus the backend tsc build. No backend or pure-util logic changed in this round, so the existing `lockState.test.ts` and `roomHistory.test.ts` suites cover the unchanged parts.
Manual test steps against a deployed preview:
1. In Room Builder, lock a wall, click elsewhere to deselect, then click that locked wall and release the mouse. Expected: the Wall panel appears on press and *stays open* after release, showing the amber Locked banner with greyed controls. Previously it flashed and disappeared.
2. Click on empty canvas away from any wall. Expected: the panel closes — plain deselect still works.
3. Click a locked wall, then click its header padlock. Expected: it unlocks in place and the panel controls become editable.
4. Click the device icon once without moving the mouse. Expected: the Settings panel opens on the Device tab, and any open furniture/door/wall panel closes.
5. Drag the device icon across the room. Expected: it repositions as before and the Settings panel does *not* pop open.
6. Drag the device a very short distance (1-2px). Expected: it is treated as a click and opens Device settings rather than nudging the sensor.
7. Lock the device position, then click the device icon. Expected: it does not move, and Device settings open so the position can be unlocked there.
8. Lock a wall, a furniture item, a door and the device position. Save the room, then navigate to Live Dashboard. Expected: no padlock icons anywhere — on the door, walls, furniture or device — and no amber outlines.
9. Open the Zone Editor for the same room. Expected: likewise no padlocks or amber outlines; zone editing behaves exactly as before.
10. Return to Room Builder. Expected: all four padlocks are back and everything is still locked.
11. Run through the Wizard's device placement step.

Fixes #98