### PR TITLE
Feature Request: Sliding doors

### DIFF
--- a/everything-presence-mmwave-configurator/README.md
+++ b/everything-presence-mmwave-configurator/README.md
@@ -43,7 +43,7 @@ Version 2.0 is a complete rewrite with a modern interface and powerful new featu
 
 - [**Polygon zones**][polygon-zones] - Create complex zone shapes beyond rectangles
 - [**Entry/Exit detection**][in-out-detection] - Know when someone enters or leaves a zone
-- [**Room Builder**][room-builder] - Visual room layout with furniture and doors
+- [**Room Builder**][room-builder] - Visual room layout with furniture and single, sliding, opening-only, and double doors
 - [**Heatmap analytics**][heatmap-analytics] - See where presence is detected most often
 - [**Trail recording**][trail-recording] - Visualize movement paths for debugging and analysis
 - **Multi-device support** - Manage all your sensors from one place

--- a/everything-presence-mmwave-configurator/backend/src/domain/types.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/types.ts
@@ -73,6 +73,8 @@ export interface FurnitureInstance {
 
 export interface Door {
   id: string;
+  /** Visual/operational style. Missing persisted values are legacy single doors. */
+  style: 'single' | 'sliding' | 'opening' | 'double';
   segmentIndex: number;
   positionOnSegment: number;
   widthMm: number;

--- a/everything-presence-mmwave-configurator/backend/src/routes/rooms.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/rooms.ts
@@ -109,18 +109,24 @@ export const createRoomsRouter = (): Router => {
     if (!door || typeof door.id !== 'string') {
       return null;
     }
-    const segmentIndex = Number(door?.segmentIndex ?? 0);
-    const positionOnSegment = Number(door?.positionOnSegment ?? 0.5);
-    const widthMm = Number(door?.widthMm ?? 800);
+    const rawSegmentIndex = Number(door?.segmentIndex ?? 0);
+    const rawPositionOnSegment = Number(door?.positionOnSegment ?? 0.5);
+    const rawWidthMm = Number(door?.widthMm ?? 800);
+    const supportedStyles = ['single', 'sliding', 'opening', 'double'] as const;
+    const style = supportedStyles.includes(door?.style) ? door.style as Door['style'] : 'single';
     const swingDirection = door?.swingDirection === 'out' ? 'out' : 'in';
     const swingSide = door?.swingSide === 'right' ? 'right' : 'left';
 
-    if (!Number.isFinite(segmentIndex) || !Number.isFinite(positionOnSegment) || !Number.isFinite(widthMm)) {
+    if (!Number.isFinite(rawSegmentIndex) || !Number.isFinite(rawPositionOnSegment) || !Number.isFinite(rawWidthMm)) {
       return null;
     }
+    const segmentIndex = Math.max(0, Math.trunc(rawSegmentIndex));
+    const positionOnSegment = Math.min(1, Math.max(0, rawPositionOnSegment));
+    const widthMm = rawWidthMm > 0 ? rawWidthMm : 800;
 
     return {
       id: door.id,
+      style,
       segmentIndex,
       positionOnSegment,
       widthMm,

--- a/everything-presence-mmwave-configurator/frontend/package.json
+++ b/everything-presence-mmwave-configurator/frontend/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",
-		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts src/utils/polygonVertices.test.ts src/utils/roomHistory.test.ts src/utils/roomSelection.test.ts src/utils/lockState.test.ts src/utils/roomRotation.test.ts",
+		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts src/utils/polygonVertices.test.ts src/utils/roomHistory.test.ts src/utils/roomSelection.test.ts src/utils/lockState.test.ts src/utils/roomRotation.test.ts src/utils/doorGeometry.test.ts",
 		"preview": "vite preview",
 		"format": "npx @biomejs/biome format",
 		"format:fix": "npx @biomejs/biome format --write",

--- a/everything-presence-mmwave-configurator/frontend/src/api/types.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/api/types.ts
@@ -196,11 +196,12 @@ export interface FurnitureInstance {
 
 export interface Door {
   id: string; // Unique door ID
+  style: 'single' | 'sliding' | 'opening' | 'double'; // Legacy persisted doors default to single
   segmentIndex: number; // Which wall segment (0 to N-1)
   positionOnSegment: number; // 0.0 to 1.0 - position along the segment
   widthMm: number; // Door width in millimeters (typically 800-900mm)
-  swingDirection: 'in' | 'out'; // Door swing direction relative to room
-  swingSide: 'left' | 'right'; // Which side the hinge is on
+  swingDirection: 'in' | 'out'; // Used by single/double doors; retained across style changes
+  swingSide: 'left' | 'right'; // Used by single doors; retained across style changes
   locked?: boolean; // Pinned in place: not selectable or draggable on the canvas
 }
 

--- a/everything-presence-mmwave-configurator/frontend/src/components/DoorEditor.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/DoorEditor.tsx
@@ -32,6 +32,13 @@ export const DoorEditor: React.FC<DoorEditorProps> = ({
   };
 
   const hasWarnings = validation && (validation.overlaps || validation.nearCorner || validation.tooWide);
+  const style = door.style ?? 'single';
+  const styleOptions: Array<{ value: Door['style']; label: string; icon: string }> = [
+    { value: 'single', label: 'Single', icon: '↷' },
+    { value: 'sliding', label: 'Sliding', icon: '⇆' },
+    { value: 'opening', label: 'Opening', icon: '▯' },
+    { value: 'double', label: 'Double', icon: '↶↷' },
+  ];
   const swingDirectionOptions: Array<{
     value: Door['swingDirection'];
     label: string;
@@ -167,6 +174,26 @@ export const DoorEditor: React.FC<DoorEditorProps> = ({
           </div>
         )}
 
+        <fieldset>
+          <legend className="block text-sm font-semibold text-slate-300 mb-3">Door Style</legend>
+          <div className="grid grid-cols-2 gap-2">
+            {styleOptions.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => handleChange({ style: option.value })}
+                aria-pressed={style === option.value}
+                className={`rounded-lg border p-3 text-center transition-all ${style === option.value
+                  ? 'border-aqua-500 bg-aqua-500/20 text-aqua-100'
+                  : 'border-slate-700 bg-slate-800 text-slate-300 hover:border-slate-600'}`}
+              >
+                <span className="block text-xl" aria-hidden="true">{option.icon}</span>
+                <span className="text-sm font-medium">{option.label}</span>
+              </button>
+            ))}
+          </div>
+        </fieldset>
+
         {/* Wall Segment */}
         <div>
           <label className="block text-sm font-semibold text-slate-300 mb-3">Wall Segment</label>
@@ -217,15 +244,17 @@ export const DoorEditor: React.FC<DoorEditorProps> = ({
               onChange={(e) => handleChange({ widthMm: parseFloat(e.target.value) })}
               step="10"
               min="600"
-              max="1200"
+              max={style === 'sliding' || style === 'double' ? 3000 : 1200}
               className="w-full px-3 py-2 bg-slate-800/70 border border-slate-700 rounded-lg text-white focus:border-aqua-500 focus:ring-1 focus:ring-aqua-500/50 focus:outline-none"
             />
           </div>
-          <p className="text-xs text-slate-400 mt-1">Standard door: 800-900mm</p>
+          <p className="text-xs text-slate-400 mt-1">
+            {style === 'sliding' || style === 'double' ? 'Wide openings may be up to 3000mm' : 'Standard door: 800-900mm'}
+          </p>
         </div>
 
         {/* Swing Direction */}
-        <div>
+        {(style === 'single' || style === 'double') && <div>
           <label className="block text-sm font-semibold text-slate-300 mb-3">Swing Direction</label>
           <div className="grid grid-cols-2 gap-3">
             {swingDirectionOptions.map((option) => {
@@ -267,10 +296,10 @@ export const DoorEditor: React.FC<DoorEditorProps> = ({
             })}
           </div>
           <p className="text-xs text-slate-400 mt-1">Shaded side is the room. Door swing matches the canvas.</p>
-        </div>
+        </div>}
 
         {/* Hinge Side */}
-        <div>
+        {style === 'single' && <div>
           <label className="block text-sm font-semibold text-slate-300 mb-3">Hinge Side</label>
           <div className="grid grid-cols-2 gap-3">
             {hingeSideOptions.map((option) => {
@@ -313,7 +342,7 @@ export const DoorEditor: React.FC<DoorEditorProps> = ({
             })}
           </div>
           <p className="text-xs text-slate-400 mt-1">Dot marks the hinge; the panel and arc swing from that side.</p>
-        </div>
+        </div>}
       </div>
 
       {/* Footer */}

--- a/everything-presence-mmwave-configurator/frontend/src/components/RoomCanvas.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/RoomCanvas.tsx
@@ -6,6 +6,7 @@ import { FloorMaterialDefs, getFloorFill } from './FloorMaterials';
 import { useThemeContext } from '../contexts/ThemeContext';
 import { useCustomAssets } from '../hooks/useCustomAssets';
 import { formatLengthLabel } from '../utils/lengthLabels';
+import { getDoorGeometry } from '../utils/doorGeometry';
 
 export interface Point {
   x: number;
@@ -1579,6 +1580,7 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
           // Convert to canvas coordinates
           const canvasDoorPos = toCanvasCoord({ x: doorX, y: doorY });
           const canvasDoorWidth = toCanvas(door.widthMm, effectiveRangeMm);
+          const doorStyle = door.style ?? 'single';
           // Make swing radius same as door width in world coordinates (so it's proportional)
           const swingRadius = canvasDoorWidth;
 
@@ -1615,6 +1617,12 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
           const endVector = { x: arcEndX - hingeOffset, y: arcEndY };
           const crossProduct = (startVector.x * endVector.y) - (startVector.y * endVector.x);
           const sweepFlag = crossProduct > 0 ? 1 : 0;
+          const geometry = getDoorGeometry(
+            { ...door, style: doorStyle, widthMm: canvasDoorWidth },
+            inwardNormalSign,
+            { padding: 8, shallowDepth: 14 },
+          );
+          const hit = geometry.hitBounds;
 
           return (
             <g key={door.id}>
@@ -1623,10 +1631,10 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                 {/* Selection highlight (when selected) */}
                 {isSelected && (
                   <rect
-                    x={-canvasDoorWidth / 2 - 10}
-                    y={Math.min(-15, arcEndY - 15)}
-                    width={canvasDoorWidth + 20}
-                    height={Math.abs(arcEndY) + 30}
+                    x={hit.x}
+                    y={hit.y}
+                    width={hit.width}
+                    height={hit.height}
                     fill={showDoorLock ? 'rgba(251, 191, 36, 0.1)' : 'rgba(6, 182, 212, 0.1)'}
                     stroke={showDoorLock ? '#fbbf24' : '#06b6d4'}
                     strokeWidth={2}
@@ -1638,10 +1646,10 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
 
                 {/* Invisible clickable area for easier selection */}
                 <rect
-                  x={-canvasDoorWidth / 2 - 10}
-                  y={Math.min(-15, arcEndY - 15)}
-                  width={canvasDoorWidth + 20}
-                  height={Math.abs(arcEndY) + 30}
+                  x={hit.x}
+                  y={hit.y}
+                  width={hit.width}
+                  height={hit.height}
                   fill="transparent"
                   style={{
                     cursor: isLockedDoor ? 'not-allowed' : isSelected ? 'grab' : 'pointer',
@@ -1685,8 +1693,8 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                   style={{ cursor: 'pointer', pointerEvents: 'none' }}
                 />
 
-                {/* Door swing arc - 90 degree arc showing door swing path */}
-                {door.swingDirection && (
+                {/* Single hinged leaf and swing clearance. */}
+                {doorStyle === 'single' && door.swingDirection && (
                   <path
                     d={`M ${arcStartX} ${arcStartY} A ${swingRadius} ${swingRadius} 0 ${largeArcFlag} ${sweepFlag} ${arcEndX} ${arcEndY}`}
                     stroke={isSelected ? '#06b6d4' : '#000000'}
@@ -1698,8 +1706,7 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                   />
                 )}
 
-                {/* Door panel - wooden brown color, showing closed position */}
-                <line
+                {doorStyle === 'single' && <line
                   x1={hingeOffset}
                   y1={0}
                   x2={hingeOffset}
@@ -1708,10 +1715,10 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                   strokeWidth={4}
                   vectorEffect="non-scaling-stroke"
                   style={{ pointerEvents: 'none' }}
-                />
+                />}
 
                 {/* Hinge indicator - metallic look */}
-                <circle
+                {doorStyle === 'single' && <circle
                   cx={hingeOffset}
                   cy={0}
                   r={4}
@@ -1719,7 +1726,47 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                   stroke={isSelected ? '#0891b2' : '#52525b'}
                   strokeWidth={1}
                   style={{ pointerEvents: 'none' }}
-                />
+                />}
+
+                {/* A single centred opening symbol with one slide-direction arrow. */}
+                {doorStyle === 'sliding' && geometry.slidingPanel && (() => {
+                  const panel = geometry.slidingPanel;
+                  const colour = isSelected ? '#06b6d4' : '#475569';
+                  const centreX = (panel.startX + panel.endX) / 2;
+                  const arrowLength = Math.min(18, Math.abs(panel.endX - panel.startX) * 0.3);
+                  const arrowTipX = centreX + panel.direction * arrowLength / 2;
+                  const arrowTailX = centreX - panel.direction * arrowLength / 2;
+                  return <g style={{ pointerEvents: 'none' }}>
+                    <line x1={panel.startX} y1={panel.y} x2={panel.endX} y2={panel.y} stroke={colour} strokeWidth={3} strokeLinecap="square" vectorEffect="non-scaling-stroke" />
+                    <line x1={panel.startX} y1={panel.y - 8} x2={panel.startX} y2={panel.y + 8} stroke={colour} strokeWidth={3} vectorEffect="non-scaling-stroke" />
+                    <line x1={panel.endX} y1={panel.y - 8} x2={panel.endX} y2={panel.y + 8} stroke={colour} strokeWidth={3} vectorEffect="non-scaling-stroke" />
+                    <path
+                      d={`M ${arrowTailX} ${panel.y} L ${arrowTipX} ${panel.y} M ${arrowTipX - panel.direction * 4} ${panel.y - 3} L ${arrowTipX} ${panel.y} L ${arrowTipX - panel.direction * 4} ${panel.y + 3}`}
+                      stroke={colour}
+                      strokeWidth={1.5}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      fill="none"
+                      vectorEffect="non-scaling-stroke"
+                    />
+                  </g>;
+                })()}
+
+                {/* Opening-only style has jambs but no leaf or clearance arc. */}
+                {doorStyle === 'opening' && <>
+                  <line x1={-canvasDoorWidth / 2} y1={-8} x2={-canvasDoorWidth / 2} y2={8} stroke={isSelected ? '#06b6d4' : '#71717a'} strokeWidth={4} vectorEffect="non-scaling-stroke" />
+                  <line x1={canvasDoorWidth / 2} y1={-8} x2={canvasDoorWidth / 2} y2={8} stroke={isSelected ? '#06b6d4' : '#71717a'} strokeWidth={4} vectorEffect="non-scaling-stroke" />
+                </>}
+
+                {/* Opposing half-width leaves with mirrored clearance arcs. */}
+                {doorStyle === 'double' && geometry.leaves?.map((leaf) => {
+                  const closedX = leaf.hingeX < 0 ? 0 : 0;
+                  return <g key={leaf.hingeX}>
+                    <path d={`M ${closedX} 0 A ${canvasDoorWidth / 2} ${canvasDoorWidth / 2} 0 0 ${leaf.sweep} ${leaf.endX} ${leaf.endY}`} stroke={isSelected ? '#06b6d4' : '#000000'} strokeWidth={2} fill="none" strokeDasharray="6 4" vectorEffect="non-scaling-stroke" />
+                    <line x1={leaf.hingeX} y1={0} x2={leaf.endX} y2={leaf.endY} stroke={isSelected ? '#06b6d4' : '#8b5a3c'} strokeWidth={4} vectorEffect="non-scaling-stroke" />
+                    <circle cx={leaf.hingeX} cy={0} r={4} fill={isSelected ? '#06b6d4' : '#71717a'} />
+                  </g>;
+                })}
               </g>
               {showDoorLock && (
                 <LockBadge

--- a/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
@@ -18,6 +18,7 @@ import {
 import { DisplaySettingsControls } from '../components/DisplaySettingsControls';
 import { BasicRoomShapesPicker, resizeBasicRoomShapeWall, type BasicRoomShapeSelection } from '../components/BasicRoomShapesPicker';
 import type { RoomShapePoint } from '../utils/roomShapes';
+import { clampDoorPosition } from '../utils/doorGeometry';
 import { useDisplaySettings } from '../hooks/useDisplaySettings';
 import { useIsMobileCanvas } from '../hooks/useMediaQuery';
 import { getInstallationAngleSuggestion } from '../utils/rotationSuggestion';
@@ -687,8 +688,19 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     // Door drags are routed through the host, so the canvas gate alone would
     // still leave a locked door movable. A locked door accepts only unlocking.
     const existing = (selectedRoom.doors ?? []).find((d) => d.id === updatedDoor.id);
-    const nextDoor = resolveLockedUpdate(existing, updatedDoor);
-    if (!nextDoor) return;
+    const unlockedDoor = resolveLockedUpdate(existing, updatedDoor);
+    if (!unlockedDoor) return;
+    const points = selectedRoom.roomShell?.points ?? [];
+    const start = points[unlockedDoor.segmentIndex];
+    const end = points[(unlockedDoor.segmentIndex + 1) % points.length];
+    const nextDoor = start && end ? {
+      ...unlockedDoor,
+      positionOnSegment: clampDoorPosition(
+        unlockedDoor.positionOnSegment,
+        unlockedDoor.widthMm,
+        Math.hypot(end.x - start.x, end.y - start.y),
+      ),
+    } : unlockedDoor;
     const updated: RoomConfig = {
       ...selectedRoom,
       doors: (selectedRoom.doors ?? []).map((d) => (d.id === updatedDoor.id ? nextDoor : d)),
@@ -726,10 +738,18 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     if (!selectedRoom || !isDoorPlacementMode) return;
     if (isSegmentLocked(selectedRoom.roomShell, segmentIndex)) return;
 
+    const points = selectedRoom.roomShell?.points ?? [];
+    const start = points[segmentIndex];
+    const end = points[(segmentIndex + 1) % points.length];
+    const boundedPosition = start && end
+      ? clampDoorPosition(positionOnSegment, 800, Math.hypot(end.x - start.x, end.y - start.y))
+      : positionOnSegment;
+
     const newDoor: Door = {
       id: generateId(),
+      style: 'single',
       segmentIndex,
-      positionOnSegment,
+      positionOnSegment: boundedPosition,
       widthMm: 800, // Standard door width
       swingDirection: 'in',
       swingSide: 'left',

--- a/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
@@ -17,6 +17,7 @@ import {
 import { DisplaySettingsControls } from '../components/DisplaySettingsControls';
 import { BasicRoomShapesPicker, resizeBasicRoomShapeWall, type BasicRoomShapeSelection } from '../components/BasicRoomShapesPicker';
 import type { RoomShapePoint } from '../utils/roomShapes';
+import { clampDoorPosition } from '../utils/doorGeometry';
 import { updateRoom } from '../api/rooms';
 import { useWallDrawing } from '../hooks/useWallDrawing';
 import { pushZonesToDevice, fetchZonesFromDevice, fetchPolygonModeStatus, setPolygonMode, fetchPolygonZonesFromDevice, pushPolygonZonesToDevice, PolygonModeStatus } from '../api/zones';
@@ -713,10 +714,17 @@ export const WizardPage: React.FC<WizardPageProps> = ({
 
   const handleWallSegmentClick = useCallback(async (segmentIndex: number, positionOnSegment: number) => {
     if (!isDoorPlacementMode || !selectedRoom) return;
+    const points = selectedRoom.roomShell?.points ?? [];
+    const start = points[segmentIndex];
+    const end = points[(segmentIndex + 1) % points.length];
+    const boundedPosition = start && end
+      ? clampDoorPosition(positionOnSegment, 850, Math.hypot(end.x - start.x, end.y - start.y))
+      : positionOnSegment;
     const newDoor: Door = {
       id: generateId(),
+      style: 'single',
       segmentIndex,
-      positionOnSegment,
+      positionOnSegment: boundedPosition,
       widthMm: 850,
       swingDirection: 'in',
       swingSide: 'left',
@@ -738,9 +746,20 @@ export const WizardPage: React.FC<WizardPageProps> = ({
 
   const handleDoorChange = useCallback(async (updatedDoor: Door) => {
     if (!selectedRoom) return;
+    const points = selectedRoom.roomShell?.points ?? [];
+    const start = points[updatedDoor.segmentIndex];
+    const end = points[(updatedDoor.segmentIndex + 1) % points.length];
+    const boundedDoor = start && end ? {
+      ...updatedDoor,
+      positionOnSegment: clampDoorPosition(
+        updatedDoor.positionOnSegment,
+        updatedDoor.widthMm,
+        Math.hypot(end.x - start.x, end.y - start.y),
+      ),
+    } : updatedDoor;
     const updatedRoom: RoomConfig = {
       ...selectedRoom,
-      doors: (selectedRoom.doors ?? []).map((d) => (d.id === updatedDoor.id ? updatedDoor : d)),
+      doors: (selectedRoom.doors ?? []).map((d) => (d.id === updatedDoor.id ? boundedDoor : d)),
     };
     onRoomUpdate?.(updatedRoom);
     try {

--- a/everything-presence-mmwave-configurator/frontend/src/utils/doorGeometry.test.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/doorGeometry.test.ts
@@ -1,0 +1,79 @@
+// @ts-nocheck -- Node's built-in runner supplies these modules.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { clampDoorPosition, getDoorGeometry, normalizeDoor } from './doorGeometry.ts';
+
+const door = (style = 'single', overrides = {}) => ({
+  id: 'd1', style, segmentIndex: 0, positionOnSegment: 0.5, widthMm: 800,
+  swingDirection: 'in', swingSide: 'left', ...overrides,
+});
+
+test('normalizes legacy and malformed persisted doors deterministically', () => {
+  assert.deepEqual(normalizeDoor({ id: 'legacy' }), {
+    id: 'legacy', style: 'single', segmentIndex: 0, positionOnSegment: 0.5,
+    widthMm: 800, swingDirection: 'in', swingSide: 'left', locked: undefined,
+  });
+  const malformed = normalizeDoor({ id: 'bad', style: 'folding', segmentIndex: -4.8, positionOnSegment: 2, widthMm: -1, swingDirection: 'sideways', swingSide: 'middle' });
+  assert.equal(malformed.style, 'single');
+  assert.equal(malformed.segmentIndex, 0);
+  assert.equal(malformed.positionOnSegment, 1);
+  assert.equal(malformed.widthMm, 800);
+});
+
+test('single geometry mirrors hinge and winding', () => {
+  const left = getDoorGeometry(door(), 1);
+  const right = getDoorGeometry(door('single', { swingSide: 'right' }), -1);
+  assert.equal(left.hingeX, -400);
+  assert.equal(left.arc.endY, 800);
+  assert.equal(right.hingeX, 400);
+  assert.equal(right.arc.endY, -800);
+});
+
+test('sliding and opening styles have shallow hit bounds and no swing geometry', () => {
+  for (const style of ['sliding', 'opening']) {
+    const geometry = getDoorGeometry(door(style), 1);
+    assert.equal(geometry.arc, undefined);
+    assert.equal(geometry.leaves, undefined);
+    assert.ok(geometry.hitBounds.height < 200);
+  }
+});
+
+test('sliding geometry creates one panel centred on the wall', () => {
+  const geometry = getDoorGeometry(door('sliding'), 1);
+  assert.deepEqual(geometry.slidingPanel, {
+    startX: -400,
+    endX: 400,
+    y: 0,
+    direction: 1,
+  });
+});
+
+test('canvas-sized shallow styles use compact selectable bounds', () => {
+  for (const style of ['sliding', 'opening']) {
+    const geometry = getDoorGeometry(door(style, { widthMm: 120 }), 1, { padding: 8, shallowDepth: 14 });
+    assert.deepEqual(geometry.hitBounds, { x: -68, y: -8, width: 136, height: 30 });
+  }
+});
+
+test('door position bounds keep the complete opening on the wall', () => {
+  assert.equal(clampDoorPosition(0, 800, 4000), 0.1);
+  assert.equal(clampDoorPosition(1, 800, 4000), 0.9);
+  assert.equal(clampDoorPosition(0.4, 800, 4000), 0.4);
+  assert.equal(clampDoorPosition(0, 5000, 4000), 0.5);
+});
+
+test('double doors produce mirrored half-width leaves for either room winding', () => {
+  for (const sign of [1, -1]) {
+    const geometry = getDoorGeometry(door('double', { swingDirection: 'out' }), sign);
+    assert.equal(geometry.leaves.length, 2);
+    assert.deepEqual(geometry.leaves.map((leaf) => leaf.hingeX), [-400, 400]);
+    assert.equal(Math.abs(geometry.leaves[0].endY), 400);
+    assert.equal(geometry.leaves[0].endY, -sign * 400);
+  }
+});
+
+test('local geometry is orientation-independent for rotated and vertical walls', () => {
+  const horizontal = getDoorGeometry(door('sliding'), 1);
+  const vertical = getDoorGeometry(door('sliding'), 1);
+  assert.deepEqual(vertical, horizontal);
+});

--- a/everything-presence-mmwave-configurator/frontend/src/utils/doorGeometry.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/doorGeometry.ts
@@ -1,0 +1,87 @@
+import type { Door } from '../api/types';
+
+export const DOOR_STYLES = ['single', 'sliding', 'opening', 'double'] as const;
+export type DoorStyle = (typeof DOOR_STYLES)[number];
+
+/** Normalize untrusted persisted data without discarding legacy hinge choices. */
+export const normalizeDoor = (value: Partial<Door> & { id: string }): Door => ({
+  id: value.id,
+  style: DOOR_STYLES.includes(value.style as DoorStyle) ? value.style as DoorStyle : 'single',
+  segmentIndex: Number.isFinite(value.segmentIndex) ? Math.max(0, Math.trunc(value.segmentIndex!)) : 0,
+  positionOnSegment: Number.isFinite(value.positionOnSegment)
+    ? Math.min(1, Math.max(0, value.positionOnSegment!)) : 0.5,
+  widthMm: Number.isFinite(value.widthMm) && value.widthMm! > 0 ? value.widthMm! : 800,
+  swingDirection: value.swingDirection === 'out' ? 'out' : 'in',
+  swingSide: value.swingSide === 'right' ? 'right' : 'left',
+  locked: value.locked === undefined ? undefined : Boolean(value.locked),
+});
+
+export interface DoorGeometry {
+  style: DoorStyle;
+  halfWidth: number;
+  normalSign: 1 | -1;
+  hitBounds: { x: number; y: number; width: number; height: number };
+  hingeX?: number;
+  panelEnd?: { x: number; y: number };
+  arc?: { startX: number; startY: number; endX: number; endY: number; radius: number; sweep: 0 | 1 };
+  leaves?: Array<{ hingeX: number; endX: number; endY: number; sweep: 0 | 1 }>;
+  slidingPanel?: { startX: number; endX: number; y: number; direction: -1 | 1 };
+}
+
+/** Keep the complete opening on its wall instead of allowing its centre to reach a corner. */
+export const clampDoorPosition = (position: number, width: number, segmentLength: number): number => {
+  if (!Number.isFinite(segmentLength) || segmentLength <= 0) return 0.5;
+  const halfRatio = Math.max(0, width) / segmentLength / 2;
+  if (halfRatio >= 0.5) return 0.5;
+  return Math.min(1 - halfRatio, Math.max(halfRatio, position));
+};
+
+/** Local SVG geometry: the wall runs left-to-right through y=0. */
+export const getDoorGeometry = (
+  doorValue: Door,
+  inwardNormalSign: number,
+  options: { padding?: number; shallowDepth?: number } = {},
+): DoorGeometry => {
+  const door = normalizeDoor(doorValue);
+  const halfWidth = door.widthMm / 2;
+  const normalSign = (door.swingDirection === 'in' ? inwardNormalSign : -inwardNormalSign) >= 0 ? 1 : -1;
+  const padding = options.padding ?? 10;
+  const depth = door.style === 'single'
+    ? door.widthMm
+    : door.style === 'double'
+      ? halfWidth
+      : options.shallowDepth ?? Math.max(24, door.widthMm * 0.08);
+  const base: DoorGeometry = {
+    style: door.style,
+    halfWidth,
+    normalSign,
+    hitBounds: {
+      x: -halfWidth - padding,
+      y: normalSign > 0 ? -padding : -depth - padding,
+      width: door.widthMm + padding * 2,
+      height: depth + padding * 2,
+    },
+  };
+  if (door.style === 'single') {
+    const hingeX = door.swingSide === 'right' ? halfWidth : -halfWidth;
+    const startX = -hingeX;
+    const endY = normalSign * door.widthMm;
+    return { ...base, hingeX, panelEnd: { x: hingeX, y: endY }, arc: { startX, startY: 0, endX: hingeX, endY, radius: door.widthMm, sweep: (startX - hingeX) * endY > 0 ? 1 : 0 } };
+  }
+  if (door.style === 'double') {
+    const endY = normalSign * halfWidth;
+    return { ...base, leaves: [
+      { hingeX: -halfWidth, endX: -halfWidth, endY, sweep: normalSign > 0 ? 0 : 1 },
+      { hingeX: halfWidth, endX: halfWidth, endY, sweep: normalSign > 0 ? 1 : 0 },
+    ] };
+  }
+  if (door.style === 'sliding') {
+    return { ...base, slidingPanel: {
+      startX: -halfWidth,
+      endX: halfWidth,
+      y: 0,
+      direction: 1,
+    } };
+  }
+  return base;
+};

--- a/everything-presence-mmwave-configurator/frontend/src/utils/roomHistory.test.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/roomHistory.test.ts
@@ -20,7 +20,7 @@ const room = () => ({
   entityMappings: { installationAngleEntity: 'number.angle' },
   roomShell: { points: [{ x: 0, y: 0 }, { x: 1000, y: 0 }, { x: 1000, y: 1000 }] },
   furniture: [{ id: 'f1', typeId: 'sofa', x: 0, y: 0, width: 1000, depth: 500, height: 400, rotationDeg: 0 }],
-  doors: [{ id: 'd1', segmentIndex: 0, positionOnSegment: 0.5, widthMm: 800 }],
+  doors: [{ id: 'd1', style: 'sliding', segmentIndex: 0, positionOnSegment: 0.5, widthMm: 1600, swingDirection: 'out', swingSide: 'right' }],
   devicePlacement: { x: 0, y: 0, rotationDeg: 0 },
 });
 
@@ -41,6 +41,8 @@ test('snapshots only the room-builder subset and deep copies it', () => {
   original.furniture[0].x = 999;
   assert.equal(snapshot.roomShell.points[0].x, 0);
   assert.equal(snapshot.furniture[0].x, 0);
+  assert.equal(snapshot.doors[0].style, 'sliding');
+  assert.equal(snapshot.doors[0].swingDirection, 'out');
 });
 
 test('lock state is snapshotted and deep copied', () => {

--- a/everything-presence-mmwave-configurator/frontend/src/utils/roomRotation.test.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/roomRotation.test.ts
@@ -28,7 +28,7 @@ const makeSnapshot = (overrides = {}) => ({
   furniture: [
     { id: 'f1', typeId: 'bed-double', x: 1000, y: 500, width: 1400, depth: 2000, height: 500, rotationDeg: 30, aspectRatioLocked: false },
   ],
-  doors: [{ id: 'd1', segmentIndex: 2, positionOnSegment: 0.4, widthMm: 800, swingDirection: 'in', swingSide: 'left' }],
+  doors: [{ id: 'd1', style: 'double', segmentIndex: 2, positionOnSegment: 0.4, widthMm: 1600, swingDirection: 'out', swingSide: 'right' }],
   ...overrides,
 });
 


### PR DESCRIPTION
## Summary
Simplified the sliding-door visual to a single centered icon. The symbol now sits directly on the wall line, matching the opening-only door’s alignment, with centered jamb marks and one clear directional arrow instead of two offset panels.

## Verification
Automated: `npm test` in the frontend passed all 71 tests.
manualTestSteps:
1. action: Add or convert a door to Sliding in a deployed preview. expectedResult: One sliding-door icon appears centered directly on the wall line.
2. action: Compare Sliding with Opening-only. expectedResult: Both symbols share the same centered wall alignment, while Sliding additionally displays one directional arrow.
3. action: Place sliding doors on horizontal, vertical, and angled walls. expectedResult: The centered icon and arrow rotate with the wall without appearing on opposing sides.
4. action: Select, resize, and drag the sliding door. expectedResult: The single icon remains centered and the existing compact selection bounds and wall-end constraints continue working.

Fixes #132