### PR TITLE
Feature Request: Ability to rotate floor plan

### DIFF
--- a/everything-presence-mmwave-configurator/frontend/package.json
+++ b/everything-presence-mmwave-configurator/frontend/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",
-		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts src/utils/polygonVertices.test.ts src/utils/roomHistory.test.ts src/utils/roomSelection.test.ts src/utils/lockState.test.ts",
+		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts src/utils/polygonVertices.test.ts src/utils/roomHistory.test.ts src/utils/roomSelection.test.ts src/utils/lockState.test.ts src/utils/roomRotation.test.ts",
 		"preview": "vite preview",
 		"format": "npx @biomejs/biome format",
 		"format:fix": "npx @biomejs/biome format --write",

--- a/everything-presence-mmwave-configurator/frontend/src/index.css
+++ b/everything-presence-mmwave-configurator/frontend/src/index.css
@@ -89,9 +89,42 @@ body {
   }
 }
 
+/*
+ * Room Builder floor-plan rotation.
+ *
+ * The geometry is committed before this plays, so the canvas starts back at the
+ * orientation it had (`--room-rotate-from`, set inline as the negated angle) and
+ * swings into its new one. Keep the duration in step with
+ * ROOM_ROTATION_SPIN_MS in RoomBuilderPage.tsx.
+ *
+ * Under `prefers-reduced-motion` the page skips the spin entirely rather than
+ * relying on the rule below, because with no animation `animationend` never
+ * fires and the wrapper would hold on to `pointer-events-none`.
+ */
+.room-rotate-spin {
+  animation: room-rotate-spin 420ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  transform-origin: 50% 50%;
+  will-change: transform;
+}
+
+@keyframes room-rotate-spin {
+  from {
+    transform: rotate(var(--room-rotate-from, -90deg)) scale(0.92);
+  }
+
+  70% {
+    transform: rotate(calc(var(--room-rotate-from, -90deg) * 0.06)) scale(1.01);
+  }
+
+  to {
+    transform: rotate(0deg) scale(1);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .mobile-sheet-backdrop,
-  .mobile-sheet-panel {
+  .mobile-sheet-panel,
+  .room-rotate-spin {
     animation: none;
   }
 }
@@ -493,6 +526,11 @@ body {
   color: #7c3aed !important;
 }
 
+.light .text-sky-100,
+.light .text-sky-200 {
+  color: #0369a1 !important;
+}
+
 /* Light mode for colored button backgrounds/borders */
 .light .bg-emerald-600\/10 {
   background-color: rgba(5, 150, 105, 0.15) !important;
@@ -514,6 +552,14 @@ body {
   background-color: rgba(147, 51, 234, 0.15) !important;
 }
 
+.light .bg-sky-600\/10 {
+  background-color: rgba(2, 132, 199, 0.12) !important;
+}
+
+.light .bg-sky-600\/20 {
+  background-color: rgba(2, 132, 199, 0.18) !important;
+}
+
 .light .border-emerald-600\/50 {
   border-color: rgba(5, 150, 105, 0.5) !important;
 }
@@ -528,6 +574,11 @@ body {
 
 .light .border-purple-600\/50 {
   border-color: rgba(147, 51, 234, 0.5) !important;
+}
+
+.light .border-sky-600\/50,
+.light .border-sky-600\/60 {
+  border-color: rgba(2, 132, 199, 0.5) !important;
 }
 
 /* Light mode hover states for colored buttons */
@@ -545,4 +596,8 @@ body {
 
 .light .hover\:bg-purple-600\/30:hover {
   background-color: rgba(147, 51, 234, 0.25) !important;
+}
+
+.light .hover\:bg-sky-600\/20:hover {
+  background-color: rgba(2, 132, 199, 0.22) !important;
 }

--- a/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
@@ -66,6 +66,15 @@ import {
   undoRoomHistory,
   type RoomHistory,
 } from '../utils/roomHistory';
+import {
+  ROTATION_STEP_DEG,
+  canRotateRoomSnapshot,
+  describeRotationScope,
+  normalizeSignedAngle,
+  rotatePointsKeepingBoundsCenter,
+  rotateRoomSnapshot,
+  type RotationScope,
+} from '../utils/roomRotation';
 
 interface RoomBuilderPageProps {
   onBack?: () => void;
@@ -86,11 +95,14 @@ interface RoomBuilderPageProps {
 }
 
 type MobileRoomBuilderSheet = 'navigation' | 'tools' | 'zoom' | null;
-type RoomBuilderSettingsTab = 'canvas' | 'device' | 'display' | 'floor';
+type RoomBuilderSettingsTab = 'canvas' | 'device' | 'display' | 'floor' | 'layout';
 type RoomBuilderView = 'wizard' | 'zoneEditor' | 'roomBuilder' | 'settings' | 'liveDashboard';
 type PendingLeave = { type: 'navigate'; view: RoomBuilderView } | { type: 'back' };
 
 const roomSignature = (room: RoomConfig | null | undefined): string => (room ? stableStringify(room) : '');
+
+/** Keep in step with the `room-rotate-spin` keyframes in index.css. */
+const ROOM_ROTATION_SPIN_MS = 420;
 
 // One user gesture should be one undo step. Continuous input (dragging
 // furniture, sweeping a slider, dragging a wall) fires a change per pointer
@@ -126,6 +138,19 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   const [rangeMm, setRangeMm] = useState(15000);
   const [showBasicShapes, setShowBasicShapes] = useState(false);
   const [activeBasicShape, setActiveBasicShape] = useState<BasicRoomShapeSelection | null>(null);
+  /**
+   * How far the basic shape has been turned since it was placed.
+   *
+   * The shape itself is parametric and always regenerates axis-aligned, so this
+   * is what a wall-length edit re-applies to keep a rotated room rotated instead
+   * of snapping it back to square.
+   */
+  const [basicShapeRotationDeg, setBasicShapeRotationDeg] = useState(0);
+  // Leaving shape mode - by any route, including an undo - retires the angle
+  // with it, so a shape placed later never inherits the last one's orientation.
+  useEffect(() => {
+    if (!activeBasicShape) setBasicShapeRotationDeg(0);
+  }, [activeBasicShape]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // Last state each room was known to have on the server; the baseline for
@@ -158,6 +183,20 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   const [settingsTab, setSettingsTab] = useState<RoomBuilderSettingsTab>('display');
   const [showNavMenu, setShowNavMenu] = useState(false);
   const [activeMobileSheet, setActiveMobileSheet] = useState<MobileRoomBuilderSheet>(null);
+  /**
+   * Which way a floor-plan rotation is meant to be read. 'layout' turns the plan
+   * and the sensor together (a pure reorientation); 'roomOnly' turns the drawing
+   * around a fixed sensor, which is the repair for "the sensor detects things 90
+   * degrees off what I drew".
+   */
+  const [rotationScope, setRotationScope] = useState<RotationScope>('layout');
+  /** Free-text angle for the Layout panel's "Custom" rotation. */
+  const [customRotationInput, setCustomRotationInput] = useState('45');
+  /** Drives the one-shot spin the canvas plays after a rotation is committed. */
+  const [rotationSpin, setRotationSpin] = useState<{ fromDeg: number; id: number } | null>(null);
+  const rotationSpinIdRef = useRef(0);
+  const rotationSpinTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rotationSpinFrameRef = useRef<number | null>(null);
   // Display settings (persisted to localStorage)
   const {
     showWalls, setShowWalls,
@@ -883,6 +922,110 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   const canUndo = historyAvailability.canUndo && !!selectedRoom;
   const canRedo = historyAvailability.canRedo && !!selectedRoom;
 
+  const canRotateLayout = !!selectedRoom && (selectedRoom.roomShell?.points?.length ?? 0) > 0;
+
+  /**
+   * Play the one-shot spin: the geometry is already committed, so the canvas
+   * starts back at the orientation the plan *had* and turns into its new one.
+   * The animation is restarted by clearing it for a frame first, otherwise a
+   * second press inside the same ROOM_ROTATION_SPIN_MS would leave the class in
+   * place and silently skip the animation.
+   */
+  const playRotationSpin = useCallback((appliedAngleDeg: number) => {
+    if (rotationSpinTimerRef.current) clearTimeout(rotationSpinTimerRef.current);
+    if (rotationSpinFrameRef.current !== null) cancelAnimationFrame(rotationSpinFrameRef.current);
+    rotationSpinFrameRef.current = null;
+    setRotationSpin(null);
+
+    // With reduced motion the CSS animation is `none`, so animationend never
+    // fires and the plan would only sit there un-interactive. Skip the spin
+    // entirely instead: the geometry is already committed either way.
+    if (typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return;
+    }
+
+    const id = (rotationSpinIdRef.current += 1);
+    const start = () => {
+      rotationSpinFrameRef.current = null;
+      setRotationSpin({ fromDeg: -appliedAngleDeg, id });
+      // Belt and braces alongside onAnimationEnd, which can be missed if the
+      // canvas is re-mounted or the tab is backgrounded mid-animation.
+      rotationSpinTimerRef.current = setTimeout(() => {
+        setRotationSpin((current) => (current?.id === id ? null : current));
+      }, ROOM_ROTATION_SPIN_MS + 120);
+    };
+    // One frame with the class removed, so pressing rotate twice in quick
+    // succession restarts the animation instead of silently skipping it.
+    if (typeof requestAnimationFrame === 'function') {
+      rotationSpinFrameRef.current = requestAnimationFrame(start);
+    } else {
+      start();
+    }
+  }, []);
+
+  useEffect(() => () => {
+    if (rotationSpinTimerRef.current) clearTimeout(rotationSpinTimerRef.current);
+    if (rotationSpinFrameRef.current !== null) cancelAnimationFrame(rotationSpinFrameRef.current);
+  }, []);
+
+  /**
+   * Turn the whole floor plan. Wall outline, doors, furniture and (in 'layout'
+   * scope) the sensor all move together through `commitRoom`, so a rotation is a
+   * single undoable step that persists with the normal room save.
+   *
+   * Locks are deliberately overridden: rotating some objects but not others
+   * would tear the plan apart, so pinned walls, furniture, doors and even a
+   * position-locked sensor all come along. The Layout panel says so, and Undo is
+   * one keystroke away.
+   */
+  const rotateLayout = useCallback(
+    (angleDeg: number, scope: RotationScope) => {
+      const room = selectedRoom;
+      if (!room) return;
+      const snapshot = snapshotRoom(room);
+      if (!canRotateRoomSnapshot(snapshot)) return;
+
+      const angle = normalizeSignedAngle(angleDeg);
+      const rotated = rotateRoomSnapshot(snapshot, angle, scope);
+      if (rotated === snapshot) return;
+
+      // A rotation is never part of a drag gesture, so it always opens a fresh
+      // undo step rather than collapsing into the previous one.
+      endHistoryGesture();
+      commitRoom(applyRoomSnapshot(room, rotated));
+
+      // Wall indices and door anchors survive a rotation, but every transient
+      // interaction is now pointing at coordinates that have just moved.
+      stopDrawing();
+      setSelectedSegment(null);
+      setHoveredSegment(null);
+      setSegmentDragIndex(null);
+      setSegmentDragStart(null);
+      setSegmentDragBase(null);
+      setEndpointDrag(null);
+      setDoorDrag(null);
+      setIsDoorPlacementMode(false);
+      // Basic-shape mode survives a rotation: dropping it here would take the
+      // wall dimension labels with it and there is no way to get them back short
+      // of replacing the outline. Remember the angle instead, so a later
+      // wall-length edit regenerates the shape at its current orientation.
+      setBasicShapeRotationDeg((prev) => normalizeSignedAngle(prev + angle));
+      setCursorPos(null);
+      setCursorDelta(null);
+      // The suggested installation angle was computed against the old walls.
+      setShowRotationSuggestion(false);
+      lastRotationSuggestionRef.current = null;
+
+      playRotationSpin(angle);
+    },
+    [commitRoom, endHistoryGesture, playRotationSpin, selectedRoom, stopDrawing],
+  );
+
+  const rotateLayoutBy = useCallback(
+    (angleDeg: number) => rotateLayout(angleDeg, rotationScope),
+    [rotateLayout, rotationScope],
+  );
+
   useEffect(() => {
     const load = async () => {
       try {
@@ -973,6 +1116,10 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     setDoorDrag(null);
     setSelectedDoorId(null);
     setActiveBasicShape(selection);
+    // Swapping one shape straight for another never passes through "no shape",
+    // so the effect above cannot clear this - a freshly placed shape is
+    // axis-aligned again.
+    setBasicShapeRotationDeg(0);
     setShowBasicShapes(false);
     setActiveMobileSheet(null);
     const maxDimension = Math.max(
@@ -1104,6 +1251,18 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
         }
       }
 
+      // Rotate follows undo/redo above rather than the bail-out below: the
+      // toolbar buttons advertise "(R)", and pressing it right after clicking
+      // one has to work even though focus is still on that button. Text fields
+      // keep their own letter.
+      if ((e.key === 'r' || e.key === 'R') && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        if (isTextEntry) return;
+        if (!canRotateLayout) return;
+        e.preventDefault();
+        rotateLayoutBy(e.shiftKey ? -ROTATION_STEP_DEG : ROTATION_STEP_DEG);
+        return;
+      }
+
       if (isEditable) return;
 
       if (e.key === 'Escape') {
@@ -1145,6 +1304,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, [
+    canRotateLayout,
     deleteSelectedWallPoint,
     handleCloseLoop,
     handleRedo,
@@ -1152,6 +1312,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     isDrawingWall,
     activeBasicShape,
     removeLastPoint,
+    rotateLayoutBy,
     selectedRoom?.roomShell?.points,
     selectedSegment,
     setIsDrawingWall,
@@ -1998,6 +2159,27 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
             setZoom((z) => Math.min(5, Math.max(0.1, z + delta)));
           }}
         >
+                {/*
+                  Rotation spin: the geometry is already rotated by the time this
+                  renders, so the wrapper starts the canvas back at the old
+                  orientation and turns it into place. `getScreenCTM` keeps
+                  pointer maths honest through the transform, but interacting
+                  with a moving plan is never what anyone means, so the wrapper
+                  swallows pointer events for the duration.
+                */}
+                <div
+                  className={`h-full w-full ${rotationSpin ? 'room-rotate-spin pointer-events-none' : ''}`}
+                  style={
+                    rotationSpin
+                      ? ({ '--room-rotate-from': `${rotationSpin.fromDeg}deg` } as React.CSSProperties)
+                      : undefined
+                  }
+                  onAnimationEnd={(e) => {
+                    // Animation events bubble, so ignore anything the canvas itself animates.
+                    if (e.target !== e.currentTarget) return;
+                    setRotationSpin((current) => (current?.id === rotationSpin?.id ? null : current));
+                  }}
+                >
                 <RoomCanvas
                   points={selectedRoom.roomShell?.points ?? []}
                   // The canvas emits this while a corner point is being dragged.
@@ -2025,12 +2207,15 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                   onWallLengthChange={activeBasicShape ? (segmentIndex, lengthMm) => {
                     try {
                       const resized = resizeBasicRoomShapeWall(activeBasicShape, segmentIndex, lengthMm);
+                      // The shape regenerates axis-aligned, so put back however
+                      // far the plan has been rotated since it was placed.
+                      const points = rotatePointsKeepingBoundsCenter(resized.points, basicShapeRotationDeg);
                       setActiveBasicShape(resized.selection);
-                      handlePointsChange(resized.points);
+                      handlePointsChange(points);
                       setPanOffsetMm({ x: 0, y: 0 });
                       const maxDimension = Math.max(
-                        Math.max(...resized.points.map((point) => point.x)) - Math.min(...resized.points.map((point) => point.x)),
-                        Math.max(...resized.points.map((point) => point.y)) - Math.min(...resized.points.map((point) => point.y)),
+                        Math.max(...points.map((point) => point.x)) - Math.min(...points.map((point) => point.x)),
+                        Math.max(...points.map((point) => point.y)) - Math.min(...points.map((point) => point.y)),
                       );
                       setZoom(Math.min(5, Math.max(0.1, (0.8 * rangeMm) / Math.max(100, maxDimension + 1000))));
                     } catch { /* Invalid dimensions leave the last valid centered outline unchanged. */ }
@@ -2274,6 +2459,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                     );
                   }}
                 />
+                </div>
           {/* Floating Room Selector (top center) */}
           <div className="absolute top-6 left-1/2 z-40 hidden -translate-x-1/2 items-center gap-2 rounded-xl border border-slate-700/50 bg-slate-900/90 backdrop-blur px-4 py-2.5 text-sm text-slate-200 shadow-xl md:flex">
             <span className="text-slate-400 font-medium">Room:</span>
@@ -2341,6 +2527,39 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                   ↷ Redo
                 </button>
               </div>
+              {/*
+                Rotate sits directly under Undo/Redo: it is the same kind of
+                whole-plan action, and having Undo right above it is the point.
+              */}
+              <div className="grid grid-cols-2 gap-2">
+                <button
+                  className="rounded-xl border border-sky-600/50 bg-sky-600/10 px-3 py-2.5 font-semibold text-sky-100 shadow-lg transition-all hover:bg-sky-600/20 disabled:opacity-40 active:scale-95"
+                  onClick={() => rotateLayoutBy(-ROTATION_STEP_DEG)}
+                  disabled={!canRotateLayout}
+                  title={`Rotate the floor plan 90° anti-clockwise (Shift+R) — ${describeRotationScope(rotationScope)}`}
+                >
+                  ↺ 90°
+                </button>
+                <button
+                  className="rounded-xl border border-sky-600/50 bg-sky-600/10 px-3 py-2.5 font-semibold text-sky-100 shadow-lg transition-all hover:bg-sky-600/20 disabled:opacity-40 active:scale-95"
+                  onClick={() => rotateLayoutBy(ROTATION_STEP_DEG)}
+                  disabled={!canRotateLayout}
+                  title={`Rotate the floor plan 90° clockwise (R) — ${describeRotationScope(rotationScope)}`}
+                >
+                  ↻ 90°
+                </button>
+              </div>
+              <button
+                type="button"
+                className="-mt-1 rounded-lg px-1 text-left text-[11px] font-medium text-slate-400 transition hover:text-sky-200"
+                onClick={() => {
+                  setSettingsTab('layout');
+                  setShowSettings(true);
+                }}
+                title="Choose what a rotation moves"
+              >
+                Rotating: {describeRotationScope(rotationScope)} · change
+              </button>
               <button
                 className="rounded-xl border border-rose-600/50 bg-rose-600/10 px-4 py-2.5 font-semibold text-rose-100 shadow-lg transition-all hover:bg-rose-600/20 disabled:opacity-40 active:scale-95"
                 onClick={handleClear}
@@ -2432,10 +2651,11 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                         </button>
                       </div>
 
-                      <div className="grid grid-cols-4 gap-1 rounded-lg border border-slate-700/60 bg-slate-950/50 p-1">
+                      <div className="grid grid-cols-5 gap-1 rounded-lg border border-slate-700/60 bg-slate-950/50 p-1">
                         {[
                           ['display', 'Display'],
                           ['device', 'Device'],
+                          ['layout', 'Layout'],
                           ['canvas', 'Canvas'],
                           ['floor', 'Floor'],
                         ].map(([tab, label]) => (
@@ -2453,6 +2673,124 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                           </button>
                         ))}
                       </div>
+
+                      {settingsTab === 'layout' && (
+                      <div className="space-y-1">
+                        <div className="font-semibold text-slate-200">Rotate floor plan</div>
+                        <p className="text-[11px] leading-relaxed text-slate-400">
+                          Turns the whole plan — walls, doors and furniture — in one undoable step.
+                          Use this instead of redrawing a room that came out the wrong way round.
+                        </p>
+
+                        <div className="pt-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                          What moves
+                        </div>
+                        <div className="space-y-1">
+                          {([
+                            {
+                              scope: 'layout' as RotationScope,
+                              detail: 'Turns the plan and the sensor together. Zones, targets and the heatmap stay exactly where they are on the walls — pick this to simply view the room the other way up.',
+                            },
+                            {
+                              scope: 'roomOnly' as RotationScope,
+                              detail: 'Leaves the sensor exactly where it is and swings the drawing around it. Pick this when the sensor reports targets at the wrong angle for the room you drew.',
+                            },
+                          ]).map(({ scope, detail }) => (
+                            <button
+                              key={scope}
+                              type="button"
+                              aria-pressed={rotationScope === scope}
+                              onClick={() => setRotationScope(scope)}
+                              className={`w-full rounded-md border px-2 py-1.5 text-left transition ${
+                                rotationScope === scope
+                                  ? 'border-aqua-500 bg-aqua-600/10 text-aqua-100'
+                                  : 'border-slate-700 text-slate-200 hover:border-slate-600'
+                              }`}
+                            >
+                              <div className="text-xs font-semibold">{describeRotationScope(scope)}</div>
+                              <div className="text-[11px] leading-relaxed text-slate-400">{detail}</div>
+                            </button>
+                          ))}
+                        </div>
+
+                        <div className="pt-2 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                          Turn
+                        </div>
+                        <div className="grid grid-cols-3 gap-2">
+                          <button
+                            type="button"
+                            className="rounded-md border border-slate-700 px-2 py-1.5 text-[11px] font-semibold text-slate-100 transition hover:border-aqua-500 disabled:opacity-40"
+                            onClick={() => rotateLayoutBy(-ROTATION_STEP_DEG)}
+                            disabled={!canRotateLayout}
+                            title="Shift+R"
+                          >
+                            ↺ 90°
+                          </button>
+                          <button
+                            type="button"
+                            className="rounded-md border border-slate-700 px-2 py-1.5 text-[11px] font-semibold text-slate-100 transition hover:border-aqua-500 disabled:opacity-40"
+                            onClick={() => rotateLayoutBy(ROTATION_STEP_DEG)}
+                            disabled={!canRotateLayout}
+                            title="R"
+                          >
+                            ↻ 90°
+                          </button>
+                          <button
+                            type="button"
+                            className="rounded-md border border-slate-700 px-2 py-1.5 text-[11px] font-semibold text-slate-100 transition hover:border-aqua-500 disabled:opacity-40"
+                            onClick={() => rotateLayoutBy(180)}
+                            disabled={!canRotateLayout}
+                            title="Turn the plan end to end"
+                          >
+                            ↻ 180°
+                          </button>
+                        </div>
+
+                        <div className="flex items-center gap-2 pt-2">
+                          <label className="flex items-center gap-2">
+                            <span className="w-14 text-xs">Custom</span>
+                            <input
+                              type="number"
+                              className="w-20 rounded-md border border-slate-700 bg-slate-800/70 px-2 py-1 text-slate-100 focus:border-aqua-500 focus:ring-1 focus:ring-aqua-500/50 focus:outline-none"
+                              value={customRotationInput}
+                              onChange={(e) => setCustomRotationInput(e.target.value)}
+                              step={1}
+                              min={-180}
+                              max={180}
+                            />
+                            <span className="text-slate-400">deg</span>
+                          </label>
+                          <button
+                            type="button"
+                            className="ml-auto rounded-md border border-slate-700 px-2 py-1 text-[11px] font-semibold text-slate-100 transition hover:border-aqua-500 disabled:opacity-40"
+                            onClick={() => {
+                              const angle = Number(customRotationInput);
+                              if (!Number.isFinite(angle) || normalizeSignedAngle(angle) === 0) return;
+                              rotateLayoutBy(angle);
+                            }}
+                            disabled={
+                              !canRotateLayout ||
+                              // `Number('')` is 0, so a blank field would look applicable.
+                              customRotationInput.trim() === '' ||
+                              !Number.isFinite(Number(customRotationInput)) ||
+                              normalizeSignedAngle(Number(customRotationInput)) === 0
+                            }
+                          >
+                            Apply
+                          </button>
+                        </div>
+
+                        {lockedObjectCount > 0 && (
+                          <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-[11px] leading-relaxed text-amber-200">
+                            {lockedObjectCount} pinned {lockedObjectCount === 1 ? 'object' : 'objects'} will be
+                            rotated. Press Undo (Ctrl/Cmd+Z) to revert changes.
+                          </div>
+                        )}
+                        {!canRotateLayout && (
+                          <div className="text-[11px] text-slate-400">Draw a wall outline first.</div>
+                        )}
+                      </div>
+                      )}
 
                       {settingsTab === 'canvas' && (
                       <div className="space-y-1">
@@ -3516,6 +3854,33 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
             disabled={!canRedo}
           >
             Redo
+          </button>
+          <button
+            type="button"
+            className="rounded-lg border border-sky-600/60 bg-sky-600/20 px-3 py-3 font-semibold text-sky-100 disabled:opacity-40"
+            onClick={() => rotateLayoutBy(-ROTATION_STEP_DEG)}
+            disabled={!canRotateLayout}
+          >
+            ↺ Rotate 90°
+          </button>
+          <button
+            type="button"
+            className="rounded-lg border border-sky-600/60 bg-sky-600/20 px-3 py-3 font-semibold text-sky-100 disabled:opacity-40"
+            onClick={() => rotateLayoutBy(ROTATION_STEP_DEG)}
+            disabled={!canRotateLayout}
+          >
+            ↻ Rotate 90°
+          </button>
+          <button
+            type="button"
+            className="col-span-2 rounded-lg border border-slate-700 bg-slate-900/60 px-3 py-2 text-left text-xs font-medium text-slate-300"
+            onClick={() => {
+              setActiveMobileSheet(null);
+              setSettingsTab('layout');
+              setShowSettings(true);
+            }}
+          >
+            Rotating: <span className="font-semibold text-sky-200">{describeRotationScope(rotationScope)}</span> · change
           </button>
           <button
             type="button"

--- a/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
@@ -23,6 +23,15 @@ import { pushZonesToDevice, fetchZonesFromDevice, fetchPolygonModeStatus, setPol
 import { fetchMetaConfig, fetchZoneAvailability, ingressAware } from '../api/client';
 import { useDeviceMappings } from '../contexts/DeviceMappingsContext';
 import { getInstallationAngleSuggestion } from '../utils/rotationSuggestion';
+import {
+  ROTATION_STEP_DEG,
+  canRotateRoomSnapshot,
+  normalizeSignedAngle,
+  normalizeUnsignedAngle,
+  rotatePointsKeepingBoundsCenter,
+  rotateRoomSnapshot,
+  type RotationScope,
+} from '../utils/roomRotation';
 import { useDisplaySettings } from '../hooks/useDisplaySettings';
 import { useIsMobileCanvas } from '../hooks/useMediaQuery';
 import { getDeviceIconUrl } from '../utils/deviceIcon';
@@ -134,6 +143,19 @@ export const WizardPage: React.FC<WizardPageProps> = ({
   const [canvasPan, setCanvasPan] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
   const [showOutlineShapeChoice, setShowOutlineShapeChoice] = useState(false);
   const [activeBasicShape, setActiveBasicShape] = useState<BasicRoomShapeSelection | null>(null);
+  /**
+   * How far the basic shape has been turned since it was placed.
+   *
+   * The shape itself is parametric and always regenerates axis-aligned, so this
+   * is what a wall-length edit re-applies to keep a rotated room rotated instead
+   * of snapping it back to square.
+   */
+  const [basicShapeRotationDeg, setBasicShapeRotationDeg] = useState(0);
+  // Leaving shape mode - by any route - retires the angle with it, so a shape
+  // placed later never inherits the last one's orientation.
+  useEffect(() => {
+    if (!activeBasicShape) setBasicShapeRotationDeg(0);
+  }, [activeBasicShape]);
 
   // Zone selection for embedded zone drawing
   const [selectedZoneId, setSelectedZoneId] = useState<string | null>(null);
@@ -531,6 +553,75 @@ export const WizardPage: React.FC<WizardPageProps> = ({
     }
   }, [selectedRoom, onRoomUpdate]);
 
+  const canRotateLayout = (selectedRoom?.roomShell?.points?.length ?? 0) > 0;
+
+  /**
+   * Turn the whole floor plan during setup, so a room drawn the wrong way round
+   * can be corrected here instead of being redrawn (or left to the Room Builder).
+   *
+   * Same pure transform the Room Builder uses. The wizard has no undo stack, so
+   * this persists straight away through the usual optimistic-update-then-save
+   * path; pressing the opposite arrow is the way back.
+   */
+  const rotateLayout = useCallback(async (angleDeg: number, scope: RotationScope) => {
+    if (!selectedRoom) return;
+    const snapshot = {
+      roomShell: selectedRoom.roomShell,
+      roomShellFillMode: selectedRoom.roomShellFillMode,
+      floorMaterial: selectedRoom.floorMaterial,
+      devicePlacement: selectedRoom.devicePlacement,
+      furniture: selectedRoom.furniture,
+      doors: selectedRoom.doors,
+    };
+    if (!canRotateRoomSnapshot(snapshot)) return;
+
+    const rotated = rotateRoomSnapshot(snapshot, angleDeg, scope);
+    if (rotated === snapshot) return;
+
+    // Drawing a wall while the plan turns under you would drop the next point in
+    // the wrong place, and every other transient interaction now points at
+    // coordinates that have just moved.
+    stopDrawing();
+    // Basic-shape mode survives a rotation: dropping it here would take the wall
+    // dimension labels with it and there is no way to get them back short of
+    // replacing the outline. Remember the angle instead, so a later wall-length
+    // edit regenerates the shape at its current orientation.
+    setBasicShapeRotationDeg((prev) => normalizeSignedAngle(prev + angleDeg));
+    setIsDoorPlacementMode(false);
+    setDoorDrag(null);
+    setSelectedDoorId(null);
+    setSelectedFurnitureId(null);
+    setCursorPos(null);
+    // The suggested installation angle was worked out against the old walls.
+    setShowRotationSuggestion(false);
+    lastRotationSuggestionRef.current = null;
+
+    const updatedRoom: RoomConfig = {
+      ...selectedRoom,
+      ...rotated,
+      // This screen's rotation slider spans 0..359, so a signed heading would
+      // leave its thumb pinned at zero. Fold it back into the range it edits.
+      ...(rotated.devicePlacement
+        ? {
+          devicePlacement: {
+            ...rotated.devicePlacement,
+            rotationDeg: normalizeUnsignedAngle(rotated.devicePlacement.rotationDeg ?? 0),
+          },
+        }
+        : {}),
+    };
+    // Optimistic update
+    onRoomUpdate?.(updatedRoom);
+    try {
+      await updateRoom(selectedRoom.id, updatedRoom);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to rotate the floor plan');
+      // Revert on error
+      onRoomUpdate?.(selectedRoom);
+    }
+  }, [selectedRoom, onRoomUpdate, stopDrawing]);
+
   // Generate UUID helper
   const generateId = useCallback(() => {
     if (typeof crypto !== 'undefined' && crypto.randomUUID) {
@@ -778,6 +869,8 @@ export const WizardPage: React.FC<WizardPageProps> = ({
       setError(null);
       setShowOutlineShapeChoice(false);
       setActiveBasicShape(selection);
+      // A freshly placed shape is axis-aligned again.
+      setBasicShapeRotationDeg(0);
       setIsDrawingWall(false);
       setCanvasPan({ x: 0, y: 0 });
       const maxDimension = Math.max(
@@ -798,11 +891,23 @@ export const WizardPage: React.FC<WizardPageProps> = ({
     const handler = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
       const tag = target.tagName.toLowerCase();
-      const isEditable =
+      const isTextEntry =
+        target.isContentEditable ||
         tag === 'input' ||
         tag === 'textarea' ||
-        tag === 'select' ||
-        tag === 'button';
+        tag === 'select';
+      const isEditable = isTextEntry || tag === 'button';
+
+      // Rotate is handled before the "focus is on a control" bail-out, so
+      // pressing R straight after clicking a rotate button still works.
+      if ((e.key === 'r' || e.key === 'R') && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        if (isTextEntry) return;
+        if (!canRotateLayout) return;
+        e.preventDefault();
+        rotateLayout(e.shiftKey ? -ROTATION_STEP_DEG : ROTATION_STEP_DEG, 'layout');
+        return;
+      }
+
       if (isEditable) return;
 
       if (e.key === 'Escape') {
@@ -837,7 +942,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [currentStep, isDrawingWall, activeBasicShape, selectedRoom?.roomShell?.points, stopDrawing, setIsDrawingWall, removeLastPoint, handleCloseLoop]);
+  }, [currentStep, isDrawingWall, activeBasicShape, canRotateLayout, rotateLayout, selectedRoom?.roomShell?.points, stopDrawing, setIsDrawingWall, removeLastPoint, handleCloseLoop]);
 
   // Auto-initialize device placement to room center when entering placement step
   useEffect(() => {
@@ -1651,12 +1756,15 @@ export const WizardPage: React.FC<WizardPageProps> = ({
               onWallLengthChange={activeBasicShape ? (segmentIndex, lengthMm) => {
                 try {
                   const resized = resizeBasicRoomShapeWall(activeBasicShape, segmentIndex, lengthMm);
+                  // The shape regenerates axis-aligned, so put back however far
+                  // the plan has been rotated since it was placed.
+                  const points = rotatePointsKeepingBoundsCenter(resized.points, basicShapeRotationDeg);
                   setActiveBasicShape(resized.selection);
-                  void handleRoomOutlineChange(resized.points);
+                  void handleRoomOutlineChange(points);
                   setCanvasPan({ x: 0, y: 0 });
                   const maxDimension = Math.max(
-                    Math.max(...resized.points.map((point) => point.x)) - Math.min(...resized.points.map((point) => point.x)),
-                    Math.max(...resized.points.map((point) => point.y)) - Math.min(...resized.points.map((point) => point.y)),
+                    Math.max(...points.map((point) => point.x)) - Math.min(...points.map((point) => point.x)),
+                    Math.max(...points.map((point) => point.y)) - Math.min(...points.map((point) => point.y)),
                   );
                   setCanvasZoom(Math.min(5, Math.max(0.1, (0.8 * 15000) / Math.max(100, maxDimension + 1000))));
                 } catch { /* Invalid dimensions leave the last valid centered outline unchanged. */ }
@@ -2043,6 +2151,29 @@ export const WizardPage: React.FC<WizardPageProps> = ({
               >
                 ⤺ Remove last point (Del)
               </button>
+              {/*
+                Drawn the room the wrong way round? Turn the whole plan rather
+                than starting again. 'layout' scope keeps the sensor rigid with
+                the walls, so nothing about the setup so far is disturbed.
+              */}
+              <div className="grid grid-cols-2 gap-2">
+                <button
+                  className="rounded-xl border border-sky-600/50 bg-sky-600/10 px-3 py-2.5 text-sm font-semibold text-sky-100 shadow-lg transition-all hover:bg-sky-600/20 disabled:opacity-40 active:scale-95"
+                  onClick={() => rotateLayout(-ROTATION_STEP_DEG, 'layout')}
+                  disabled={!canRotateLayout}
+                  title="Rotate the whole floor plan 90° anti-clockwise"
+                >
+                  ↺ 90°
+                </button>
+                <button
+                  className="rounded-xl border border-sky-600/50 bg-sky-600/10 px-3 py-2.5 text-sm font-semibold text-sky-100 shadow-lg transition-all hover:bg-sky-600/20 disabled:opacity-40 active:scale-95"
+                  onClick={() => rotateLayout(ROTATION_STEP_DEG, 'layout')}
+                  disabled={!canRotateLayout}
+                  title="Rotate the whole floor plan 90° clockwise"
+                >
+                  ↻ 90°
+                </button>
+              </div>
               <button
                 className="rounded-xl border border-rose-600/50 bg-rose-600/10 px-4 py-2.5 text-sm font-semibold text-rose-100 shadow-lg transition-all hover:bg-rose-600/20 disabled:opacity-40 active:scale-95"
                 onClick={handleClear}
@@ -2269,6 +2400,36 @@ export const WizardPage: React.FC<WizardPageProps> = ({
                   <span className="w-12 text-right font-mono font-semibold">{selectedRoom.devicePlacement.rotationDeg ?? 0}°</span>
                 </label>
               </div>
+              {/*
+                The other half of the alignment problem: the sensor is aimed
+                correctly but the room was drawn at the wrong orientation. This
+                swings the drawing around the sensor and leaves its aim alone,
+                which the rotation slider above cannot do.
+              */}
+              <div className="rounded-xl border border-slate-700/50 bg-slate-900/90 backdrop-blur p-4 shadow-lg space-y-2">
+                <div className="text-xs font-semibold text-slate-300">Room drawn the wrong way round?</div>
+                <div className="grid grid-cols-2 gap-2">
+                  <button
+                    className="rounded-lg border border-sky-600/50 bg-sky-600/10 px-3 py-2 text-xs font-semibold text-sky-100 transition-all hover:bg-sky-600/20 disabled:opacity-40 active:scale-95"
+                    onClick={() => rotateLayout(-ROTATION_STEP_DEG, 'roomOnly')}
+                    disabled={!canRotateLayout}
+                    title="Turn the room 90° anti-clockwise around the sensor, leaving the sensor's aim unchanged"
+                  >
+                    ↺ 90°
+                  </button>
+                  <button
+                    className="rounded-lg border border-sky-600/50 bg-sky-600/10 px-3 py-2 text-xs font-semibold text-sky-100 transition-all hover:bg-sky-600/20 disabled:opacity-40 active:scale-95"
+                    onClick={() => rotateLayout(ROTATION_STEP_DEG, 'roomOnly')}
+                    disabled={!canRotateLayout}
+                    title="Turn the room 90° clockwise around the sensor, leaving the sensor's aim unchanged"
+                  >
+                    ↻ 90°
+                  </button>
+                </div>
+                <div className="text-[11px] leading-relaxed text-slate-400">
+                  Turns the walls around the sensor without changing where it is aimed.
+                </div>
+              </div>
               <div className="rounded-xl border border-slate-700/50 bg-slate-900/90 backdrop-blur p-3 shadow-lg">
                 <label className="flex items-center gap-2 text-xs text-slate-200 cursor-pointer">
                   <input
@@ -2396,6 +2557,22 @@ export const WizardPage: React.FC<WizardPageProps> = ({
                       disabled={!selectedRoom}
                     >
                       Clear
+                    </button>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2">
+                    <button
+                      className="rounded-lg border border-sky-600/50 bg-sky-600/20 px-3 py-3 text-sm font-semibold text-sky-100 disabled:opacity-40"
+                      onClick={() => rotateLayout(-ROTATION_STEP_DEG, 'layout')}
+                      disabled={!canRotateLayout}
+                    >
+                      ↺ Rotate 90°
+                    </button>
+                    <button
+                      className="rounded-lg border border-sky-600/50 bg-sky-600/20 px-3 py-3 text-sm font-semibold text-sky-100 disabled:opacity-40"
+                      onClick={() => rotateLayout(ROTATION_STEP_DEG, 'layout')}
+                      disabled={!canRotateLayout}
+                    >
+                      ↻ Rotate 90°
                     </button>
                   </div>
                   <div className="rounded-lg border border-slate-700 bg-slate-800/50 p-3 text-xs text-slate-300">
@@ -2542,6 +2719,28 @@ export const WizardPage: React.FC<WizardPageProps> = ({
                       className="w-full"
                     />
                   </label>
+                  <div className="space-y-2 rounded-lg border border-slate-700 bg-slate-800/50 p-3">
+                    <div className="text-sm font-semibold text-slate-200">Room drawn the wrong way round?</div>
+                    <div className="grid grid-cols-2 gap-2">
+                      <button
+                        className="rounded-lg border border-sky-600/50 bg-sky-600/20 px-3 py-3 text-sm font-semibold text-sky-100 disabled:opacity-40"
+                        onClick={() => rotateLayout(-ROTATION_STEP_DEG, 'roomOnly')}
+                        disabled={!canRotateLayout}
+                      >
+                        ↺ 90°
+                      </button>
+                      <button
+                        className="rounded-lg border border-sky-600/50 bg-sky-600/20 px-3 py-3 text-sm font-semibold text-sky-100 disabled:opacity-40"
+                        onClick={() => rotateLayout(ROTATION_STEP_DEG, 'roomOnly')}
+                        disabled={!canRotateLayout}
+                      >
+                        ↻ 90°
+                      </button>
+                    </div>
+                    <div className="text-xs leading-relaxed text-slate-400">
+                      Turns the walls around the sensor without changing where it is aimed.
+                    </div>
+                  </div>
                   <label className="flex items-center gap-3 rounded-lg border border-slate-700 bg-slate-800/50 p-3 text-sm text-slate-200">
                     <input
                       type="checkbox"

--- a/everything-presence-mmwave-configurator/frontend/src/utils/lockState.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/lockState.ts
@@ -13,6 +13,13 @@ import type { DevicePlacement, Door, FurnitureInstance, RoomShell } from '../api
  * `points[i] -> points[(i + 1) % points.length]`, exactly like `Door.segmentIndex`.
  * Splitting a wall or deleting a corner therefore renumbers every later segment,
  * which is what the remap helpers below exist for.
+ *
+ * One edit is deliberately exempt: rotating the whole floor plan
+ * (`utils/roomRotation`) moves pinned walls, furniture, doors and even a
+ * position-locked device. Locks pin an object *relative to the room*, and a plan
+ * that turned only part way would no longer be the same room, so the Room
+ * Builder warns about the pinned objects rather than skipping them - and the
+ * locks themselves survive the rotation untouched.
  */
 
 /** Anything that carries a lock flag. */

--- a/everything-presence-mmwave-configurator/frontend/src/utils/roomRotation.test.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/roomRotation.test.ts
@@ -1,0 +1,285 @@
+// @ts-nocheck -- Node's built-in runner supplies these modules; frontend production types stay dependency-free.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  canRotateRoomSnapshot,
+  getPointsBoundsCenter,
+  getRotationPivot,
+  normalizeFurnitureAngle,
+  normalizeSignedAngle,
+  normalizeUnsignedAngle,
+  rotatePoint,
+  rotatePointsKeepingBoundsCenter,
+  rotateRoomSnapshot,
+} from './roomRotation.ts';
+
+const rect = (width, length) => [
+  { x: -width / 2, y: -length / 2 },
+  { x: width / 2, y: -length / 2 },
+  { x: width / 2, y: length / 2 },
+  { x: -width / 2, y: length / 2 },
+];
+
+const makeSnapshot = (overrides = {}) => ({
+  roomShell: { points: rect(4000, 2000) },
+  roomShellFillMode: 'solid',
+  floorMaterial: 'wood',
+  devicePlacement: { x: 0, y: -1000, rotationDeg: 90, mountType: 'wall' },
+  furniture: [
+    { id: 'f1', typeId: 'bed-double', x: 1000, y: 500, width: 1400, depth: 2000, height: 500, rotationDeg: 30, aspectRatioLocked: false },
+  ],
+  doors: [{ id: 'd1', segmentIndex: 2, positionOnSegment: 0.4, widthMm: 800, swingDirection: 'in', swingSide: 'left' }],
+  ...overrides,
+});
+
+/** The device -> room mapping every screen duplicates, for the rigidity check below. */
+const deviceToRoom = (placement, installationAngleDeg, point) => {
+  const rad = (((placement.rotationDeg ?? 0) + installationAngleDeg) * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  return {
+    x: point.x * cos - point.y * sin + placement.x,
+    y: point.x * sin + point.y * cos + placement.y,
+  };
+};
+
+/**
+ * Tolerance is always explicit: the util rounds every coordinate to 0.001 mm,
+ * so anything compared against an unrounded reference has to allow at least
+ * that, and a silent default would hide which comparison needed the slack.
+ */
+const closeTo = (actual, expected, tolerance) =>
+  assert.ok(
+    Math.abs(actual - expected) <= tolerance,
+    `expected ${actual} to be within ${tolerance} of ${expected}`,
+  );
+
+test('normalizeSignedAngle folds into (-180, 180] to match the device slider', () => {
+  assert.equal(normalizeSignedAngle(0), 0);
+  assert.equal(normalizeSignedAngle(90), 90);
+  assert.equal(normalizeSignedAngle(270), -90);
+  assert.equal(normalizeSignedAngle(-270), 90);
+  assert.equal(normalizeSignedAngle(180), 180);
+  assert.equal(normalizeSignedAngle(-180), 180);
+  assert.equal(normalizeSignedAngle(540), 180);
+  assert.equal(normalizeSignedAngle(Number.NaN), 0);
+});
+
+test('normalizeFurnitureAngle folds into [0, 360)', () => {
+  assert.equal(normalizeFurnitureAngle(0), 0);
+  assert.equal(normalizeFurnitureAngle(360), 0);
+  assert.equal(normalizeFurnitureAngle(-90), 270);
+  assert.equal(normalizeFurnitureAngle(450), 90);
+  assert.equal(normalizeFurnitureAngle(Number.NaN), 0);
+});
+
+test('normalizeUnsignedAngle is the [0, 360) fold the Wizard slider needs', () => {
+  // The Wizard's device rotation slider is 0..359, so a signed heading coming
+  // out of a rotation has to be folded before it reaches that control.
+  assert.equal(normalizeUnsignedAngle(-90), 270);
+  assert.equal(normalizeUnsignedAngle(-180), 180);
+  assert.equal(normalizeUnsignedAngle(180), 180);
+  assert.equal(normalizeUnsignedAngle(0), 0);
+  assert.equal(normalizeUnsignedAngle(Number.NaN), 0);
+  // The furniture normaliser is the same fold under a domain-specific name.
+  assert.equal(normalizeUnsignedAngle, normalizeFurnitureAngle);
+});
+
+test('a quarter turn is exact, so four of them are the identity', () => {
+  assert.deepEqual(rotatePoint({ x: 1000, y: 0 }, 90), { x: 0, y: 1000 });
+  assert.deepEqual(rotatePoint({ x: 1000, y: 0 }, -90), { x: 0, y: -1000 });
+  assert.deepEqual(rotatePoint({ x: 1000, y: 250 }, 180), { x: -1000, y: -250 });
+
+  let point = { x: 1234.5, y: -678.25 };
+  for (let i = 0; i < 4; i += 1) point = rotatePoint(point, 90);
+  assert.deepEqual(point, { x: 1234.5, y: -678.25 });
+});
+
+test('a regenerated basic shape can be put back at its current orientation', () => {
+  // resizeBasicRoomShapeWall always hands back an axis-aligned, bounds-centred
+  // outline, so this is what keeps a rotated room rotated after a wall edit.
+  const shape = rect(4000, 2000);
+  const turned = rotatePointsKeepingBoundsCenter(shape, 90);
+  assert.deepEqual(turned, [
+    { x: 1000, y: -2000 },
+    { x: 1000, y: 2000 },
+    { x: -1000, y: 2000 },
+    { x: -1000, y: -2000 },
+  ]);
+  // Point order is preserved, so wall indices still address the same parametric
+  // segment they came from.
+  assert.equal(turned.length, shape.length);
+  assert.deepEqual(getPointsBoundsCenter(turned), { x: 0, y: 0 });
+});
+
+test('putting a shape back at its orientation keeps its bounds centre put', () => {
+  // A quarter turn already preserves the bounding-box centre; an arbitrary angle
+  // does not, so the helper re-centres.
+  const offset = rect(4000, 2000).map((point) => ({ x: point.x + 5000, y: point.y - 3000 }));
+  for (const angle of [90, 180, -90, 37.5, -12]) {
+    const turned = rotatePointsKeepingBoundsCenter(offset, angle);
+    const center = getPointsBoundsCenter(turned);
+    closeTo(center.x, 5000, 0.01);
+    closeTo(center.y, -3000, 0.01);
+  }
+});
+
+test('putting a shape back at zero degrees is a no-op copy', () => {
+  const shape = rect(3000, 3000);
+  const same = rotatePointsKeepingBoundsCenter(shape, 0);
+  assert.deepEqual(same, shape);
+  assert.notEqual(same, shape, 'returns a copy, never the caller\'s array');
+  assert.deepEqual(rotatePointsKeepingBoundsCenter([], 90), []);
+  assert.deepEqual(rotatePointsKeepingBoundsCenter(null, 90), []);
+});
+
+test('rotation happens about the given pivot', () => {
+  assert.deepEqual(rotatePoint({ x: 2000, y: 1000 }, 90, { x: 1000, y: 1000 }), { x: 1000, y: 2000 });
+});
+
+test('bounds centre is used as the default pivot, device position for roomOnly', () => {
+  assert.deepEqual(getPointsBoundsCenter(rect(4000, 2000)), { x: 0, y: 0 });
+  assert.equal(getPointsBoundsCenter([]), null);
+  assert.equal(getPointsBoundsCenter(null), null);
+
+  const snapshot = makeSnapshot();
+  assert.deepEqual(getRotationPivot(snapshot, 'layout'), { x: 0, y: 0 });
+  assert.deepEqual(getRotationPivot(snapshot, 'roomOnly'), { x: 0, y: -1000 });
+  // No sensor placed yet: roomOnly has nothing to pivot on, so it falls back.
+  assert.deepEqual(
+    getRotationPivot(makeSnapshot({ devicePlacement: undefined }), 'roomOnly'),
+    { x: 0, y: 0 },
+  );
+});
+
+test('layout scope turns the outline and keeps point order (so walls and doors keep their indices)', () => {
+  const before = makeSnapshot();
+  const after = rotateRoomSnapshot(before, 90, 'layout');
+
+  assert.deepEqual(after.roomShell.points, [
+    { x: 1000, y: -2000 },
+    { x: 1000, y: 2000 },
+    { x: -1000, y: 2000 },
+    { x: -1000, y: -2000 },
+  ]);
+  assert.deepEqual(after.doors, before.doors);
+  assert.notEqual(after.doors, before.doors, 'doors are copied, not shared with the source snapshot');
+  assert.deepEqual(before.roomShell.points, rect(4000, 2000), 'input snapshot is not mutated');
+});
+
+test('layout scope moves the sensor and adds the same angle to its heading', () => {
+  const after = rotateRoomSnapshot(makeSnapshot(), 90, 'layout');
+  assert.deepEqual(
+    { x: after.devicePlacement.x, y: after.devicePlacement.y },
+    { x: 1000, y: 0 },
+  );
+  assert.equal(after.devicePlacement.rotationDeg, 180);
+  assert.equal(after.devicePlacement.mountType, 'wall', 'unrelated placement fields survive');
+});
+
+test('layout scope is rigid: every device-frame point maps to the rotated room point', () => {
+  // Zones, live targets and the heatmap are all device-frame, so if this holds
+  // they follow the walls on every screen with no extra code.
+  const before = makeSnapshot();
+  const angle = 90;
+  const after = rotateRoomSnapshot(before, angle, 'layout');
+  const pivot = getRotationPivot(before, 'layout');
+
+  for (const installationAngle of [0, -45, 17.5, 45]) {
+    for (const probe of [{ x: 0, y: 0 }, { x: 1500, y: 3000 }, { x: -2200, y: 800 }]) {
+      const expected = rotatePoint(deviceToRoom(before.devicePlacement, installationAngle, probe), angle, pivot);
+      const actual = deviceToRoom(after.devicePlacement, installationAngle, probe);
+      // Tolerance is the util's own mm rounding, not float noise.
+      closeTo(actual.x, expected.x, 0.01);
+      closeTo(actual.y, expected.y, 0.01);
+    }
+  }
+});
+
+test('roomOnly scope leaves the sensor completely alone and pivots on it', () => {
+  const before = makeSnapshot();
+  const after = rotateRoomSnapshot(before, 90, 'roomOnly');
+
+  assert.deepEqual(after.devicePlacement, before.devicePlacement);
+  // Pivot is the sensor at (0, -1000): the wall it is mounted on swings with it,
+  // which is the same result as the layout rotation shifted by pivot - R(pivot).
+  assert.deepEqual(after.roomShell.points, [
+    { x: 0, y: -3000 },
+    { x: 0, y: 1000 },
+    { x: -2000, y: 1000 },
+    { x: -2000, y: -3000 },
+  ]);
+});
+
+test('furniture is carried round and re-aimed by the same angle', () => {
+  const after = rotateRoomSnapshot(makeSnapshot(), 90, 'layout');
+  const item = after.furniture[0];
+  assert.deepEqual({ x: item.x, y: item.y }, { x: -500, y: 1000 });
+  assert.equal(item.rotationDeg, 120);
+  assert.equal(item.width, 1400, 'dimensions are untouched');
+
+  const backAgain = rotateRoomSnapshot(after, -90, 'layout');
+  assert.deepEqual(
+    { x: backAgain.furniture[0].x, y: backAgain.furniture[0].y },
+    { x: 1000, y: 500 },
+  );
+  assert.equal(backAgain.furniture[0].rotationDeg, 30);
+});
+
+test('furniture rotation stays inside [0, 360)', () => {
+  const snapshot = makeSnapshot();
+  snapshot.furniture[0].rotationDeg = 300;
+  assert.equal(rotateRoomSnapshot(snapshot, 90, 'layout').furniture[0].rotationDeg, 30);
+});
+
+test('rotation moves pinned objects too, and preserves the locks themselves', () => {
+  const before = makeSnapshot();
+  before.roomShell.locked = true;
+  before.roomShell.lockedSegments = [1, 2];
+  before.furniture[0].locked = true;
+  before.doors[0].locked = true;
+  before.devicePlacement.locked = true;
+
+  const after = rotateRoomSnapshot(before, 90, 'layout');
+  assert.equal(after.roomShell.locked, true);
+  assert.deepEqual(after.roomShell.lockedSegments, [1, 2]);
+  assert.notEqual(after.roomShell.lockedSegments, before.roomShell.lockedSegments);
+  assert.equal(after.furniture[0].locked, true);
+  assert.equal(after.doors[0].locked, true);
+  assert.equal(after.devicePlacement.locked, true);
+  // A pinned device still moves in layout scope: skipping it would desynchronise
+  // every zone from the walls.
+  assert.deepEqual({ x: after.devicePlacement.x, y: after.devicePlacement.y }, { x: 1000, y: 0 });
+  assert.notDeepEqual(after.roomShell.points, before.roomShell.points);
+});
+
+test('no-op rotations and empty rooms are returned untouched', () => {
+  const snapshot = makeSnapshot();
+  assert.equal(rotateRoomSnapshot(snapshot, 0, 'layout'), snapshot);
+  assert.equal(rotateRoomSnapshot(snapshot, 360, 'layout'), snapshot);
+
+  const empty = makeSnapshot({ roomShell: { points: [] } });
+  assert.equal(canRotateRoomSnapshot(empty), false);
+  assert.equal(canRotateRoomSnapshot(snapshot), true);
+  assert.equal(rotateRoomSnapshot(empty, 90, 'layout'), empty);
+});
+
+test('rooms without furniture, doors or a sensor rotate without inventing fields', () => {
+  const bare = { roomShell: { points: rect(3000, 3000) } };
+  const after = rotateRoomSnapshot(bare, 90, 'layout');
+  assert.equal(after.furniture, undefined);
+  assert.equal(after.doors, undefined);
+  assert.equal(after.devicePlacement, undefined);
+  assert.equal(after.roomShell.points.length, 4);
+});
+
+test('an arbitrary angle round-trips within mm rounding', () => {
+  const before = makeSnapshot();
+  const there = rotateRoomSnapshot(before, 37.5, 'layout');
+  const back = rotateRoomSnapshot(there, -37.5, 'layout');
+  back.roomShell.points.forEach((point, index) => {
+    closeTo(point.x, before.roomShell.points[index].x, 0.01);
+    closeTo(point.y, before.roomShell.points[index].y, 0.01);
+  });
+  closeTo(back.devicePlacement.rotationDeg, 90, 0.01);
+});

--- a/everything-presence-mmwave-configurator/frontend/src/utils/roomRotation.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/roomRotation.ts
@@ -1,0 +1,271 @@
+import type { RoomSnapshot } from './roomHistory';
+
+/**
+ * Rotating a whole floor plan.
+ *
+ * Room geometry lives in one mm-based, y-down world space: `roomShell.points`,
+ * `FurnitureInstance.x/y/rotationDeg` and `devicePlacement.x/y/rotationDeg`.
+ * Doors are wall-relative (`segmentIndex` + `positionOnSegment`) and locked wall
+ * indices are just wall numbers, so both follow the outline for free as long as
+ * point order and winding are preserved - which a rotation always does.
+ *
+ * Zones, live targets and the heatmap are stored in DEVICE-relative mm and are
+ * mapped into room space by every screen as
+ * `rotate(devicePlacement.rotationDeg + installationAngle)` then translate by the
+ * device position. Rotating the device's position about the pivot AND adding the
+ * same angle to `devicePlacement.rotationDeg` makes that mapping rigid:
+ *
+ *   deviceToRoom_new(p) = R_pivot(deviceToRoom_old(p))   for every device-frame p
+ *
+ * so in the `'layout'` scope zones, targets, heat pixels and the FOV cone rotate
+ * with the walls on every screen with no change to any of those call sites.
+ *
+ * The two scopes are deliberately different repairs:
+ *
+ * - `'layout'` rotates the drawing *and* the sensor: a rigid reorientation, the
+ *   room is simply drawn the other way up and nothing about how the sensor maps
+ *   onto it changes.
+ * - `'roomOnly'` rotates the drawing around a fixed sensor: the fix for "the
+ *   sensor is detecting things 90 degrees off what I drew". The device-side
+ *   Installation Angle cannot repair that on its own because it is capped at
+ *   +/-45 degrees.
+ *
+ * Everything here is pure and dependency-free (like `roomShapes` / `lockState`)
+ * so it can be unit-tested under Node's built-in runner.
+ */
+
+export type RotationScope = 'layout' | 'roomOnly';
+
+/** The quarter turn the toolbar buttons and keyboard shortcuts apply. */
+export const ROTATION_STEP_DEG = 90;
+
+export interface RotationPoint {
+  x: number;
+  y: number;
+}
+
+/** mm are stored as floats; trim the noise a rotation introduces without losing real half-mm values. */
+const MM_PRECISION = 1000;
+
+const roundMm = (value: number): number =>
+  Number.isFinite(value) ? Math.round(value * MM_PRECISION) / MM_PRECISION : 0;
+
+/**
+ * Fold an angle into (-180, 180], matching the device rotation slider's range so
+ * a rotated placement still lands inside the control that edits it.
+ */
+export const normalizeSignedAngle = (angle: number): number => {
+  if (!Number.isFinite(angle)) return 0;
+  // [0, 360) first, so a half turn lands on +180 rather than -180: the two are
+  // the same heading and the slider's documented bound is the positive one.
+  const positive = ((angle % 360) + 360) % 360;
+  return roundMm(positive > 180 ? positive - 360 : positive);
+};
+
+/**
+ * Fold an angle into [0, 360).
+ *
+ * The app has two conventions for a heading and they are both in use: the Room
+ * Builder's device slider spans -180..180, the Wizard's spans 0..359. A value
+ * outside a slider's range leaves its thumb pinned at one end, so a caller
+ * rewriting a heading has to fold it the way the control that edits it expects.
+ */
+export const normalizeUnsignedAngle = (angle: number): number => {
+  if (!Number.isFinite(angle)) return 0;
+  return roundMm(((angle % 360) + 360) % 360);
+};
+
+/** Fold an angle into [0, 360), matching `FurnitureInstance.rotationDeg`'s documented range. */
+export const normalizeFurnitureAngle = normalizeUnsignedAngle;
+
+/**
+ * cos/sin for a rotation, exact on quarter turns.
+ *
+ * `Math.cos(Math.PI / 2)` is 6.1e-17, not 0, so four scripted 90 degree turns
+ * would drift the outline instead of landing back exactly where it started.
+ * Quarter turns are the common case, so give them exact integers.
+ */
+const rotationMatrix = (angleDeg: number): { cos: number; sin: number } => {
+  const normalized = ((angleDeg % 360) + 360) % 360;
+  if (normalized === 0) return { cos: 1, sin: 0 };
+  if (normalized === 90) return { cos: 0, sin: 1 };
+  if (normalized === 180) return { cos: -1, sin: 0 };
+  if (normalized === 270) return { cos: 0, sin: -1 };
+  const rad = (normalized * Math.PI) / 180;
+  return { cos: Math.cos(rad), sin: Math.sin(rad) };
+};
+
+/**
+ * Rotate `point` about `pivot`, using the same y-down matrix as every other
+ * transform in the app (`x * cos - y * sin`, `x * sin + y * cos`), so a positive
+ * angle reads as clockwise on screen.
+ */
+export const rotatePoint = (
+  point: RotationPoint,
+  angleDeg: number,
+  pivot: RotationPoint = { x: 0, y: 0 },
+): RotationPoint => {
+  const { cos, sin } = rotationMatrix(angleDeg);
+  const dx = point.x - pivot.x;
+  const dy = point.y - pivot.y;
+  return {
+    x: roundMm(pivot.x + dx * cos - dy * sin),
+    y: roundMm(pivot.y + dx * sin + dy * cos),
+  };
+};
+
+/**
+ * Centre of the outline's bounding box.
+ *
+ * Bounds rather than centroid, to match `roomShapes.centerByBounds`: it is what
+ * the basic shapes are already built around, so a rectangle drawn from the shape
+ * picker rotates in place instead of creeping.
+ */
+export const getPointsBoundsCenter = (
+  points: readonly RotationPoint[] | null | undefined,
+): RotationPoint | null => {
+  if (!points?.length) return null;
+  let minX = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+  for (const point of points) {
+    if (!Number.isFinite(point?.x) || !Number.isFinite(point?.y)) continue;
+    minX = Math.min(minX, point.x);
+    maxX = Math.max(maxX, point.x);
+    minY = Math.min(minY, point.y);
+    maxY = Math.max(maxY, point.y);
+  }
+  if (!Number.isFinite(minX) || !Number.isFinite(minY)) return null;
+  return { x: roundMm((minX + maxX) / 2), y: roundMm((minY + maxY) / 2) };
+};
+
+/**
+ * Turn a shape about its own bounding-box centre, keeping that centre put.
+ *
+ * This exists for the basic room shapes. `BasicRoomShapeSelection` is purely
+ * parametric - a kind plus a few lengths - so `resizeBasicRoomShapeWall`
+ * regenerates an axis-aligned outline every time a wall length is edited. If the
+ * plan has since been rotated, applying those points raw would silently snap the
+ * room back to square. Re-applying the accumulated angle here is what lets shape
+ * mode (and with it the wall dimension labels) survive a rotation.
+ *
+ * Point order is preserved, so wall indices still line up with the parametric
+ * segment they came from.
+ */
+export const rotatePointsKeepingBoundsCenter = (
+  points: readonly RotationPoint[] | null | undefined,
+  angleDeg: number,
+): RotationPoint[] => {
+  const source = (points ?? []).map((point) => ({ x: point.x, y: point.y }));
+  const angle = normalizeSignedAngle(angleDeg);
+  const center = getPointsBoundsCenter(source);
+  if (!center || angle === 0) return source;
+
+  const rotated = source.map((point) => rotatePoint(point, angle, center));
+  // A quarter turn keeps a bounding box centred on the same point, but an
+  // arbitrary angle does not, so put the centre back where it was.
+  const movedCenter = getPointsBoundsCenter(rotated);
+  if (!movedCenter) return rotated;
+  const dx = center.x - movedCenter.x;
+  const dy = center.y - movedCenter.y;
+  if (dx === 0 && dy === 0) return rotated;
+  return rotated.map((point) => ({ x: roundMm(point.x + dx), y: roundMm(point.y + dy) }));
+};
+
+/**
+ * Where the plan turns.
+ *
+ * `'roomOnly'` pivots on the sensor, which is what keeps a wall-mounted sensor on
+ * its own wall as that wall swings round; everything else pivots on the room's
+ * bounding-box centre so the plan stays roughly where it was on screen.
+ */
+export const getRotationPivot = (
+  snapshot: Pick<RoomSnapshot, 'roomShell' | 'devicePlacement'> | null | undefined,
+  scope: RotationScope,
+): RotationPoint | null => {
+  const device = snapshot?.devicePlacement;
+  if (
+    scope === 'roomOnly' &&
+    device &&
+    Number.isFinite(device.x) &&
+    Number.isFinite(device.y)
+  ) {
+    return { x: device.x, y: device.y };
+  }
+  return getPointsBoundsCenter(snapshot?.roomShell?.points);
+};
+
+/** True when there is geometry worth rotating. */
+export const canRotateRoomSnapshot = (
+  snapshot: Pick<RoomSnapshot, 'roomShell'> | null | undefined,
+): boolean => (snapshot?.roomShell?.points?.length ?? 0) > 0;
+
+export interface RotateRoomSnapshotOptions {
+  /** Overrides the scope's default pivot. Used by nothing yet; kept for callers that want a corner. */
+  pivot?: RotationPoint | null;
+}
+
+/**
+ * Turn an editable room snapshot by `angleDeg`.
+ *
+ * Returns a new snapshot (never mutates), suitable for handing straight to the
+ * Room Builder's `commitRoom` so the whole rotation is one undoable step.
+ * Locks are deliberately ignored: a plan-level rotation that skipped pinned
+ * walls or pinned furniture would produce a geometrically corrupt room, so the
+ * UI warns about pinned objects instead and the transform moves everything.
+ */
+export const rotateRoomSnapshot = (
+  snapshot: RoomSnapshot,
+  angleDeg: number,
+  scope: RotationScope = 'layout',
+  options: RotateRoomSnapshotOptions = {},
+): RoomSnapshot => {
+  const angle = normalizeSignedAngle(angleDeg);
+  const pivot = options.pivot ?? getRotationPivot(snapshot, scope);
+  if (!pivot || angle === 0 || !canRotateRoomSnapshot(snapshot)) return snapshot;
+
+  const shell = snapshot.roomShell;
+  const rotateDevice = scope === 'layout';
+
+  return {
+    ...snapshot,
+    roomShell: shell
+      ? {
+        ...shell,
+        // Point order (and therefore winding, wall indices and door anchors) is
+        // preserved, so `lockedSegments` and `doors` need no remapping.
+        points: (shell.points ?? []).map((point) => rotatePoint(point, angle, pivot)),
+        ...(shell.lockedSegments ? { lockedSegments: [...shell.lockedSegments] } : {}),
+      }
+      : shell,
+    devicePlacement:
+      snapshot.devicePlacement && rotateDevice
+        ? {
+          ...snapshot.devicePlacement,
+          ...rotatePoint(
+            { x: snapshot.devicePlacement.x, y: snapshot.devicePlacement.y },
+            angle,
+            pivot,
+          ),
+          // Adding the same angle to the mount heading is what keeps zones,
+          // targets and the heatmap glued to the walls.
+          rotationDeg: normalizeSignedAngle((snapshot.devicePlacement.rotationDeg ?? 0) + angle),
+        }
+        : snapshot.devicePlacement,
+    furniture: snapshot.furniture
+      ? snapshot.furniture.map((item) => ({
+        ...item,
+        ...rotatePoint({ x: item.x, y: item.y }, angle, pivot),
+        rotationDeg: normalizeFurnitureAngle((item.rotationDeg ?? 0) + angle),
+      }))
+      : snapshot.furniture,
+    // Doors are stored against the wall they sit on, so they come along for the
+    // ride untouched.
+    doors: snapshot.doors ? snapshot.doors.map((door) => ({ ...door })) : snapshot.doors,
+  };
+};
+
+/** Human label for the scope, shared by the toolbar tooltips and the settings panel. */
+export const describeRotationScope = (scope: RotationScope): string =>
+  scope === 'roomOnly' ? 'Keep sensor aiming' : 'Rotate everything';


### PR DESCRIPTION
## Summary
Fixed the reported regression: in the Wizard, picking a Rectangle or L-shape shows a dimension label on every wall, and rotating made those labels vanish permanently.
Cause was mine. Those labels are driven by `showAllWallLengthLabels={!!activeBasicShape}`, and my rotate handler called `setActiveBasicShape(null)`. Nothing can set `activeBasicShape` again except picking a shape from the picker, which replaces the whole outline — so the labels were unrecoverable. I had cleared it deliberately, because `BasicRoomShapeSelection` is purely parametric (kind + a few lengths, no orientation) and `resizeBasicRoomShapeWall` regenerates an axis-aligned outline on every wall-length edit; leaving shape mode on would have let a later edit silently snap a rotated room back to square.
The real fix keeps shape mode alive through a rotation and makes the regeneration orientation-aware. New pure helper `rotatePointsKeepingBoundsCenter(points, angleDeg)` in roomRotation.ts turns a shape about its own bounding-box centre and puts that centre back where it was (a quarter turn preserves it already; an arbitrary angle does not). Each page now tracks a `basicShapeRotationDeg` that accumulates on rotation instead of dropping the shape, and `onWallLengthChange` pipes the regenerated points through that helper before applying them. Point order is preserved, so wall indices still address the parametric segment they came from and a wall-length edit still targets the right dimension after rotation.

## Verification
Automated: `npm --prefix everything-presence-mmwave-configurator/frontend test`, then `npx tsc --noEmit` and `npm run build` in frontend/.
Manual, against a deployed preview (NOT run here) — the reported bug first:
1. Wizard → Outline step → Basic Shapes → pick Rectangle. Expected: a dimension label on all four walls.
2. Action: press ↻ 90°. Expected: the room turns AND every wall dimension label is still there. This is the bug that was reported; before the fix they disappeared for good.
3. Action: press ↻ 90° three more times. Expected: labels present the whole way round and the room is back where it started.
4. Action: after rotating, click a wall's dimension label and type a new length. Expected: that wall resizes and the room stays rotated — it must NOT snap back to axis-aligned. Check the label you edited maps to the wall you clicked.
5. Repeat 1-4 with the L-shaped room, including editing the two cutout walls after a rotation.
6. Action: rotate, then press "✏️ Add wall". Expected: labels go away (you have left shape mode — this is correct). Then Basic Shapes → pick a shape again. Expected: a fresh axis-aligned shape with labels, not one inheriting the previous rotation.
7. Action: rotate a shape, then pick a different shape straight from the picker without leaving shape mode first. Expected: the new shape is axis-aligned.
8. Room Builder → Basic Shapes → pick a shape → rotate → edit a wall length. Expected: same as steps 2-4. Then press Ctrl/Cmd+Z. Expected: the pre-rotation outline returns (labels drop out with shape mode, as they do after any undo in shape mode).
9. Regression check on the earlier work: the Layout panel notice still reads "N pinned object(s) will be rotated. Press Undo (Ctrl/Cmd+Z) to revert changes.", and Wizard placement-step ↺/↻ still turns the walls around a fixed sensor.

Fixes #136