### PR TITLE
Bug: Wall nodes behind furniture

### DIFF
--- a/everything-presence-mmwave-configurator/frontend/package.json
+++ b/everything-presence-mmwave-configurator/frontend/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",
-		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts src/utils/polygonVertices.test.ts src/utils/roomHistory.test.ts src/utils/roomSelection.test.ts src/utils/roomBuilderSelection.test.ts src/utils/lockState.test.ts src/utils/roomRotation.test.ts src/utils/doorGeometry.test.ts",
+		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts src/utils/polygonVertices.test.ts src/utils/roomHistory.test.ts src/utils/roomSelection.test.ts src/utils/roomBuilderSelection.test.ts src/utils/lockState.test.ts src/utils/roomRotation.test.ts src/utils/doorGeometry.test.ts src/utils/canvasLayers.test.ts",
 		"preview": "vite preview",
 		"format": "npx @biomejs/biome format",
 		"format:fix": "npx @biomejs/biome format --write",

--- a/everything-presence-mmwave-configurator/frontend/src/components/RoomCanvas.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/RoomCanvas.tsx
@@ -7,6 +7,7 @@ import { useThemeContext } from '../contexts/ThemeContext';
 import { useCustomAssets } from '../hooks/useCustomAssets';
 import { formatLengthLabel } from '../utils/lengthLabels';
 import { getDoorGeometry } from '../utils/doorGeometry';
+import { canvasLayerProps } from '../utils/canvasLayers';
 
 export interface Point {
   x: number;
@@ -1171,6 +1172,54 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
     }
   };
 
+  // Furniture display geometry is derived once, because an item's body and its
+  // resize/rotate handles are drawn in different layers: bodies with the rest
+  // of the furniture, handles in the topmost layer so one item can never bury
+  // the controls of the item beside it.
+  const furnitureRenderList = (showFurniture ? furniture : []).map((item) => {
+    // Use dragging/resizing/rotating state if this furniture is being edited
+    const isDragging = furnitureDrag?.id === item.id;
+    const isResizing = furnitureResize?.id === item.id;
+    const isRotating = furnitureRotate?.id === item.id;
+
+    // Determine display position, size, and rotation
+    let displayPos = { x: item.x, y: item.y };
+    let displayWidth = item.width;
+    let displayDepth = item.depth;
+    let displayRotation = item.rotationDeg;
+
+    if (isDragging && furnitureDrag) {
+      displayPos = furnitureDrag.currentPos || furnitureDrag.basePos;
+    } else if (isResizing && furnitureResize) {
+      displayPos = furnitureResize.currentPos || furnitureResize.basePos;
+      const size = furnitureResize.currentSize || furnitureResize.baseSize;
+      displayWidth = size.width;
+      displayDepth = size.depth;
+    } else if (isRotating && furnitureRotate) {
+      displayRotation = furnitureRotate.currentRotation !== undefined ? furnitureRotate.currentRotation : furnitureRotate.baseRotation;
+    }
+
+    const isLockedItem = !!item.locked;
+    const isSelected = selectedFurnitureId === item.id;
+
+    return {
+      item,
+      isDragging,
+      displayRotation,
+      canvasPos: toCanvasCoord({ x: displayPos.x, y: displayPos.y }),
+      canvasWidth: toCanvas(displayWidth, effectiveRangeMm),
+      canvasHeight: toCanvas(displayDepth, effectiveRangeMm),
+      isLockedItem,
+      // A locked item still selects, so a left click always visibly does
+      // something and the editor panel can explain the lock. It just never
+      // starts a move.
+      isSelected,
+      showItemLock: isLockedItem && showLockIndicators,
+      // Handles only make sense on an unlocked selection that has settled.
+      showHandles: isSelected && !isLockedItem && !isDragging && !isResizing && !isRotating,
+    };
+  });
+
   return (
     <div className="w-full h-full">
       <svg
@@ -1261,10 +1310,10 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
               />,
             );
           }
-          return lines;
+          return <g {...canvasLayerProps('floor')}>{lines}</g>;
         })()}
         {safePoints.length > 0 && (
-          <>
+          <g {...canvasLayerProps('shell')}>
             {showWalls && (() => {
               const path = safePoints
                 .map(
@@ -1276,26 +1325,8 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
               const { fill, opacity } = getFloorFill(roomShellFillMode, floorMaterial);
               return <path d={closedPath} fill={fill} fillOpacity={opacity} stroke="#22d3ee" strokeWidth={2} vectorEffect="non-scaling-stroke" />;
             })()}
-            {!lockShell &&
-              safePoints.map((p, idx) => {
-                // A corner shared with a locked wall would drag that wall too.
-                if (isVertexPinned(idx)) return null;
-                const { x: cx, y: cy } = toCanvasCoord(p);
-                return (
-                  <g key={`pt-${idx}`}>
-                    <circle
-                      cx={cx}
-                      cy={cy}
-                      r={vertexHandleRadius}
-                      fill="#0ea5e9"
-                      stroke="#e0f2fe"
-                      strokeWidth={handleStrokeWidth}
-                      vectorEffect="non-scaling-stroke"
-                      onPointerDown={handleDragStart(idx)}
-                    />
-                  </g>
-                );
-              })}
+            {/* Corner handles are not drawn here - they belong to the handles
+                layer at the end of the canvas, above furniture and doors. */}
             {/* Locked walls: drawn amber so the pin is visible while editing. */}
             {showWalls && showLockIndicators &&
               safePoints.map((p, idx) => {
@@ -1465,66 +1496,9 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                   />
                 );
               })}
-            {!lockShell &&
-              selectedSegment !== null &&
-              selectedSegment !== undefined &&
-              !isSegmentPinned(selectedSegment) &&
-              (() => {
-                const p = safePoints[selectedSegment];
-                const next = safePoints[(selectedSegment + 1) % safePoints.length];
-                if (!p || !next) return null;
-                const { x: x1, y: y1 } = toCanvasCoord(p);
-                const { x: x2, y: y2 } = toCanvasCoord(next);
-                return (
-                  <>
-                    <rect
-                      x={x1 - endpointHandleSize / 2}
-                      y={y1 - endpointHandleSize / 2}
-                      width={endpointHandleSize}
-                      height={endpointHandleSize}
-                      fill="#0ea5e9"
-                      stroke="#e0f2fe"
-                      strokeWidth={handleStrokeWidth}
-                      rx={endpointHandleRadius}
-                      vectorEffect="non-scaling-stroke"
-                      onPointerDown={(e) => {
-                        e.stopPropagation();
-                        if (e.cancelable) e.preventDefault();
-                        capturePointer(e);
-                        if (onEndpointDragStart) {
-                          const world = toWorldFromEvent(e as any) ?? { x: p.x, y: p.y };
-                          onEndpointDragStart(selectedSegment, 'start', world);
-                          suppressClickRef.current = true;
-                          onDragStateChange?.(true);
-                        }
-                      }}
-                    />
-                    <rect
-                      x={x2 - endpointHandleSize / 2}
-                      y={y2 - endpointHandleSize / 2}
-                      width={endpointHandleSize}
-                      height={endpointHandleSize}
-                      fill="#0ea5e9"
-                      stroke="#e0f2fe"
-                      strokeWidth={handleStrokeWidth}
-                      rx={endpointHandleRadius}
-                      vectorEffect="non-scaling-stroke"
-                      onPointerDown={(e) => {
-                        e.stopPropagation();
-                        if (e.cancelable) e.preventDefault();
-                        capturePointer(e);
-                        if (onEndpointDragStart) {
-                          const world = toWorldFromEvent(e as any) ?? { x: next.x, y: next.y };
-                          onEndpointDragStart(selectedSegment, 'end', world);
-                          suppressClickRef.current = true;
-                          onDragStateChange?.(true);
-                        }
-                      }}
-                    />
-                  </>
-                );
-              })()}
-          </>
+            {/* Endpoint handles for the selected wall are drawn in the handles
+                layer at the end of the canvas, for the same reason. */}
+          </g>
         )}
         {previewFrom && (
           (() => {
@@ -1625,7 +1599,7 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
           const hit = geometry.hitBounds;
 
           return (
-            <g key={door.id}>
+            <g key={door.id} {...canvasLayerProps('doors')}>
               {/* Door group with transform */}
               <g transform={`translate(${canvasDoorPos.x}, ${canvasDoorPos.y}) rotate(${segmentAngle})`}>
                 {/* Selection highlight (when selected) */}
@@ -1781,47 +1755,24 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
           );
         })}
 
-        {/* Render furniture */}
-        {showFurniture && furniture.map((item) => {
-          // Use dragging position if this furniture is being dragged
-          const isDragging = furnitureDrag?.id === item.id;
-          const isResizing = furnitureResize?.id === item.id;
-          const isRotating = furnitureRotate?.id === item.id;
-
-          // Determine display position, size, and rotation
-          let displayPos = { x: item.x, y: item.y };
-          let displayWidth = item.width;
-          let displayDepth = item.depth;
-          let displayRotation = item.rotationDeg;
-
-          if (isDragging && furnitureDrag) {
-            displayPos = furnitureDrag.currentPos || furnitureDrag.basePos;
-          } else if (isResizing && furnitureResize) {
-            displayPos = furnitureResize.currentPos || furnitureResize.basePos;
-            const size = furnitureResize.currentSize || furnitureResize.baseSize;
-            displayWidth = size.width;
-            displayDepth = size.depth;
-          } else if (isRotating && furnitureRotate) {
-            displayRotation = furnitureRotate.currentRotation !== undefined ? furnitureRotate.currentRotation : furnitureRotate.baseRotation;
-          }
-
-          const displayX = displayPos.x;
-          const displayY = displayPos.y;
-
-          const canvasPos = toCanvasCoord({ x: displayX, y: displayY });
-          const canvasWidth = toCanvas(displayWidth, effectiveRangeMm);
-          const canvasHeight = toCanvas(displayDepth, effectiveRangeMm);
-          const isLockedItem = !!item.locked;
-          const showItemLock = isLockedItem && showLockIndicators;
-          // A locked item still selects, so a left click always visibly does
-          // something and the editor panel can explain the lock. It just never
-          // starts a move.
-          const isSelected = selectedFurnitureId === item.id;
+        {/* Render furniture bodies. Their resize/rotate handles live in the
+            handles layer at the end of the canvas. */}
+        {furnitureRenderList.map(({
+          item,
+          isDragging,
+          displayRotation,
+          canvasPos,
+          canvasWidth,
+          canvasHeight,
+          isLockedItem,
+          isSelected,
+          showItemLock,
+        }) => {
           const Icon = getFurnitureIcon(item.typeId);
           const customType = getCustomFurnitureType(customFurniture, item.typeId);
 
           return (
-            <g key={item.id}>
+            <g key={item.id} {...canvasLayerProps('furniture')}>
               {/* Main furniture group with transform */}
               <g transform={`translate(${canvasPos.x}, ${canvasPos.y}) rotate(${displayRotation})`}>
                 {/* Furniture icon - render directly as SVG to fill bounds */}
@@ -1896,122 +1847,6 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                   label="Furniture is locked - select it to unlock"
                 />
               )}
-
-              {/* Resize handles (only when selected, unlocked and not dragging/rotating) */}
-              {isSelected && !isLockedItem && !isDragging && !isResizing && !isRotating && (() => {
-                const handleSize = 14;
-                const handles: Array<{ corner: 'nw' | 'ne' | 'sw' | 'se'; x: number; y: number; cursor: string }> = [
-                  { corner: 'nw', x: -canvasWidth / 2, y: -canvasHeight / 2, cursor: 'nwse-resize' },
-                  { corner: 'ne', x: canvasWidth / 2, y: -canvasHeight / 2, cursor: 'nesw-resize' },
-                  { corner: 'sw', x: -canvasWidth / 2, y: canvasHeight / 2, cursor: 'nesw-resize' },
-                  { corner: 'se', x: canvasWidth / 2, y: canvasHeight / 2, cursor: 'nwse-resize' },
-                ];
-
-                return (
-                  <>
-                    {handles.map((handle) => (
-                      <rect
-                        key={handle.corner}
-                        x={handle.x - handleSize / 2}
-                        y={handle.y - handleSize / 2}
-                        width={handleSize}
-                        height={handleSize}
-                        fill="#0ea5e9"
-                        stroke="#ffffff"
-                        strokeWidth={1.5}
-                        rx={1}
-                        transform={`translate(${canvasPos.x}, ${canvasPos.y}) rotate(${displayRotation})`}
-                        style={{ transformOrigin: '0 0', cursor: handle.cursor }}
-                        onPointerDown={(e) => {
-                          e.stopPropagation();
-                          if (e.cancelable) e.preventDefault();
-                          capturePointer(e);
-                          const worldPos = toWorldFromEvent(e as any);
-                          if (!worldPos) return;
-                          suppressClickRef.current = true;
-                          setFurnitureResize({
-                            id: item.id,
-                            corner: handle.corner,
-                            start: worldPos,
-                            baseSize: { width: item.width, depth: item.depth },
-                            basePos: { x: item.x, y: item.y },
-                          });
-                          onDragStateChange?.(true);
-                        }}
-                        onPointerMove={handlePointerMove}
-                        onPointerUp={handlePointerUp}
-                        onPointerCancel={handlePointerUp}
-                      />
-                    ))}
-                    {/* Rotation handle (at top center) */}
-                    <g transform={`translate(${canvasPos.x}, ${canvasPos.y}) rotate(${displayRotation})`}>
-                      {/* Line connecting to rotation handle */}
-                      <line
-                        x1={0}
-                        y1={-canvasHeight / 2}
-                        x2={0}
-                        y2={-canvasHeight / 2 - 20}
-                        stroke="#a855f7"
-                        strokeWidth={2}
-                        strokeDasharray="3 3"
-                      />
-                      <circle
-                        cx={0}
-                        cy={-canvasHeight / 2 - 20}
-                        r={24}
-                        fill="transparent"
-                        style={{ cursor: 'grab', pointerEvents: 'all' }}
-                        onPointerDown={(e) => {
-                          e.stopPropagation();
-                          if (e.cancelable) e.preventDefault();
-                          capturePointer(e);
-                          const worldPos = toWorldFromEvent(e as any);
-                          if (!worldPos) return;
-                          suppressClickRef.current = true;
-                          setFurnitureRotate({
-                            id: item.id,
-                            start: worldPos,
-                            centerPos: { x: item.x, y: item.y },
-                            baseRotation: item.rotationDeg,
-                          });
-                          onDragStateChange?.(true);
-                        }}
-                        onPointerMove={handlePointerMove}
-                        onPointerUp={handlePointerUp}
-                        onPointerCancel={handlePointerUp}
-                      />
-                      {/* Rotation handle circle */}
-                      <circle
-                        cx={0}
-                        cy={-canvasHeight / 2 - 20}
-                        r={10}
-                        fill="#a855f7"
-                        stroke="#ffffff"
-                        strokeWidth={1.5}
-                        style={{ cursor: 'grab', pointerEvents: 'all' }}
-                        onPointerDown={(e) => {
-                          e.stopPropagation();
-                          if (e.cancelable) e.preventDefault();
-                          capturePointer(e);
-                          const worldPos = toWorldFromEvent(e as any);
-                          if (!worldPos) return;
-                          suppressClickRef.current = true;
-                          setFurnitureRotate({
-                            id: item.id,
-                            start: worldPos,
-                            centerPos: { x: item.x, y: item.y },
-                            baseRotation: item.rotationDeg,
-                          });
-                          onDragStateChange?.(true);
-                        }}
-                        onPointerMove={handlePointerMove}
-                        onPointerUp={handlePointerUp}
-                        onPointerCancel={handlePointerUp}
-                      />
-                    </g>
-                  </>
-                );
-              })()}
             </g>
           );
         })}
@@ -2149,7 +1984,7 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
             const iconRotationDeg = safePlacement.mountType === 'ceiling' ? (safePlacement.rotationDeg ?? 0) : 0;
 
             return (
-              <g style={{ pointerEvents: 'none' }}>
+              <g style={{ pointerEvents: 'none' }} {...canvasLayerProps('device')}>
                 {heightCoveragePath && (
                   <path
                     d={heightCoveragePath}
@@ -2326,7 +2161,7 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
             const iconRotationDeg = safePlacement.mountType === 'ceiling' ? (safePlacement.rotationDeg ?? 0) : 0;
 
             return (
-              <g>
+              <g {...canvasLayerProps('device')}>
                 {heightCoveragePath && (
                   <path
                     d={heightCoveragePath}
@@ -2403,6 +2238,222 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
             );
           })()
         )}
+
+        {/* Editing handles - always the last layer of the canvas.
+            SVG has no z-index, so a later sibling both paints over an earlier
+            one and wins its clicks. Drawn any earlier, a corner node sitting
+            behind a sofa would be invisible *and* dead: the furniture's
+            transparent hit rect would swallow the press that should have
+            grabbed the corner. Keeping every handle here also means one
+            furniture item can never bury the grips of the item beside it. */}
+        <g
+          {...canvasLayerProps('handles')}
+          // In door placement mode a click belongs to the wall under the
+          // pointer, so the handles stay visible but let it through.
+          style={isDoorPlacementMode ? { pointerEvents: 'none' } : undefined}
+        >
+          {/* Wall corner handles */}
+          {!lockShell &&
+            safePoints.map((p, idx) => {
+              // A corner shared with a locked wall would drag that wall too.
+              if (isVertexPinned(idx)) return null;
+              const { x: cx, y: cy } = toCanvasCoord(p);
+              return (
+                <g key={`pt-${idx}`}>
+                  <circle
+                    cx={cx}
+                    cy={cy}
+                    r={vertexHandleRadius}
+                    fill="#0ea5e9"
+                    stroke="#e0f2fe"
+                    strokeWidth={handleStrokeWidth}
+                    vectorEffect="non-scaling-stroke"
+                    onPointerDown={handleDragStart(idx)}
+                  />
+                </g>
+              );
+            })}
+
+          {/* Endpoint handles for the selected wall */}
+          {!lockShell &&
+            safePoints.length > 0 &&
+            selectedSegment !== null &&
+            selectedSegment !== undefined &&
+            !isSegmentPinned(selectedSegment) &&
+            (() => {
+              const p = safePoints[selectedSegment];
+              const next = safePoints[(selectedSegment + 1) % safePoints.length];
+              if (!p || !next) return null;
+              const { x: x1, y: y1 } = toCanvasCoord(p);
+              const { x: x2, y: y2 } = toCanvasCoord(next);
+              return (
+                <>
+                  <rect
+                    x={x1 - endpointHandleSize / 2}
+                    y={y1 - endpointHandleSize / 2}
+                    width={endpointHandleSize}
+                    height={endpointHandleSize}
+                    fill="#0ea5e9"
+                    stroke="#e0f2fe"
+                    strokeWidth={handleStrokeWidth}
+                    rx={endpointHandleRadius}
+                    vectorEffect="non-scaling-stroke"
+                    onPointerDown={(e) => {
+                      e.stopPropagation();
+                      if (e.cancelable) e.preventDefault();
+                      capturePointer(e);
+                      if (onEndpointDragStart) {
+                        const world = toWorldFromEvent(e as any) ?? { x: p.x, y: p.y };
+                        onEndpointDragStart(selectedSegment, 'start', world);
+                        suppressClickRef.current = true;
+                        onDragStateChange?.(true);
+                      }
+                    }}
+                  />
+                  <rect
+                    x={x2 - endpointHandleSize / 2}
+                    y={y2 - endpointHandleSize / 2}
+                    width={endpointHandleSize}
+                    height={endpointHandleSize}
+                    fill="#0ea5e9"
+                    stroke="#e0f2fe"
+                    strokeWidth={handleStrokeWidth}
+                    rx={endpointHandleRadius}
+                    vectorEffect="non-scaling-stroke"
+                    onPointerDown={(e) => {
+                      e.stopPropagation();
+                      if (e.cancelable) e.preventDefault();
+                      capturePointer(e);
+                      if (onEndpointDragStart) {
+                        const world = toWorldFromEvent(e as any) ?? { x: next.x, y: next.y };
+                        onEndpointDragStart(selectedSegment, 'end', world);
+                        suppressClickRef.current = true;
+                        onDragStateChange?.(true);
+                      }
+                    }}
+                  />
+                </>
+              );
+            })()}
+
+          {/* Furniture resize and rotation handles (only for a selected,
+              unlocked item that is not mid-drag) */}
+          {furnitureRenderList.map(({ item, canvasPos, canvasWidth, canvasHeight, displayRotation, showHandles }) => {
+            if (!showHandles) return null;
+            const handleSize = 14;
+            const handles: Array<{ corner: 'nw' | 'ne' | 'sw' | 'se'; x: number; y: number; cursor: string }> = [
+              { corner: 'nw', x: -canvasWidth / 2, y: -canvasHeight / 2, cursor: 'nwse-resize' },
+              { corner: 'ne', x: canvasWidth / 2, y: -canvasHeight / 2, cursor: 'nesw-resize' },
+              { corner: 'sw', x: -canvasWidth / 2, y: canvasHeight / 2, cursor: 'nesw-resize' },
+              { corner: 'se', x: canvasWidth / 2, y: canvasHeight / 2, cursor: 'nwse-resize' },
+            ];
+
+            return (
+              <g key={`furniture-handles-${item.id}`}>
+                {handles.map((handle) => (
+                  <rect
+                    key={handle.corner}
+                    x={handle.x - handleSize / 2}
+                    y={handle.y - handleSize / 2}
+                    width={handleSize}
+                    height={handleSize}
+                    fill="#0ea5e9"
+                    stroke="#ffffff"
+                    strokeWidth={1.5}
+                    rx={1}
+                    transform={`translate(${canvasPos.x}, ${canvasPos.y}) rotate(${displayRotation})`}
+                    style={{ transformOrigin: '0 0', cursor: handle.cursor }}
+                    onPointerDown={(e) => {
+                      e.stopPropagation();
+                      if (e.cancelable) e.preventDefault();
+                      capturePointer(e);
+                      const worldPos = toWorldFromEvent(e as any);
+                      if (!worldPos) return;
+                      suppressClickRef.current = true;
+                      setFurnitureResize({
+                        id: item.id,
+                        corner: handle.corner,
+                        start: worldPos,
+                        baseSize: { width: item.width, depth: item.depth },
+                        basePos: { x: item.x, y: item.y },
+                      });
+                      onDragStateChange?.(true);
+                    }}
+                    onPointerMove={handlePointerMove}
+                    onPointerUp={handlePointerUp}
+                    onPointerCancel={handlePointerUp}
+                  />
+                ))}
+                {/* Rotation handle (at top center) */}
+                <g transform={`translate(${canvasPos.x}, ${canvasPos.y}) rotate(${displayRotation})`}>
+                  {/* Line connecting to rotation handle */}
+                  <line
+                    x1={0}
+                    y1={-canvasHeight / 2}
+                    x2={0}
+                    y2={-canvasHeight / 2 - 20}
+                    stroke="#a855f7"
+                    strokeWidth={2}
+                    strokeDasharray="3 3"
+                  />
+                  <circle
+                    cx={0}
+                    cy={-canvasHeight / 2 - 20}
+                    r={24}
+                    fill="transparent"
+                    style={{ cursor: 'grab', pointerEvents: 'all' }}
+                    onPointerDown={(e) => {
+                      e.stopPropagation();
+                      if (e.cancelable) e.preventDefault();
+                      capturePointer(e);
+                      const worldPos = toWorldFromEvent(e as any);
+                      if (!worldPos) return;
+                      suppressClickRef.current = true;
+                      setFurnitureRotate({
+                        id: item.id,
+                        start: worldPos,
+                        centerPos: { x: item.x, y: item.y },
+                        baseRotation: item.rotationDeg,
+                      });
+                      onDragStateChange?.(true);
+                    }}
+                    onPointerMove={handlePointerMove}
+                    onPointerUp={handlePointerUp}
+                    onPointerCancel={handlePointerUp}
+                  />
+                  {/* Rotation handle circle */}
+                  <circle
+                    cx={0}
+                    cy={-canvasHeight / 2 - 20}
+                    r={10}
+                    fill="#a855f7"
+                    stroke="#ffffff"
+                    strokeWidth={1.5}
+                    style={{ cursor: 'grab', pointerEvents: 'all' }}
+                    onPointerDown={(e) => {
+                      e.stopPropagation();
+                      if (e.cancelable) e.preventDefault();
+                      capturePointer(e);
+                      const worldPos = toWorldFromEvent(e as any);
+                      if (!worldPos) return;
+                      suppressClickRef.current = true;
+                      setFurnitureRotate({
+                        id: item.id,
+                        start: worldPos,
+                        centerPos: { x: item.x, y: item.y },
+                        baseRotation: item.rotationDeg,
+                      });
+                      onDragStateChange?.(true);
+                    }}
+                    onPointerMove={handlePointerMove}
+                    onPointerUp={handlePointerUp}
+                    onPointerCancel={handlePointerUp}
+                  />
+                </g>
+              </g>
+            );
+          })}
+        </g>
       </svg>
     </div>
   );

--- a/everything-presence-mmwave-configurator/frontend/src/utils/canvasLayers.test.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/canvasLayers.test.ts
@@ -1,0 +1,42 @@
+// @ts-nocheck -- Node's built-in runner supplies these modules.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { CANVAS_LAYER_ORDER, HANDLES_LAYER, canvasLayerProps, canvasLayerRank } from './canvasLayers.ts';
+
+test('handles are the top layer and unknown layers rank below them', () => {
+  assert.equal(CANVAS_LAYER_ORDER[CANVAS_LAYER_ORDER.length - 1], HANDLES_LAYER);
+  assert.ok(canvasLayerRank('furniture') < canvasLayerRank(HANDLES_LAYER));
+  assert.ok(canvasLayerRank('doors') < canvasLayerRank('furniture'));
+  assert.ok(canvasLayerRank('device') < canvasLayerRank(HANDLES_LAYER));
+  // A layer nobody listed still cannot bury a control.
+  assert.ok(canvasLayerRank('zones-somebody-added-later') < canvasLayerRank(HANDLES_LAYER));
+});
+
+test('canvasLayerProps tags a group with its layer', () => {
+  assert.deepEqual(canvasLayerProps('handles'), { 'data-canvas-layer': 'handles' });
+});
+
+/**
+ * The room canvas is one flat `<svg>`, so paint order is source order: a block
+ * emitted after the wall handles both covers them and steals their clicks.
+ * This guards the ordering that regressed when furniture ended up drawn over
+ * the draggable wall corner nodes.
+ */
+test('RoomCanvas emits its layers in paint order, handles last', () => {
+  const source = readFileSync(new URL('../components/RoomCanvas.tsx', import.meta.url), 'utf8');
+  const layers = [...source.matchAll(/canvasLayerProps\('([a-z-]+)'\)/g)].map((match) => match[1]);
+
+  assert.ok(layers.includes('furniture'), 'furniture layer should be tagged');
+  assert.ok(layers.includes('doors'), 'doors layer should be tagged');
+  assert.equal(layers.filter((layer) => layer === HANDLES_LAYER).length, 1, 'handles should be a single layer');
+  assert.equal(layers[layers.length - 1], HANDLES_LAYER, 'handles must be the last layer emitted');
+
+  for (const layer of layers) {
+    assert.ok(CANVAS_LAYER_ORDER.includes(layer), `unknown canvas layer: ${layer}`);
+  }
+  const ranks = layers.map(canvasLayerRank);
+  for (let i = 1; i < ranks.length; i++) {
+    assert.ok(ranks[i] >= ranks[i - 1], `layer "${layers[i]}" is drawn after "${layers[i - 1]}"`);
+  }
+});

--- a/everything-presence-mmwave-configurator/frontend/src/utils/canvasLayers.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/canvasLayers.ts
@@ -1,0 +1,43 @@
+/**
+ * Paint order for the room canvas.
+ *
+ * Everything the canvas draws lives in one `<svg>`, and SVG has no `z-index`:
+ * a later sibling always paints over an earlier one, and always wins
+ * hit-testing against it. The order of the blocks in `components/RoomCanvas`
+ * is therefore a contract rather than an accident, so each block tags its
+ * group with `canvasLayerProps(...)` and they are emitted bottom to top in the
+ * order declared here.
+ *
+ * The rule that matters is the last one: interactive editing handles - wall
+ * corner nodes, wall segment endpoint handles, furniture resize/rotate grips -
+ * are drawn after every object they sit on. A handle buried under a sofa is
+ * not merely invisible, it is unclickable, because the furniture's transparent
+ * hit rect swallows the press that should have grabbed the corner.
+ */
+
+/** Canvas layers, bottom to top. */
+export const CANVAS_LAYER_ORDER = ['floor', 'shell', 'doors', 'furniture', 'device', 'handles'] as const;
+
+export type CanvasLayerId = (typeof CANVAS_LAYER_ORDER)[number];
+
+/** The topmost layer: interactive editing handles, painted above everything else. */
+export const HANDLES_LAYER: CanvasLayerId = 'handles';
+
+/**
+ * Where a layer sits in the paint order, lowest first. Unknown names rank
+ * below the handles, so a layer nobody listed here can never bury a control.
+ */
+export const canvasLayerRank = (layer: string): number => {
+  const index = (CANVAS_LAYER_ORDER as readonly string[]).indexOf(layer);
+  if (index >= 0) return index;
+  return CANVAS_LAYER_ORDER.indexOf(HANDLES_LAYER) - 0.5;
+};
+
+/**
+ * Marks an SVG group as belonging to a canvas layer. The attribute documents
+ * the intended paint order in the DOM (and lets a test assert it), while the
+ * `CanvasLayerId` type keeps the names honest.
+ */
+export const canvasLayerProps = (layer: CanvasLayerId): { 'data-canvas-layer': CanvasLayerId } => ({
+  'data-canvas-layer': layer,
+});


### PR DESCRIPTION
## Summary
Fixed the Room Builder canvas so wall editing handles are never painted (or click-blocked) by furniture. The canvas is a single flat <svg>, where SVG paints later siblings over earlier ones and gives them hit-testing priority, so the wall corner nodes and selected-wall endpoint handles - previously emitted long before the doors, furniture and device blocks - sat underneath furniture and lost their presses to each item's transparent hit rect. All interactive handles are now emitted last, in one explicit 'handles' layer group at the end of the SVG: wall corner nodes, selected-segment endpoint handles, and the furniture resize/rotate grips. The furniture grips were previously per-item children, so one item's body could bury its neighbour's grips; furniture display geometry (drag/resize/rotate position, size, rotation, canvas coords, lock/selection flags) is now derived once into `furnitureRenderList`, consumed by the furniture body block where it was, and again by the shared handles layer. To make the ordering intent explicit rather than incidental, a new `utils/canvasLayers.ts` declares the bottom-to-top paint order (floor, shell, doors, furniture, device, handles) and a `canvasLayerProps(layer)` helper that tags each group with a type-checked `data-canvas-layer` attribute; the canvas blocks now carry those tags.

## Verification
Automated:
1. `cd everything-presence-mmwave-configurator/frontend && npm ci` (or `npm install`), then `npm test` - all suites pass, including the new `canvasLayers.test.ts`, whose "RoomCanvas emits its layers in paint order, handles last" case fails if any canvas layer is emitted after the handles layer.
2. `npm run build` in the same directory - the frontend bundles with no errors.
Manual, against a deployed preview of the add-on:
3. Open Room Builder with the shell unlocked, and drag a large furniture item (e.g. a sofa or bed) into a corner so it overlaps a wall corner node. Expect: the blue round corner node stays fully visible on top of the furniture.
4. Press and drag exactly on that corner node. Expect: the wall corner moves and the room outline reshapes; the furniture underneath does not get selected or dragged.
5. Click the same furniture item somewhere away from any corner node. Expect: it selects and drags as before.
6. Select a wall segment whose ends are covered by furniture. Expect: the two square endpoint handles render above the furniture and dragging either one moves that wall end.
7. Select a furniture item that is partly overlapped by another item. Expect: its four corner resize squares and the purple rotation handle draw above the neighbouring item, and both resizing and rotating work when grabbed there.
8. Enter door placement mode and click a wall close to a corner. Expect: a door is placed on that wall (the corner node does not intercept the click).
9. Lock the room shell (or open a basic shape) and check corner/endpoint handles disappear as before; open the Zone Editor and confirm zones, their handles and the device icon look and behave unchanged.

Fixes #381