### PR TITLE
[Feature] Automatic renaming of zone entites in HomeAssistant

### DIFF
--- a/everything-presence-mmwave-configurator/DOCS.md
+++ b/everything-presence-mmwave-configurator/DOCS.md
@@ -35,6 +35,10 @@ Use this installation method **ONLY** if you have a [Home Assistant OS Installat
 
 ## Configuration
 
+### Zone label synchronization
+
+Saving a custom label in the Zone Editor also updates the Home Assistant display names of mapped entities for that zone, including rectangular coordinates and timeouts, occupancy and target-count sensors, and polygon regular, exclusion, and entry entities. Entity IDs are intentionally left unchanged so dashboards, automations, and stored mappings continue to work. Registry display-name updates require the WebSocket transport; with the REST fallback the label is still stored and the editor shows a warning that Home Assistant names could not be synchronized.
+
 ### Options
 
 - **port:** This is the port used to reach the web interface.

--- a/everything-presence-mmwave-configurator/backend/package.json
+++ b/everything-presence-mmwave-configurator/backend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc -p tsconfig.json",
+    "test": "node --test -r ts-node/register src/domain/zoneEntityNaming.test.ts",
     "start": "node dist/index.js",
     "lint": "echo \"(no lint configured yet)\""
   },

--- a/everything-presence-mmwave-configurator/backend/src/domain/zoneEntityNaming.test.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/zoneEntityNaming.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { DeviceMapping } from '../config/deviceMappingStorage';
+import type { DeviceProfile } from './deviceProfiles';
+import { getZoneEntityNames } from './zoneEntityNaming';
+
+const mapping: DeviceMapping = {
+  deviceId: 'device-id',
+  profileId: 'test-profile',
+  deviceName: 'Test Device',
+  discoveredAt: '2026-01-01T00:00:00.000Z',
+  lastUpdated: '2026-01-01T00:00:00.000Z',
+  confirmedByUser: true,
+  autoMatchedCount: 0,
+  manuallyMappedCount: 0,
+  mappings: {
+    zone1BeginX: 'number.device_zone_1_begin_x',
+    zone1OffDelay: 'number.device_zone_1_timeout',
+    zone1Occupancy: 'binary_sensor.device_zone_1_occupancy',
+    zone1TargetCount: 'sensor.device_zone_1_target_count',
+    polygonZone1: 'text.device_polygon_zone_1',
+    exclusion1BeginX: 'number.device_exclusion_1_begin_x',
+  },
+  unmappedEntities: [],
+};
+
+const profile: DeviceProfile = {
+  id: 'test-profile',
+  label: 'Test Profile',
+  manufacturer: 'Test',
+  capabilities: {},
+  limits: {},
+  entityMap: {},
+  entities: {
+    zone1BeginX: { template: '', category: 'zone', required: false, zoneType: 'regular', zoneIndex: 1, coord: 'beginX' },
+    zone1OffDelay: { template: '', category: 'setting', required: false, zoneIndex: 1, label: 'Zone 1 Off Delay' },
+    zone1Occupancy: { template: '', category: 'sensor', required: false, zoneIndex: 1, subcategory: 'zoneOccupancy' },
+    zone1TargetCount: { template: '', category: 'sensor', required: false, zoneIndex: 1, subcategory: 'zoneTargetCount' },
+    polygonZone1: { template: '', category: 'zone', required: false, zoneType: 'polygon', zoneIndex: 1 },
+    exclusion1BeginX: { template: '', category: 'zone', required: false, zoneType: 'exclusion', zoneIndex: 1, coord: 'beginX' },
+  },
+};
+
+test('names every mapped regular and polygon entity deterministically', () => {
+  assert.deepEqual(getZoneEntityNames(mapping, profile, 'Zone 1', 'Desk'), [
+    { entityId: 'number.device_zone_1_begin_x', name: 'Desk Begin X' },
+    { entityId: 'number.device_zone_1_timeout', name: 'Desk Timeout' },
+    { entityId: 'binary_sensor.device_zone_1_occupancy', name: 'Desk Occupancy' },
+    { entityId: 'sensor.device_zone_1_target_count', name: 'Desk Target Count' },
+    { entityId: 'text.device_polygon_zone_1', name: 'Desk Polygon' },
+  ]);
+});
+
+test('supports exclusion zones and clears registry overrides for removed labels', () => {
+  assert.deepEqual(getZoneEntityNames(mapping, profile, 'Exclusion 1', ''), [
+    { entityId: 'number.device_exclusion_1_begin_x', name: null },
+  ]);
+});

--- a/everything-presence-mmwave-configurator/backend/src/domain/zoneEntityNaming.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/zoneEntityNaming.ts
@@ -1,0 +1,89 @@
+import type { DeviceMapping } from '../config/deviceMappingStorage';
+import type { DeviceProfile, EntityDefinition, ZoneType } from './deviceProfiles';
+import type { IHaReadTransport } from '../ha/readTransport';
+
+export interface ZoneRenameWarning {
+  zoneId: string;
+  entityId?: string;
+  message: string;
+}
+
+export interface ZoneRenameResult {
+  renamed: number;
+  warnings: ZoneRenameWarning[];
+}
+
+const zoneTypesForId = (zoneId: string): { index: number; types: ZoneType[] } | null => {
+  const match = zoneId.trim().match(/^(?:(Polygon)\s+)?(Zone|Exclusion|Entry)\s+(\d+)$/i);
+  if (!match) return null;
+  const index = Number(match[3]);
+  const polygon = !!match[1];
+  const family = match[2].toLowerCase();
+  if (family === 'zone') return { index, types: polygon ? ['polygon'] : ['regular', 'polygon'] };
+  if (family === 'exclusion') return { index, types: polygon ? ['polygonExclusion'] : ['exclusion', 'polygonExclusion'] };
+  return { index, types: polygon ? ['polygonEntry'] : ['entry', 'polygonEntry'] };
+};
+
+const belongsToZone = (definition: EntityDefinition, types: ZoneType[], index: number): boolean => {
+  if (definition.zoneIndex !== index) return false;
+  if (definition.zoneType) return types.includes(definition.zoneType);
+  // Occupancy/count sensors and per-zone timeout settings describe regular zones.
+  return types.includes('regular') && (
+    definition.subcategory === 'zoneOccupancy' ||
+    definition.subcategory === 'zoneTargetCount' ||
+    (definition.category === 'setting' && !!definition.label)
+  );
+};
+
+const words = (value: string) => value.replace(/([a-z])([A-Z])/g, '$1 $2').replace(/_/g, ' ')
+  .replace(/\b\w/g, letter => letter.toUpperCase());
+
+export const suffixForZoneEntity = (key: string, definition: EntityDefinition): string => {
+  if (definition.coord) return words(definition.coord);
+  if (definition.subcategory === 'zoneOccupancy') return 'Occupancy';
+  if (definition.subcategory === 'zoneTargetCount') return 'Target Count';
+  if (definition.zoneType?.startsWith('polygon')) return 'Polygon';
+  if (/offDelay|timeout/i.test(key) || /off delay|timeout/i.test(definition.label ?? '')) return 'Timeout';
+  return definition.label?.replace(/^(?:Zone|Exclusion|Entry)\s+\d+\s*/i, '').trim() || words(key);
+};
+
+export const getZoneEntityNames = (
+  mapping: DeviceMapping,
+  profile: DeviceProfile,
+  zoneId: string,
+  label: string
+): Array<{ entityId: string; name: string | null }> => {
+  const zone = zoneTypesForId(zoneId);
+  if (!zone || !profile.entities) return [];
+  const byEntity = new Map<string, string | null>();
+  for (const [key, definition] of Object.entries(profile.entities)) {
+    if (!belongsToZone(definition, zone.types, zone.index)) continue;
+    const entityId = mapping.mappings[key];
+    if (entityId) byEntity.set(entityId, label ? `${label} ${suffixForZoneEntity(key, definition)}` : null);
+  }
+  return Array.from(byEntity, ([entityId, name]) => ({ entityId, name }));
+};
+
+export const synchronizeZoneEntityNames = async (
+  transport: IHaReadTransport,
+  mapping: DeviceMapping,
+  profile: DeviceProfile,
+  labels: Record<string, string>
+): Promise<ZoneRenameResult> => {
+  const warnings: ZoneRenameWarning[] = [];
+  let renamed = 0;
+  const seen = new Set<string>();
+  for (const [zoneId, label] of Object.entries(labels)) {
+    for (const update of getZoneEntityNames(mapping, profile, zoneId, label)) {
+      if (seen.has(update.entityId)) continue;
+      seen.add(update.entityId);
+      try {
+        await transport.updateEntityRegistryName(update.entityId, update.name);
+        renamed++;
+      } catch (error) {
+        warnings.push({ zoneId, entityId: update.entityId, message: error instanceof Error ? error.message : String(error) });
+      }
+    }
+  }
+  return { renamed, warnings };
+};

--- a/everything-presence-mmwave-configurator/backend/src/ha/readTransport.ts
+++ b/everything-presence-mmwave-configurator/backend/src/ha/readTransport.ts
@@ -90,6 +90,9 @@ export interface IHaReadTransport {
    */
   listEntityRegistry(): Promise<EntityRegistryEntry[]>;
 
+  /** Update the user-facing registry name without changing the entity ID. */
+  updateEntityRegistryName(entityId: string, name: string | null): Promise<void>;
+
   /**
    * List all areas from the area registry
    */

--- a/everything-presence-mmwave-configurator/backend/src/ha/restReadTransport.ts
+++ b/everything-presence-mmwave-configurator/backend/src/ha/restReadTransport.ts
@@ -156,6 +156,10 @@ export class RestReadTransport implements IHaReadTransport {
     }
   }
 
+  async updateEntityRegistryName(_entityId: string, _name: string | null): Promise<void> {
+    throw new Error('Entity registry renaming requires the Home Assistant WebSocket transport');
+  }
+
   /**
    * Fallback: Query device registry via HA template API.
    * This works when the device_registry endpoint isn't directly accessible.

--- a/everything-presence-mmwave-configurator/backend/src/ha/types.ts
+++ b/everything-presence-mmwave-configurator/backend/src/ha/types.ts
@@ -33,3 +33,8 @@ export interface EntityRegistryEntry {
   original_name?: string | null;
   unique_id?: string | null;
 }
+
+export interface EntityRegistryUpdateResult {
+  entity_id: string;
+  name: string | null;
+}

--- a/everything-presence-mmwave-configurator/backend/src/ha/wsReadTransport.ts
+++ b/everything-presence-mmwave-configurator/backend/src/ha/wsReadTransport.ts
@@ -249,6 +249,18 @@ export class WsReadTransport implements IHaReadTransport {
     }
   }
 
+  async updateEntityRegistryName(entityId: string, name: string | null): Promise<void> {
+    const response = await this.call({
+      type: 'config/entity_registry/update',
+      entity_id: entityId,
+      name,
+    }) as HaWsMessage;
+    if (response.type !== 'result' || !response.success) {
+      const message = (response as any).error?.message ?? 'Home Assistant rejected the registry update';
+      throw new Error(message);
+    }
+  }
+
   async listAreaRegistry(): Promise<AreaRegistryEntry[]> {
     try {
       const response = (await this.call({

--- a/everything-presence-mmwave-configurator/backend/src/routes/deviceMappings.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/deviceMappings.ts
@@ -7,6 +7,8 @@ import type { IHaReadTransport, DeviceRegistryEntry } from '../ha/readTransport'
 import type { EntityRegistryEntry } from '../ha/types';
 import { normalizeMappingKeys } from '../domain/mappingUtils';
 import type { DeviceProfileLoader } from '../domain/deviceProfiles';
+import { synchronizeZoneEntityNames } from '../domain/zoneEntityNaming';
+import type { ZoneRenameWarning } from '../domain/zoneEntityNaming';
 
 export interface DeviceMappingsRouterDependencies {
   readTransport?: IHaReadTransport;
@@ -538,7 +540,30 @@ export const createDeviceMappingsRouter = (deps?: DeviceMappingsRouterDependenci
 
       logger.info({ deviceId, labelCount: Object.keys(cleanedLabels).length }, 'Zone labels updated');
 
-      return res.json({ zoneLabels: cleanedLabels });
+      const changedLabels: Record<string, string> = {};
+      const previousLabels = existing.zoneLabels ?? {};
+      for (const zoneId of new Set([...Object.keys(previousLabels), ...Object.keys(cleanedLabels)])) {
+        if ((previousLabels[zoneId] ?? '') !== (cleanedLabels[zoneId] ?? '')) {
+          changedLabels[zoneId] = cleanedLabels[zoneId] ?? '';
+        }
+      }
+
+      let renamed = 0;
+      const warnings: ZoneRenameWarning[] = [];
+      if (Object.keys(changedLabels).length > 0) {
+        const profile = profileLoader?.getProfileById(existing.profileId);
+        if (!readTransport) {
+          warnings.push({ zoneId: '*', message: 'Home Assistant transport is unavailable; labels were saved but entities were not renamed' });
+        } else if (!profile) {
+          warnings.push({ zoneId: '*', message: `Device profile ${existing.profileId} was not found; labels were saved but entities were not renamed` });
+        } else {
+          const result = await synchronizeZoneEntityNames(readTransport, updated, profile, changedLabels);
+          renamed = result.renamed;
+          warnings.push(...result.warnings);
+        }
+      }
+
+      return res.json({ zoneLabels: cleanedLabels, synchronization: { renamed, warnings } });
     } catch (error) {
       logger.error({ error, deviceId }, 'Failed to update zone labels');
       return res.status(500).json({ message: 'Failed to update zone labels' });

--- a/everything-presence-mmwave-configurator/frontend/src/api/deviceMappings.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/api/deviceMappings.ts
@@ -349,7 +349,7 @@ export const getZoneLabels = async (deviceId: string): Promise<Record<string, st
 export const saveZoneLabels = async (
   deviceId: string,
   zoneLabels: Record<string, string>
-): Promise<Record<string, string> | null> => {
+): Promise<ZoneLabelsSaveResult | null> => {
   try {
     const res = await fetch(ingressAware(`api/device-mappings/${deviceId}/zone-labels`), {
       method: 'PUT',
@@ -360,10 +360,20 @@ export const saveZoneLabels = async (
       console.warn('Device mapping not found - cannot save zone labels');
       return null;
     }
-    const data = await handle<{ zoneLabels: Record<string, string> }>(res);
-    return data.zoneLabels;
+    return await handle<ZoneLabelsSaveResult>(res);
   } catch (error) {
     console.error('Failed to save zone labels:', error);
     return null;
   }
 };
+
+export interface ZoneLabelRenameWarning {
+  zoneId: string;
+  entityId?: string;
+  message: string;
+}
+
+export interface ZoneLabelsSaveResult {
+  zoneLabels: Record<string, string>;
+  synchronization: { renamed: number; warnings: ZoneLabelRenameWarning[] };
+}

--- a/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
@@ -1373,9 +1373,16 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
         }
         const savedLabels = await saveZoneLabels(selectedRoom.deviceId, labelsToSave);
         if (savedLabels) {
-          setDeviceZoneLabels(savedLabels);
+          setDeviceZoneLabels(savedLabels.zoneLabels);
           // Invalidate the device mapping cache so other pages get fresh labels
           clearCache(selectedRoom.deviceId);
+          if (savedLabels.synchronization.warnings.length > 0) {
+            const sample = savedLabels.synchronization.warnings.slice(0, 3)
+              .map(item => item.entityId ? `${item.entityId}: ${item.message}` : item.message)
+              .join('; ');
+            const renameWarning = `Zone labels were saved, but ${savedLabels.synchronization.warnings.length} Home Assistant entity name update(s) failed. ${sample}`;
+            setWarning(current => current ? `${current} ${renameWarning}` : renameWarning);
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
Implemented automatic synchronization of saved Zone Configurator labels to Home Assistant entity-registry display names. The backend now supports WebSocket registry updates, explicitly rejects renaming through REST, derives deterministic names for mapped rectangular and polygon zone entities, persists labels before attempting synchronization, and returns per-entity warnings without changing entity IDs. The frontend retains synchronization results and surfaces rename warnings. Documentation and focused naming tests were added. The retry also corrected the route’s type-only warning import for compiler-safe module emission.

## Verification
npm ci --include=dev; npm run build --workspaces; npm test --workspace backend; npm prune --omit=dev --workspaces.

Save a custom label for a mapped rectangular or polygon zone while using WebSocket transport: mapped Home Assistant entities receive label-based display names while entity IDs remain unchanged.

Remove that label and save: registry name overrides are cleared.

Save through REST fallback or force a registry update failure: labels remain saved and the Zone Editor displays an actionable synchronization warning.

Fixes #264