### PR TITLE
Bug: hitting delete when selecting furnature deletes a wall

### DIFF
--- a/everything-presence-mmwave-configurator/frontend/package.json
+++ b/everything-presence-mmwave-configurator/frontend/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",
-		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts src/utils/polygonVertices.test.ts src/utils/roomHistory.test.ts src/utils/roomSelection.test.ts src/utils/lockState.test.ts src/utils/roomRotation.test.ts src/utils/doorGeometry.test.ts",
+		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts src/utils/polygonVertices.test.ts src/utils/roomHistory.test.ts src/utils/roomSelection.test.ts src/utils/roomBuilderSelection.test.ts src/utils/lockState.test.ts src/utils/roomRotation.test.ts src/utils/doorGeometry.test.ts",
 		"preview": "vite preview",
 		"format": "npx @biomejs/biome format",
 		"format:fix": "npx @biomejs/biome format --write",

--- a/everything-presence-mmwave-configurator/frontend/src/components/DoorEditor.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/DoorEditor.tsx
@@ -420,10 +420,10 @@ export const DoorEditor: React.FC<DoorEditorProps> = ({
         <button
           onClick={onDelete}
           disabled={isLocked}
-          title={isLocked ? 'Unlock this door before deleting it' : undefined}
+          title={isLocked ? 'Unlock this door before deleting it' : 'Delete this door (Del)'}
           className="w-full px-4 py-2.5 bg-red-600/20 hover:bg-red-600/30 border border-red-600/50 rounded-lg text-red-200 font-semibold transition-colors disabled:opacity-40 disabled:hover:bg-red-600/20"
         >
-          Delete Door
+          Delete Door <span className="font-normal text-red-200/70">(Del)</span>
         </button>
       </div>
     </div>

--- a/everything-presence-mmwave-configurator/frontend/src/components/FurnitureEditor.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/FurnitureEditor.tsx
@@ -206,10 +206,10 @@ export const FurnitureEditor: React.FC<FurnitureEditorProps> = ({
         <button
           onClick={onDelete}
           disabled={isLocked}
-          title={isLocked ? 'Unlock this item before deleting it' : undefined}
+          title={isLocked ? 'Unlock this item before deleting it' : 'Delete this item (Del)'}
           className="w-full px-4 py-2.5 rounded-lg bg-rose-600/10 border border-rose-600/50 text-rose-100 font-semibold hover:bg-rose-600/20 transition-all active:scale-95 disabled:opacity-40 disabled:hover:bg-rose-600/10 disabled:active:scale-100"
         >
-          Delete Furniture
+          Delete Furniture <span className="font-normal text-rose-200/70">(Del)</span>
         </button>
       </div>
     </div>

--- a/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
@@ -34,6 +34,11 @@ import {
 } from '../utils/ceilingSlices';
 import { resolveLoadedRoomSelection } from '../utils/roomSelection';
 import {
+  resolveDeleteKeyTarget,
+  resolveSelectionState,
+  type BuilderSelection,
+} from '../utils/roomBuilderSelection';
+import {
   applyDevicePlacementUpdate,
   areAllItemsLocked,
   areAllSegmentsLocked,
@@ -250,6 +255,36 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
   // Last `initialRoomId` we acted on, so the sync effect below can tell an actual
   // prop change from a re-render.
   const lastInitialRoomIdRef = useRef<string | null>(initialRoomId ?? null);
+
+  /**
+   * The single owner of "what is selected". Furniture, doors and wall segments
+   * are mutually exclusive, and routing every selection change through here is
+   * what keeps them that way - a leftover wall selection used to send Del to the
+   * wall branch while the furniture panel was open.
+   */
+  const selectEntity = useCallback((selection: BuilderSelection) => {
+    const next = resolveSelectionState(selection);
+    setSelectedFurnitureId(next.selectedFurnitureId);
+    setSelectedDoorId(next.selectedDoorId);
+    setSelectedSegment(next.selectedSegment);
+    if (next.selectedSegment === null) setHoveredSegment(null);
+  }, []);
+
+  /** Short-lived nudge for keyboard actions that have no visible button to grey out. */
+  const [transientHint, setTransientHint] = useState<string | null>(null);
+  const transientHintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const showTransientHint = useCallback((message: string) => {
+    setTransientHint(message);
+    if (transientHintTimerRef.current) clearTimeout(transientHintTimerRef.current);
+    transientHintTimerRef.current = setTimeout(() => {
+      setTransientHint(null);
+      transientHintTimerRef.current = null;
+    }, 3000);
+  }, []);
+  useEffect(() => () => {
+    if (transientHintTimerRef.current) clearTimeout(transientHintTimerRef.current);
+  }, []);
+
   const CANVAS_SIZE = 700;
   const HALF = CANVAS_SIZE / 2;
   const WALL_EDITOR_WIDTH = 280;
@@ -634,10 +669,12 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
       furniture: [...(selectedRoom.furniture ?? []), newFurniture],
     };
     commitRoom(updated);
-    setSelectedFurnitureId(newFurniture.id);
+    // Selecting through the helper drops any wall segment or door still selected
+    // behind the library, so Del now means "delete this new piece of furniture".
+    selectEntity({ kind: 'furniture', id: newFurniture.id });
     setShowFurnitureLibrary(false);
     setActiveMobileSheet(null);
-  }, [commitRoom, selectedRoom]);
+  }, [commitRoom, selectEntity, selectedRoom]);
 
   const handleFurnitureChange = useCallback((updatedFurniture: FurnitureInstance) => {
     if (!selectedRoom) return;
@@ -657,15 +694,19 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
 
   const handleFurnitureDelete = useCallback(() => {
     if (!selectedRoom || !selectedFurnitureId) return;
-    // Pinned means pinned: unlock it first.
-    if ((selectedRoom.furniture ?? []).some((f) => f.id === selectedFurnitureId && f.locked)) return;
+    // Pinned means pinned: unlock it first. The panel button greys itself out to
+    // say so; pressing Del has no such affordance, hence the hint.
+    if ((selectedRoom.furniture ?? []).some((f) => f.id === selectedFurnitureId && f.locked)) {
+      showTransientHint('This furniture is locked. Unlock it before deleting it.');
+      return;
+    }
     const updated: RoomConfig = {
       ...selectedRoom,
       furniture: (selectedRoom.furniture ?? []).filter((f) => f.id !== selectedFurnitureId),
     };
     commitRoom(updated);
     setSelectedFurnitureId(null);
-  }, [commitRoom, selectedRoom, selectedFurnitureId]);
+  }, [commitRoom, selectedRoom, selectedFurnitureId, showTransientHint]);
 
   const handleAddDoor = useCallback(() => {
     if (!selectedRoom) return;
@@ -677,11 +718,9 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     setIsDoorPlacementMode((prev) => !prev);
     if (!isDoorPlacementMode) {
       // Entering placement mode - deselect everything
-      setSelectedDoorId(null);
-      setSelectedFurnitureId(null);
-      setSelectedSegment(null);
+      selectEntity({ kind: 'none' });
     }
-  }, [selectedRoom, isDoorPlacementMode]);
+  }, [selectEntity, selectedRoom, isDoorPlacementMode]);
 
   const handleDoorChange = useCallback((updatedDoor: Door) => {
     if (!selectedRoom) return;
@@ -711,15 +750,19 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
 
   const handleDoorDelete = useCallback(() => {
     if (!selectedRoom || !selectedDoorId) return;
-    // Pinned means pinned: unlock it first.
-    if ((selectedRoom.doors ?? []).some((d) => d.id === selectedDoorId && d.locked)) return;
+    // Pinned means pinned: unlock it first. Del has no disabled state to show
+    // that, so say it out loud.
+    if ((selectedRoom.doors ?? []).some((d) => d.id === selectedDoorId && d.locked)) {
+      showTransientHint('This door is locked. Unlock it before deleting it.');
+      return;
+    }
     const updated: RoomConfig = {
       ...selectedRoom,
       doors: (selectedRoom.doors ?? []).filter((d) => d.id !== selectedDoorId),
     };
     commitRoom(updated);
     setSelectedDoorId(null);
-  }, [commitRoom, selectedRoom, selectedDoorId]);
+  }, [commitRoom, selectedRoom, selectedDoorId, showTransientHint]);
 
   // Helper to generate UUID
   const generateId = () => {
@@ -759,9 +802,9 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
       doors: [...(selectedRoom.doors ?? []), newDoor],
     };
     commitRoom(updated);
-    setSelectedDoorId(newDoor.id);
+    selectEntity({ kind: 'door', id: newDoor.id });
     setIsDoorPlacementMode(false); // Exit placement mode after placing
-  }, [commitRoom, selectedRoom, isDoorPlacementMode]);
+  }, [commitRoom, selectEntity, selectedRoom, isDoorPlacementMode]);
 
   const handleDoorDragStart = useCallback((doorId: string, x: number, y: number) => {
     const door = selectedRoom?.doors?.find((d) => d.id === doorId);
@@ -1283,6 +1326,44 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
         return;
       }
 
+      if (e.key === 'Backspace' || e.key === 'Delete') {
+        if (isTextEntry) return;
+        // Del acts on whatever is selected, and only falls back to the
+        // wall-level meanings when nothing is: it is never a general undo.
+        const target = resolveDeleteKeyTarget({
+          selectedFurnitureId,
+          selectedDoorId,
+          selectedSegment,
+          isDrawingWall,
+          hasRoomOutline: !!selectedRoom?.roomShell?.points?.length,
+        });
+        // Furniture and doors get picked from panel buttons too (the library,
+        // the mobile sheet), so their delete runs before the "focus is on a
+        // control" bail-out - the exemption undo/redo and R already have. The
+        // wall meanings stay behind it, exactly as before.
+        if (target === 'furniture') {
+          e.preventDefault();
+          handleFurnitureDelete();
+          return;
+        }
+        if (target === 'door') {
+          e.preventDefault();
+          handleDoorDelete();
+          return;
+        }
+        if (isEditable) return;
+        if (target === 'wallPoint') {
+          e.preventDefault();
+          deleteSelectedWallPoint();
+          return;
+        }
+        if (target === 'lastDrawnPoint') {
+          e.preventDefault();
+          removeLastPoint();
+        }
+        return;
+      }
+
       if (isEditable) return;
 
       if (e.key === 'Escape') {
@@ -1306,20 +1387,6 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
         }
         return;
       }
-      if (e.key === 'Backspace' || e.key === 'Delete') {
-        if (!selectedRoom?.roomShell?.points?.length) return;
-        // Del is a point-level delete, never a general undo: it removes the
-        // selected wall point, or the point just drawn while drawing is active.
-        if (selectedSegment !== null) {
-          e.preventDefault();
-          deleteSelectedWallPoint();
-          return;
-        }
-        if (isDrawingWall) {
-          e.preventDefault();
-          removeLastPoint();
-        }
-      }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
@@ -1327,12 +1394,16 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     canRotateLayout,
     deleteSelectedWallPoint,
     handleCloseLoop,
+    handleDoorDelete,
+    handleFurnitureDelete,
     handleRedo,
     handleUndo,
     isDrawingWall,
     activeBasicShape,
     removeLastPoint,
     rotateLayoutBy,
+    selectedDoorId,
+    selectedFurnitureId,
     selectedRoom?.roomShell?.points,
     selectedSegment,
     setIsDrawingWall,
@@ -1599,8 +1670,8 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
       lockedSegments: remapLockedSegmentsForSplit(selectedRoom.roomShell.lockedSegments, segmentIndex),
       doors: remapDoorsForSplit(selectedRoom.doors, segmentIndex, splitRatio),
     });
-    setSelectedSegment(segmentIndex);
-  }, [selectedRoom, isDrawingWall, isDoorPlacementMode, snapPointToGrid, handlePointsChange]);
+    selectEntity({ kind: 'segment', index: segmentIndex });
+  }, [selectedRoom, isDrawingWall, isDoorPlacementMode, selectEntity, snapPointToGrid, handlePointsChange]);
 
   const handleCanvasMove = (pt: { x: number; y: number }) => {
     setCursorPos(pt);
@@ -1840,6 +1911,16 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
       {error && (
         <div className="absolute top-6 left-1/2 -translate-x-1/2 z-50 max-w-lg rounded-xl border border-rose-500/50 bg-rose-500/10 backdrop-blur px-6 py-3 text-rose-100 shadow-xl animate-in slide-in-from-top-4 fade-in">
           {error}
+        </div>
+      )}
+
+      {/* Keyboard hint: says out loud what a disabled button would have shown. */}
+      {transientHint && (
+        <div
+          role="status"
+          className="absolute top-20 left-1/2 -translate-x-1/2 z-50 max-w-lg rounded-xl border border-amber-500/50 bg-amber-500/10 backdrop-blur px-6 py-3 text-amber-100 shadow-xl animate-in slide-in-from-top-4 fade-in"
+        >
+          {transientHint}
         </div>
       )}
 
@@ -2260,10 +2341,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                   // Clicking the device without moving it is a selection: open its
                   // settings, the same way clicking furniture opens the furniture panel.
                   onDeviceClick={() => {
-                    setSelectedFurnitureId(null);
-                    setSelectedDoorId(null);
-                    setSelectedSegment(null);
-                    setHoveredSegment(null);
+                    selectEntity({ kind: 'none' });
                     setShowFurnitureLibrary(false);
                     setActiveMobileSheet(null);
                     setSettingsTab('device');
@@ -2281,9 +2359,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                   selectedSegment={selectedSegment}
                   onSegmentHover={(idx) => setHoveredSegment(idx)}
                   onSegmentSelect={(idx) => {
-                    setSelectedSegment(idx);
-                    setSelectedDoorId(null);
-                    setSelectedFurnitureId(null);
+                    selectEntity(idx === null ? { kind: 'none' } : { kind: 'segment', index: idx });
                     setSegmentDragIndex(null);
                     setSegmentDragStart(null);
                     setSegmentDragBase(null);
@@ -2326,18 +2402,14 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                   furniture={selectedRoom.furniture ?? []}
                   selectedFurnitureId={selectedFurnitureId}
                   onFurnitureSelect={(id) => {
-                    setSelectedFurnitureId(id);
-                    setSelectedDoorId(null);
-                    setSelectedSegment(null);
+                    selectEntity(id === null ? { kind: 'none' } : { kind: 'furniture', id });
                     setShowFurnitureLibrary(false);
                   }}
                   onFurnitureChange={handleFurnitureChange}
                   doors={selectedRoom.doors ?? []}
                   selectedDoorId={selectedDoorId}
                   onDoorSelect={(id) => {
-                    setSelectedDoorId(id);
-                    setSelectedFurnitureId(null);
-                    setSelectedSegment(null);
+                    selectEntity(id === null ? { kind: 'none' } : { kind: 'door', id });
                   }}
                   onDoorChange={handleDoorChange}
                   isDoorPlacementMode={isDoorPlacementMode}
@@ -2598,7 +2670,10 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                 }`}
                 onClick={() => {
                   setShowFurnitureLibrary((v) => !v);
-                  setSelectedFurnitureId(null); // Close furniture settings when opening library
+                  // Close every open editor, not just the furniture one: a wall
+                  // segment left selected behind the library would go on
+                  // answering Del.
+                  selectEntity({ kind: 'none' });
                 }}
                 disabled={!selectedRoom}
               >
@@ -3761,7 +3836,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                   setActiveMobileSheet(null);
                   setShowSettings(false);
                   setShowFurnitureLibrary((current) => !current);
-                  setSelectedFurnitureId(null);
+                  selectEntity({ kind: 'none' });
                 }}
               />
             </CanvasBottomToolbar>
@@ -3928,7 +4003,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
             onClick={() => {
               setActiveMobileSheet(null);
               setShowFurnitureLibrary(true);
-              setSelectedFurnitureId(null);
+              selectEntity({ kind: 'none' });
             }}
             disabled={!selectedRoom}
           >

--- a/everything-presence-mmwave-configurator/frontend/src/utils/roomBuilderSelection.test.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/roomBuilderSelection.test.ts
@@ -1,0 +1,89 @@
+// @ts-nocheck -- Node's built-in runner supplies these modules; frontend production types stay dependency-free.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { resolveDeleteKeyTarget, resolveSelectionState } from './roomBuilderSelection.ts';
+
+test('selecting furniture clears the door and wall selections', () => {
+  assert.deepEqual(resolveSelectionState({ kind: 'furniture', id: 'sofa-1' }), {
+    selectedFurnitureId: 'sofa-1',
+    selectedDoorId: null,
+    selectedSegment: null,
+  });
+});
+
+test('selecting a door clears the furniture and wall selections', () => {
+  assert.deepEqual(resolveSelectionState({ kind: 'door', id: 'door-1' }), {
+    selectedFurnitureId: null,
+    selectedDoorId: 'door-1',
+    selectedSegment: null,
+  });
+});
+
+test('selecting a wall segment clears the furniture and door selections', () => {
+  assert.deepEqual(resolveSelectionState({ kind: 'segment', index: 0 }), {
+    selectedFurnitureId: null,
+    selectedDoorId: null,
+    selectedSegment: 0,
+  });
+});
+
+test('clearing the selection empties all three states', () => {
+  assert.deepEqual(resolveSelectionState({ kind: 'none' }), {
+    selectedFurnitureId: null,
+    selectedDoorId: null,
+    selectedSegment: null,
+  });
+});
+
+test('Del deletes the selected furniture, not a wall point', () => {
+  // Regression: adding furniture left an earlier wall selection in place, so Del
+  // fell through to the wall branch and removed a room corner instead.
+  assert.equal(
+    resolveDeleteKeyTarget({
+      selectedFurnitureId: 'sofa-1',
+      selectedSegment: 2,
+      hasRoomOutline: true,
+    }),
+    'furniture',
+  );
+});
+
+test('Del deletes selected furniture even in a room with no outline', () => {
+  assert.equal(
+    resolveDeleteKeyTarget({ selectedFurnitureId: 'sofa-1', hasRoomOutline: false }),
+    'furniture',
+  );
+});
+
+test('Del deletes the selected door when no furniture is selected', () => {
+  assert.equal(
+    resolveDeleteKeyTarget({ selectedDoorId: 'door-1', selectedSegment: 1, hasRoomOutline: true }),
+    'door',
+  );
+});
+
+test('Del still deletes the selected wall point when nothing else is selected', () => {
+  assert.equal(resolveDeleteKeyTarget({ selectedSegment: 0, hasRoomOutline: true }), 'wallPoint');
+});
+
+test('Del removes the last placed point while drawing', () => {
+  assert.equal(
+    resolveDeleteKeyTarget({ selectedSegment: null, isDrawingWall: true, hasRoomOutline: true }),
+    'lastDrawnPoint',
+  );
+});
+
+test('a live selection outranks the drawing tool', () => {
+  assert.equal(
+    resolveDeleteKeyTarget({ selectedFurnitureId: 'sofa-1', isDrawingWall: true, hasRoomOutline: true }),
+    'furniture',
+  );
+});
+
+test('Del does nothing with an empty selection', () => {
+  assert.equal(resolveDeleteKeyTarget({ hasRoomOutline: true }), null);
+});
+
+test('Del does nothing on wall state when the room has no outline', () => {
+  assert.equal(resolveDeleteKeyTarget({ selectedSegment: 0, isDrawingWall: true, hasRoomOutline: false }), null);
+});

--- a/everything-presence-mmwave-configurator/frontend/src/utils/roomBuilderSelection.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/roomBuilderSelection.ts
@@ -1,0 +1,58 @@
+/**
+ * The Room Builder can only ever have one thing selected: a piece of furniture,
+ * a door, or a wall segment. Every entry point that changes the selection has to
+ * clear the other two, otherwise an invisible leftover selection survives and
+ * keyboard actions get routed to the wrong object - which is exactly how
+ * "select furniture, press Del" ended up removing a wall corner: adding
+ * furniture never cleared the wall segment picked earlier.
+ */
+export type BuilderSelection =
+  | { kind: 'none' }
+  | { kind: 'furniture'; id: string }
+  | { kind: 'door'; id: string }
+  | { kind: 'segment'; index: number };
+
+export interface BuilderSelectionState {
+  selectedFurnitureId: string | null;
+  selectedDoorId: string | null;
+  selectedSegment: number | null;
+}
+
+/** The one place that decides what "X is selected" means for all three states. */
+export const resolveSelectionState = (selection: BuilderSelection): BuilderSelectionState => ({
+  selectedFurnitureId: selection.kind === 'furniture' ? selection.id : null,
+  selectedDoorId: selection.kind === 'door' ? selection.id : null,
+  selectedSegment: selection.kind === 'segment' ? selection.index : null,
+});
+
+/**
+ * What Del/Backspace acts on. `null` means "leave the key alone" - the page must
+ * not call preventDefault, so the browser keeps its own meaning for the key.
+ */
+export type DeleteKeyTarget = 'furniture' | 'door' | 'wallPoint' | 'lastDrawnPoint' | null;
+
+export interface DeleteKeyContext {
+  selectedFurnitureId?: string | null;
+  selectedDoorId?: string | null;
+  selectedSegment?: number | null;
+  /** True while the wall-drawing tool is active. */
+  isDrawingWall?: boolean;
+  /** True once the room has an outline with at least one point. */
+  hasRoomOutline?: boolean;
+}
+
+/**
+ * Precedence for Del, in the order the visible panels imply: whatever the user
+ * just selected wins, and the wall-level meanings (documented as "delete the
+ * last placed point") only apply when nothing else is selected.
+ */
+export const resolveDeleteKeyTarget = (context: DeleteKeyContext): DeleteKeyTarget => {
+  if (context.selectedFurnitureId) return 'furniture';
+  if (context.selectedDoorId) return 'door';
+  // Wall-level deletes need an outline; furniture in a room without one must
+  // still be deletable by key, so this guard sits below, not above.
+  if (!context.hasRoomOutline) return null;
+  if (context.selectedSegment !== null && context.selectedSegment !== undefined) return 'wallPoint';
+  if (context.isDrawingWall) return 'lastDrawnPoint';
+  return null;
+};


### PR DESCRIPTION
## Summary
Fixed Del deleting a wall corner while furniture was selected in the Room Builder.

A new pure helper module (`frontend/src/utils/roomBuilderSelection.ts`) carries two rules. `resolveSelectionState` maps a single "what is selected" request onto the three mutually exclusive selection states (furniture / door / wall segment). `resolveDeleteKeyTarget` gives Del a precedence order: selected furniture, then selected door, then selected wall segment (remove corner), then the drawing tool's "remove last placed point". The room-outline guard now only gates the two wall-level meanings, so furniture in a room with no outline is still deletable by key.

In `RoomBuilderPage` the Delete/Backspace branch of the window keydown effect dispatches through that helper and calls `handleFurnitureDelete` / `handleDoorDelete`, with those two handlers plus `selectedFurnitureId` / `selectedDoorId` added to the effect's dependency array. Furniture and doors can be selected from panel buttons (the furniture library, the mobile sheet), so those two cases run just before the existing "focus is on a control" bail-out — the same exemption undo/redo and R already have. The wall cases stay behind it, unchanged, and text fields keep the browser's native Del.

## Verification
1. `cd everything-presence-mmwave-configurator/frontend && npm install`
2. `npm test` — covers the new `roomBuilderSelection.test.ts` cases: furniture wins over a stale wall selection, furniture is deletable with no room outline, doors outrank walls, a selected wall still deletes a corner, and the drawing tool still removes the last placed point.
3. `npx tsc --noEmit`, then `npm run build`, then `npm run lint`

In the Room Builder:

1. Open a room with an outline, click a wall segment so the wall panel appears, then click Add Furniture and pick an item. Press Del — the new furniture disappears and the outline is untouched, with no corner removed.
2. Click an existing piece of furniture on the canvas and press Del — that item is removed, the walls are unchanged, and Ctrl+Z restores it.
3. Click a door and press Del — the door is removed and the wall it sat on stays.
4. With nothing selected, click a wall segment and press Del — the corner is removed and the two walls merge, as before.
5. Press A, place three points, then press Del — only the last placed point is removed.
6. Lock a piece of furniture with the padlock in its panel and press Del — nothing is deleted, and an amber "This furniture is locked. Unlock it before deleting it." hint appears briefly. Repeat for a locked door.
7. Select furniture, click into the X (m) field in its panel, and press Del inside the text — the character is deleted and the furniture is not.
8. Select furniture, then click a wall segment — the furniture panel closes and the wall panel opens. Del then removes the wall corner.
9. In a room with no outline, add furniture and press Del — the furniture is removed.

Fixes #382