### PR TITLE
Investigate EP1 zone editor access and invalid zone types

### DIFF
--- a/everything-presence-mmwave-configurator/backend/package.json
+++ b/everything-presence-mmwave-configurator/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc -p tsconfig.json",
-    "test": "node --test -r ts-node/register src/domain/zoneEntityNaming.test.ts",
+    "test": "node --test -r ts-node/register src/domain/zoneEntityNaming.test.ts src/domain/deviceProfiles.test.ts",
     "start": "node dist/index.js",
     "lint": "echo \"(no lint configured yet)\""
   },

--- a/everything-presence-mmwave-configurator/backend/src/domain/deviceProfiles.test.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/deviceProfiles.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { DeviceProfile } from './deviceProfiles';
+import { DEFAULT_ZONE_LIMITS, normalizeDeviceProfile, resolveZoneLimits } from './deviceProfiles';
+
+const makeProfile = (overrides: Partial<DeviceProfile>): DeviceProfile => ({
+  id: 'test-profile',
+  label: 'Test Profile',
+  manufacturer: 'Test',
+  capabilities: {},
+  limits: {},
+  entityMap: {},
+  ...overrides,
+});
+
+// Mirrors config/device-profiles/everything_presence_one.json
+const ep1 = makeProfile({
+  id: 'everything_presence_one',
+  capabilities: { tracking: false, zones: false, exclusionZones: false, entryZones: false },
+  limits: { maxZones: 0, maxExclusionZones: 0, maxEntryZones: 0, maxRangeMeters: 25 },
+});
+
+test('a profile with no zone support has no slots of any kind', () => {
+  assert.deepEqual(resolveZoneLimits(ep1), {
+    maxZones: 0,
+    maxExclusionZones: 0,
+    maxEntryZones: 0,
+  });
+});
+
+test('missing exclusion and entry limits do not become two when zones are unsupported', () => {
+  const withoutLimits = makeProfile({
+    capabilities: { zones: false },
+    limits: { maxZones: 0, maxRangeMeters: 25 },
+  });
+  assert.deepEqual(resolveZoneLimits(withoutLimits), {
+    maxZones: 0,
+    maxExclusionZones: 0,
+    maxEntryZones: 0,
+  });
+});
+
+test('a profile that says nothing keeps the legacy defaults', () => {
+  assert.deepEqual(resolveZoneLimits(makeProfile({})), DEFAULT_ZONE_LIMITS);
+});
+
+test('a capability of false overrides a non-zero limit', () => {
+  const contradictory = makeProfile({
+    capabilities: { zones: true, entryZones: false },
+    limits: { maxZones: 4, maxEntryZones: 2 },
+  });
+  assert.equal(resolveZoneLimits(contradictory).maxEntryZones, 0);
+});
+
+test('loading a profile fills in every zone limit', () => {
+  const normalized = normalizeDeviceProfile(
+    makeProfile({
+      capabilities: { zones: true, exclusionZones: true, entryZones: false },
+      limits: { maxRangeMeters: 6 },
+    })
+  );
+  assert.equal(normalized.limits.maxZones, DEFAULT_ZONE_LIMITS.maxZones);
+  assert.equal(normalized.limits.maxExclusionZones, DEFAULT_ZONE_LIMITS.maxExclusionZones);
+  assert.equal(normalized.limits.maxEntryZones, 0);
+  // Unrelated limits survive normalisation.
+  assert.equal(normalized.limits.maxRangeMeters, 6);
+});
+
+test('normalising leaves an already-consistent profile alone', () => {
+  const normalized = normalizeDeviceProfile(ep1);
+  assert.deepEqual(normalized.limits, {
+    maxZones: 0,
+    maxExclusionZones: 0,
+    maxEntryZones: 0,
+    maxRangeMeters: 25,
+  });
+});

--- a/everything-presence-mmwave-configurator/backend/src/domain/deviceProfiles.ts
+++ b/everything-presence-mmwave-configurator/backend/src/domain/deviceProfiles.ts
@@ -11,6 +11,75 @@ export interface DeviceProfileLimits {
   fieldOfViewDegrees?: number;
 }
 
+/** The capability flags that decide whether a zone type exists at all. */
+export interface ZoneCapabilityFlags {
+  zones?: boolean;
+  exclusionZones?: boolean;
+  entryZones?: boolean;
+  polygonZones?: boolean;
+}
+
+export interface ResolvedZoneLimits {
+  maxZones: number;
+  maxExclusionZones: number;
+  maxEntryZones: number;
+}
+
+/**
+ * Slot counts assumed when a profile says nothing at all about a zone type -
+ * the legacy Everything Presence Lite shape.
+ *
+ * These apply only in the absence of both a capability flag and a limit. A
+ * profile that declares `zones: false` resolves to zero slots of every kind,
+ * so a missing limit can never be read as "two".
+ */
+export const DEFAULT_ZONE_LIMITS: ResolvedZoneLimits = {
+  maxZones: 4,
+  maxExclusionZones: 2,
+  maxEntryZones: 2,
+};
+
+const readZoneCapabilities = (capabilities: unknown): ZoneCapabilityFlags => {
+  if (!capabilities || typeof capabilities !== 'object') return {};
+  return capabilities as ZoneCapabilityFlags;
+};
+
+const resolveLimit = (value: unknown, supported: boolean | undefined, fallback: number): number => {
+  // The capability is authoritative: an unsupported feature has no slots,
+  // whatever the limits block claims.
+  if (supported === false) return 0;
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+    return Math.floor(value);
+  }
+  return fallback;
+};
+
+/**
+ * How many zones of each type a profile allows.
+ *
+ * Exclusion and entry zones inherit a `zones: false` capability, so a
+ * distance-only sensor cannot acquire them by omitting a limit.
+ */
+export const resolveZoneLimits = (
+  profile: Pick<DeviceProfile, 'capabilities' | 'limits'> | null | undefined
+): ResolvedZoneLimits => {
+  const capabilities = readZoneCapabilities(profile?.capabilities);
+  const limits = profile?.limits ?? {};
+  return {
+    maxZones: resolveLimit(limits.maxZones, capabilities.zones, DEFAULT_ZONE_LIMITS.maxZones),
+    maxExclusionZones: resolveLimit(
+      limits.maxExclusionZones,
+      capabilities.exclusionZones ?? capabilities.zones,
+      DEFAULT_ZONE_LIMITS.maxExclusionZones
+    ),
+    maxEntryZones: resolveLimit(
+      limits.maxEntryZones,
+      capabilities.entryZones ?? capabilities.zones,
+      DEFAULT_ZONE_LIMITS.maxEntryZones
+    ),
+  };
+};
+
 /**
  * Entity category for classification and dynamic loading.
  */
@@ -105,6 +174,32 @@ export interface DeviceProfile {
   };
 }
 
+/**
+ * Fill in a profile's zone limits once, at load time, so no consumer has to
+ * guess a default for a missing key. A profile whose limits contradict its
+ * capabilities is corrected here and logged, since that is a packaging mistake
+ * rather than a runtime condition.
+ */
+export const normalizeDeviceProfile = (profile: DeviceProfile): DeviceProfile => {
+  const resolved = resolveZoneLimits(profile);
+  const declared = profile.limits ?? {};
+
+  for (const key of ['maxZones', 'maxExclusionZones', 'maxEntryZones'] as const) {
+    const declaredValue = declared[key];
+    if (typeof declaredValue === 'number' && declaredValue !== resolved[key]) {
+      logger.warn(
+        { profile: profile.id, limit: key, declared: declaredValue, applied: resolved[key] },
+        'Device profile limit contradicts its capabilities; using the capability'
+      );
+    }
+  }
+
+  return {
+    ...profile,
+    limits: { ...declared, ...resolved },
+  };
+};
+
 export class DeviceProfileLoader {
   private readonly dir: string;
 
@@ -125,7 +220,7 @@ export class DeviceProfileLoader {
       try {
         const raw = fs.readFileSync(fullPath, 'utf-8');
         const parsed = JSON.parse(raw) as DeviceProfile;
-        return [parsed];
+        return [normalizeDeviceProfile(parsed)];
       } catch (error) {
         logger.warn({ file: fullPath, error }, 'Failed to parse device profile');
         return [];

--- a/everything-presence-mmwave-configurator/backend/src/routes/devices.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/devices.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { DeviceDiscoveryService } from '../domain/deviceDiscovery';
-import { DeviceProfileLoader } from '../domain/deviceProfiles';
+import { DeviceProfileLoader, resolveZoneLimits } from '../domain/deviceProfiles';
 import type { IHaReadTransport } from '../ha/readTransport';
 import type { IHaWriteClient } from '../ha/writeClient';
 import { ZoneWriter } from '../ha/zoneWriter';
@@ -50,6 +50,46 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
   };
   const hasRuntimeMappings = (deviceId: string, entityMappings?: EntityMappings): boolean =>
     deviceMappingStorage.hasMapping(deviceId) || !!entityMappings;
+  /**
+   * Split a zone payload into what this profile can hold and what it cannot.
+   *
+   * A zone type the profile has no slots for must never reach the device,
+   * whichever client asked: a distance-only sensor (EP1) has no zone, exclusion
+   * or entry entities to write to. Such zones are dropped rather than failing
+   * the whole request, so a legacy room that still carries them can still save
+   * everything else; the caller reports the drop as a warning.
+   */
+  const partitionZonesBySupport = <T extends { id?: string; type?: string; enabled?: boolean }>(
+    profile: Parameters<typeof resolveZoneLimits>[0],
+    zones: T[] | undefined
+  ): { supported: T[]; unsupported: T[] } => {
+    const limits = resolveZoneLimits(profile);
+    const maxByType: Record<string, number> = {
+      regular: limits.maxZones,
+      exclusion: limits.maxExclusionZones,
+      entry: limits.maxEntryZones,
+    };
+    const supported: T[] = [];
+    const unsupported: T[] = [];
+    for (const zone of zones ?? []) {
+      // Only known types can be judged; anything else is left to the writer.
+      if (maxByType[zone?.type ?? 'regular'] === 0) {
+        unsupported.push(zone);
+      } else {
+        supported.push(zone);
+      }
+    }
+    return { supported, unsupported };
+  };
+
+  const unsupportedZoneWarnings = (
+    unsupported: Array<{ id?: string; type?: string }>
+  ): Array<{ description: string; error: string }> =>
+    unsupported.map((zone) => ({
+      description: `Skipped ${zone.type ?? 'regular'} zone ${zone.id ?? ''}`.trim(),
+      error: 'This device profile does not support this zone type',
+    }));
+
   const getDeviceFirmwareVersion = async (deviceId: string): Promise<string | undefined> => {
 
     try {
@@ -149,10 +189,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
           return res.status(404).json({ message: 'Profile not found' });
         }
 
-        const limits = profile.limits ?? {};
-        const maxZones = limits.maxZones ?? 4;
-        const maxExclusion = limits.maxExclusionZones ?? 2;
-        const maxEntry = limits.maxEntryZones ?? 2;
+        const { maxZones, maxExclusionZones: maxExclusion, maxEntryZones: maxEntry } = resolveZoneLimits(profile);
         const requiredZones = Math.min(requestedRegularCount ?? maxZones, maxZones);
         const requiredExclusions = Math.min(requestedExclusionCount ?? maxExclusion, maxExclusion);
         const requiredEntries = Math.min(requestedEntryCount ?? maxEntry, maxEntry);
@@ -516,9 +553,10 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
         }
       };
 
-      addPolygonAvailability('polygon', 'polygonZoneEntities', 'Zone', profile.limits?.maxZones ?? 4);
-      addPolygonAvailability('polygonExclusion', 'polygonExclusionEntities', 'Exclusion', profile.limits?.maxExclusionZones ?? 2);
-      addPolygonAvailability('polygonEntry', 'polygonEntryEntities', 'Entry', profile.limits?.maxEntryZones ?? 2);
+      const availabilityZoneLimits = resolveZoneLimits(profile);
+      addPolygonAvailability('polygon', 'polygonZoneEntities', 'Zone', availabilityZoneLimits.maxZones);
+      addPolygonAvailability('polygonExclusion', 'polygonExclusionEntities', 'Exclusion', availabilityZoneLimits.maxExclusionZones);
+      addPolygonAvailability('polygonEntry', 'polygonEntryEntities', 'Entry', availabilityZoneLimits.maxEntryZones);
 
       const zoneEntityIds = Array.from(
         new Set([
@@ -703,9 +741,20 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
       return res.status(400).json({ message: 'Profile does not define zones' });
     }
 
+    const { supported: writableZones, unsupported: skippedZones } = partitionZonesBySupport(profile, zones);
+    if (skippedZones.length > 0) {
+      logger.warn(
+        { deviceId, profileId, skipped: skippedZones.map((zone) => zone.id) },
+        'Dropped zones the device profile does not support'
+      );
+    }
+
     try {
-      const result = await zoneWriter.applyZones(zoneMap, zones, undefined, entityMappings, deviceId);
-      return res.json({ ok: result.ok, warnings: result.failures });
+      const result = await zoneWriter.applyZones(zoneMap, writableZones, undefined, entityMappings, deviceId);
+      return res.json({
+        ok: result.ok,
+        warnings: [...(result.failures ?? []), ...unsupportedZoneWarnings(skippedZones)],
+      });
     } catch (error) {
       logger.error({ error }, 'Failed to apply zones');
       return res.status(500).json({ message: 'Failed to apply zones' });
@@ -980,8 +1029,18 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
 
     const entityMap = profile.entityMap as any;
 
+    const { supported: writableZones, unsupported: skippedZones } = partitionZonesBySupport(profile, zones);
+    if (skippedZones.length > 0) {
+      logger.warn(
+        { deviceId, profileId, skipped: skippedZones.map((zone) => zone.id) },
+        'Dropped polygon zones the device profile does not support'
+      );
+    }
+
     try {
-      const warnings: Array<{ entityId?: string; description: string; error: string }> = [];
+      const warnings: Array<{ entityId?: string; description: string; error: string }> = [
+        ...unsupportedZoneWarnings(skippedZones),
+      ];
 
       const resolvePolygonEntity = (
         type: 'polygon' | 'polygonExclusion' | 'polygonEntry',
@@ -1006,7 +1065,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
       const polygonExclusionMap = entityMap?.polygonExclusionEntities as Record<string, string> | undefined;
       const polygonEntryMap = entityMap?.polygonEntryEntities as Record<string, string> | undefined;
 
-      const resolvedEntities = (zones ?? []).map((zone) => {
+      const resolvedEntities = writableZones.map((zone) => {
         let key = '';
         let template: string | undefined;
         let type: 'polygon' | 'polygonExclusion' | 'polygonEntry' = 'polygon';
@@ -1089,7 +1148,7 @@ export const createDevicesRouter = (deps: DevicesRouterDependencies): Router => 
         }
       }
 
-      const result = await zoneWriter.applyPolygonZones(entityMap, zones ?? [], undefined, entityMappings, deviceId);
+      const result = await zoneWriter.applyPolygonZones(entityMap, writableZones, undefined, entityMappings, deviceId);
       const combinedWarnings = [...warnings, ...result.failures];
       return res.json({ ok: result.ok, warnings: combinedWarnings });
     } catch (error) {

--- a/everything-presence-mmwave-configurator/backend/src/routes/zoneBackups.ts
+++ b/everything-presence-mmwave-configurator/backend/src/routes/zoneBackups.ts
@@ -5,6 +5,7 @@ import { ZoneWriter } from '../ha/zoneWriter';
 import type { IHaReadTransport } from '../ha/readTransport';
 import type { IHaWriteClient } from '../ha/writeClient';
 import type { DeviceProfileLoader } from '../domain/deviceProfiles';
+import { resolveZoneLimits } from '../domain/deviceProfiles';
 import { zoneBackupStorage } from '../config/zoneBackupStorage';
 import { deviceMappingStorage } from '../config/deviceMappingStorage';
 import { deviceEntityService } from '../domain/deviceEntityService';
@@ -245,10 +246,7 @@ export const createZoneBackupsRouter = (deps: ZoneBackupsRouterDependencies): Ro
       return res.status(409).json({ message: 'Device mapping not found. Run entity re-sync to create mappings.', code: 'MAPPING_NOT_FOUND' });
     }
 
-    const limits = profile.limits ?? {};
-    const maxZones = limits.maxZones ?? 4;
-    const maxExclusion = limits.maxExclusionZones ?? 2;
-    const maxEntry = limits.maxEntryZones ?? 2;
+    const { maxZones, maxExclusionZones: maxExclusion, maxEntryZones: maxEntry } = resolveZoneLimits(profile);
 
     const regularPolygonZones = sortPolygonZonesByIndex(
       backup.zones.filter((zone): zone is ZonePolygon => zone.type === 'regular' && isZonePolygon(zone) && isValidPolygon(zone.vertices))

--- a/everything-presence-mmwave-configurator/config/device-profiles/everything_presence_one.json
+++ b/everything-presence-mmwave-configurator/config/device-profiles/everything_presence_one.json
@@ -22,6 +22,8 @@
   },
   "limits": {
     "maxZones": 0,
+    "maxExclusionZones": 0,
+    "maxEntryZones": 0,
     "maxRangeMeters": 25,
     "fieldOfViewDegrees": 120
   },

--- a/everything-presence-mmwave-configurator/frontend/package.json
+++ b/everything-presence-mmwave-configurator/frontend/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",
-		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts src/utils/polygonVertices.test.ts src/utils/roomHistory.test.ts src/utils/roomSelection.test.ts src/utils/roomBuilderSelection.test.ts src/utils/lockState.test.ts src/utils/roomRotation.test.ts src/utils/doorGeometry.test.ts src/utils/canvasLayers.test.ts src/utils/tooltipPosition.test.ts",
+		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts src/utils/polygonVertices.test.ts src/utils/roomHistory.test.ts src/utils/roomSelection.test.ts src/utils/roomBuilderSelection.test.ts src/utils/lockState.test.ts src/utils/roomRotation.test.ts src/utils/doorGeometry.test.ts src/utils/canvasLayers.test.ts src/utils/tooltipPosition.test.ts src/utils/zoneCapabilities.test.ts",
 		"preview": "vite preview",
 		"format": "npx @biomejs/biome format",
 		"format:fix": "npx @biomejs/biome format --write",

--- a/everything-presence-mmwave-configurator/frontend/src/App.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/App.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { fetchDevices, fetchProfiles, fetchSettings, updateSettings, ingressAware } from './api/client';
 import { createRoom, fetchRooms } from './api/rooms';
-import { DiscoveredDevice, RoomConfig, LiveState, EntityMappings } from './api/types';
+import { DiscoveredDevice, DeviceProfile, RoomConfig, LiveState, EntityMappings } from './api/types';
+import { roomSupportsZoneEditing } from './utils/zoneCapabilities';
 import { ZoneEditorPage } from './pages/ZoneEditorPage';
 import { RoomBuilderPage } from './pages/RoomBuilderPage';
 import { WizardPage } from './pages/WizardPage';
@@ -18,7 +19,7 @@ const Card = ({ title, children }: { title: string; children: React.ReactNode })
 
 function App() {
   const [devices, setDevices] = useState<DiscoveredDevice[]>([]);
-  const [profiles, setProfiles] = useState<{ id: string; label: string }[]>([]);
+  const [profiles, setProfiles] = useState<DeviceProfile[]>([]);
   const [rooms, setRooms] = useState<RoomConfig[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -101,6 +102,24 @@ function App() {
     () => profiles.find((p) => p.id === selectedProfileId),
     [profiles, selectedProfileId]
   );
+
+  // The Zone Editor is gated on the *room's* device, not on the profile picker:
+  // a room whose sensor cannot detect zones (the Everything Presence One) has
+  // nothing to configure there. Guarding the view itself rather than each menu
+  // item means no entry point - dashboard, Room Builder, wizard or a stale
+  // view - can slip past the restriction. It is judged on the room's own
+  // profile only, so a room not yet bound to a device profile is never blocked
+  // by whatever the profile picker happens to be showing.
+  const zoneEditingSupported = useMemo(
+    () => roomSupportsZoneEditing(selectedRoom, profiles),
+    [profiles, selectedRoom]
+  );
+
+  useEffect(() => {
+    if (view === 'zoneEditor' && !zoneEditingSupported) {
+      setView('dashboard');
+    }
+  }, [view, zoneEditingSupported]);
 
   const refreshLiveState = React.useCallback(async () => {
     if (!selectedRoom || !selectedRoom.deviceId || !selectedProfile) {
@@ -644,6 +663,18 @@ function App() {
               setSelectedRoomId(roomId);
               if (profileId) setSelectedProfileId(profileId);
             }}
+            onGoRoomBuilder={(roomId, profileId) => {
+              setSelectedRoomId(roomId);
+              if (profileId) setSelectedProfileId(profileId);
+              setView('roomBuilder');
+            }}
+            onGoZoneEditor={(roomId, profileId) => {
+              setSelectedRoomId(roomId);
+              if (profileId) setSelectedProfileId(profileId);
+              // The guard above still has the final say; sending an unsupported
+              // room here simply lands on the dashboard.
+              setView('zoneEditor');
+            }}
             onRoomUpdate={(updatedRoom) => {
               setRooms((prev) => prev.map((r) => (r.id === updatedRoom.id ? updatedRoom : r)));
             }}
@@ -684,7 +715,8 @@ function App() {
             targetPositions={targetPositions}
           />
         )}
-        {view === 'zoneEditor' && (
+        {view === 'zoneEditor' && !zoneEditingSupported && dashboard}
+        {view === 'zoneEditor' && zoneEditingSupported && (
           <ZoneEditorPage
             onNavigate={(targetView) => {
               if (targetView === 'wizard') {

--- a/everything-presence-mmwave-configurator/frontend/src/components/FirmwareUpdateSection.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/FirmwareUpdateSection.tsx
@@ -40,6 +40,7 @@ import { DeviceMapping, discoverAndSaveMapping } from '../api/deviceMappings';
 import { fetchPolygonZonesFromDevice } from '../api/zones';
 import { compareVersions, getZoneMigrationThreshold, requiresZoneMigration } from '../utils/firmware';
 import { resolveEntityPrefix } from '../utils/entityUtils';
+import { resolveZoneLimits } from '../utils/zoneCapabilities';
 import polygonMigrationGraphic from '../assets/polygon-migration.png';
 
 interface FirmwareUpdateSectionProps {
@@ -1032,10 +1033,10 @@ export const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({
   const isBackupPolygon = (zone: Zone): zone is ZonePolygon =>
     typeof zone === 'object' && zone !== null && 'vertices' in zone;
 
-  const buildExpectedPolygons = (backup: ZoneBackup, limits: DeviceProfile['limits'] | undefined): ZonePolygon[] => {
-    const maxZones = limits?.maxZones ?? 4;
-    const maxExclusion = limits?.maxExclusionZones ?? 2;
-    const maxEntry = limits?.maxEntryZones ?? 2;
+  const buildExpectedPolygons = (backup: ZoneBackup, profile: DeviceProfile | null | undefined): ZonePolygon[] => {
+    // Slot counts come from the profile's capabilities as well as its limits, so
+    // a device that cannot hold entry zones never expects any back.
+    const { maxZones, maxExclusionZones: maxExclusion, maxEntryZones: maxEntry } = resolveZoneLimits(profile);
 
     const regularPolygonZones = sortZonesByIndex(
       backup.zones.filter((zone): zone is ZonePolygon => zone.type === 'regular' && isBackupPolygon(zone))
@@ -1113,7 +1114,7 @@ export const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({
     }
 
     const profile = profiles.find((item) => item.id === context.profileId) ?? null;
-    const expectedPolygons = buildExpectedPolygons(backup, profile?.limits);
+    const expectedPolygons = buildExpectedPolygons(backup, profile);
     if (expectedPolygons.length === 0) {
       return { status: 'success', message: 'No zones to verify.' };
     }
@@ -1963,7 +1964,7 @@ export const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({
         const backupId = migrationBackupId ?? lastBackupId ?? latestBackup?.id ?? null;
         const backup = backupId ? zoneBackups.find((item) => item.id === backupId) ?? null : null;
         const profile = profiles.find((item) => item.id === profileId) ?? null;
-        const expected = backup ? buildExpectedPolygons(backup, profile?.limits) : [];
+        const expected = backup ? buildExpectedPolygons(backup, profile) : [];
         const regularCount = expected.filter((zone) => zone.type === 'regular').length;
         const exclusionCount = expected.filter((zone) => zone.type === 'exclusion').length;
         const entryCount = expected.filter((zone) => zone.type === 'entry').length;

--- a/everything-presence-mmwave-configurator/frontend/src/components/ZoneEditor.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/ZoneEditor.tsx
@@ -6,13 +6,23 @@ interface ZoneEditorProps {
   zone: ZoneRect;
   onChange: (zone: ZoneRect) => void;
   onDelete?: (id: string) => void;
+  /**
+   * Zone types the device supports. Omit to offer all three. A type the device
+   * cannot hold is never offered, so a zone cannot be retyped into one.
+   */
+  allowedTypes?: ZoneRect['type'][];
 }
 
 const zoneTypes: ZoneRect['type'][] = ['regular', 'exclusion', 'entry'];
 
-export const ZoneEditor: React.FC<ZoneEditorProps> = ({ zone, onChange, onDelete }) => {
+export const ZoneEditor: React.FC<ZoneEditorProps> = ({ zone, onChange, onDelete, allowedTypes }) => {
   const update = (patch: Partial<ZoneRect>) => onChange({ ...zone, ...patch });
   const helpId = (field: string) => `zone-${zone.id.replace(/[^a-zA-Z0-9_-]/g, '-')}-${field}-help`;
+  // The zone's current type stays selectable even when unsupported, so existing
+  // configuration is shown honestly rather than silently retyped.
+  const selectableTypes = allowedTypes?.length
+    ? zoneTypes.filter((type) => allowedTypes.includes(type) || type === zone.type)
+    : zoneTypes;
 
   return (
     <div className="space-y-2 rounded-lg border border-slate-700/50 bg-slate-900/60 p-3">
@@ -25,7 +35,7 @@ export const ZoneEditor: React.FC<ZoneEditorProps> = ({ zone, onChange, onDelete
           value={zone.type}
           onChange={(e) => update({ type: e.target.value as ZoneRect['type'] })}
         >
-          {zoneTypes.map((t) => (
+          {selectableTypes.map((t) => (
             <option key={t} value={t}>
               {t}
             </option>

--- a/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
@@ -26,6 +26,7 @@ import { getInstallationAngleSuggestion } from '../utils/rotationSuggestion';
 import { useDeviceMappings } from '../contexts/DeviceMappingsContext';
 import { getDeviceIconUrl } from '../utils/deviceIcon';
 import { resolveCoverageFov } from '../utils/coverage';
+import { roomSupportsZoneEditing } from '../utils/zoneCapabilities';
 import { formatLengthLabel } from '../utils/lengthLabels';
 import { formatSnapPresetLabel } from '../utils/snapLabels';
 import {
@@ -471,6 +472,15 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     const caps = selectedProfile?.capabilities as { tracking?: boolean; distanceOnlyTracking?: boolean } | undefined;
     return Boolean(caps?.tracking) && !caps?.distanceOnlyTracking;
   }, [selectedProfile]);
+
+  // Room Builder supports every device, but the Zone Editor does not: a
+  // distance-only sensor (EP1) has no zones to draw, so the menu entry is
+  // greyed out here exactly as it is on the live dashboard.
+  const zoneEditingSupported = useMemo(
+    () => roomSupportsZoneEditing(selectedRoom, profiles),
+    [profiles, selectedRoom],
+  );
+  const zoneEditorDisabledReason = 'Zone editor is not available for EP1 (distance-only tracking)';
 
   // Device mappings context for entity resolution
   const { getEntityId } = useDeviceMappings();
@@ -2192,12 +2202,19 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                   </button>
                   <button
                     onClick={() => {
+                      if (!zoneEditingSupported) return;
                       setShowNavMenu(false);
                       navigateTo('zoneEditor');
                     }}
-                    className="w-full text-left px-4 py-2.5 text-sm font-medium text-slate-100 rounded-lg transition-all hover:bg-aqua-600/20 hover:text-aqua-400 active:scale-95"
+                    disabled={!zoneEditingSupported}
+                    className={`w-full text-left px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
+                      zoneEditingSupported
+                        ? 'text-slate-100 hover:bg-aqua-600/20 hover:text-aqua-400 active:scale-95'
+                        : 'text-slate-500 cursor-not-allowed'
+                    }`}
+                    title={zoneEditingSupported ? '' : zoneEditorDisabledReason}
                   >
-                    📐 Zone Editor
+                    📐 Zone Editor {!zoneEditingSupported && '(Not Available)'}
                   </button>
                   <button
                     onClick={() => {
@@ -3896,12 +3913,15 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
               <button
                 type="button"
                 onClick={() => {
+                  if (!zoneEditingSupported) return;
                   setActiveMobileSheet(null);
                   navigateTo('zoneEditor');
                 }}
-                className="w-full rounded-lg border border-slate-700 bg-slate-800 px-4 py-3 text-left text-sm font-semibold text-slate-100"
+                disabled={!zoneEditingSupported}
+                title={zoneEditingSupported ? '' : zoneEditorDisabledReason}
+                className="w-full rounded-lg border border-slate-700 bg-slate-800 px-4 py-3 text-left text-sm font-semibold text-slate-100 disabled:opacity-40 disabled:cursor-not-allowed"
               >
-                Zone Editor
+                Zone Editor {!zoneEditingSupported && '(Not Available)'}
               </button>
               <button
                 type="button"

--- a/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
@@ -40,6 +40,7 @@ import { resolveCoverageFov, resolveTrackingCoverageFov } from '../utils/coverag
 import { formatSnapPresetLabel } from '../utils/snapLabels';
 import { usesPolygonOnlyZones } from '../utils/firmware';
 import { resolveEntityPrefix } from '../utils/entityUtils';
+import { resolveZoneLimits, supportsZoneEditing } from '../utils/zoneCapabilities';
 
 interface WizardPageProps {
   devices: DiscoveredDevice[];
@@ -50,8 +51,8 @@ interface WizardPageProps {
   onBack?: () => void;
   onCreateRoom: (name: string, deviceId: string | null, profileId: string | null, entityMappings?: EntityMappings) => Promise<RoomConfig>;
   onSelectRoom: (roomId: string | null, profileId?: string | null) => void;
-  onGoRoomBuilder: (roomId: string | null, profileId?: string | null) => void;
-  onGoZoneEditor: (roomId: string | null, profileId?: string | null) => void;
+  onGoRoomBuilder?: (roomId: string | null, profileId?: string | null) => void;
+  onGoZoneEditor?: (roomId: string | null, profileId?: string | null) => void;
   onComplete: () => void;
   onRoomUpdate?: (room: RoomConfig) => void;
   initialStep?: string;
@@ -436,7 +437,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
     const base: StepKey[] = ['device', 'entityDiscovery', 'roomChoice'];
 
     // Check if current profile supports zones
-    const supportsZones = currentProfile?.capabilities?.zones !== false;
+    const supportsZones = supportsZoneEditing(currentProfile);
 
     if (roomPath === 'skip') {
       // Skip room setup: device → entityDiscovery → roomChoice → (zones if supported) → finish
@@ -467,14 +468,26 @@ export const WizardPage: React.FC<WizardPageProps> = ({
   const currentStep = steps[stepIndex] ?? 'device';
   const isRoomMode = roomPath !== 'skip';
 
+  // Zone slot counts for the selected device; a profile that declares a zone
+  // type unsupported resolves to zero slots.
+  const zoneLimits = useMemo(() => resolveZoneLimits(currentProfile), [currentProfile]);
+  const zoneEditingSupported = useMemo(() => supportsZoneEditing(currentProfile), [currentProfile]);
+  const allowedZoneTypes = useMemo(() => {
+    const types: ZoneRect['type'][] = [];
+    if (zoneLimits.maxZones > 0) types.push('regular');
+    if (zoneLimits.maxExclusionZones > 0) types.push('exclusion');
+    if (zoneLimits.maxEntryZones > 0) types.push('entry');
+    return types;
+  }, [zoneLimits]);
+
   // Generate all possible zone slots based on profile limits
   const allPossibleZones = useMemo(() => {
     if (!currentProfile) return [];
-    const limits = currentProfile.limits;
+    const limits = zoneLimits;
     const zones: ZoneRect[] = [];
 
     // Regular zones
-    for (let i = 1; i <= (limits.maxZones ?? 4); i++) {
+    for (let i = 1; i <= limits.maxZones; i++) {
       zones.push({
         id: `Zone ${i}`,
         type: 'regular',
@@ -487,7 +500,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
     }
 
     // Exclusion zones
-    for (let i = 1; i <= (limits.maxExclusionZones ?? 2); i++) {
+    for (let i = 1; i <= limits.maxExclusionZones; i++) {
       zones.push({
         id: `Exclusion ${i}`,
         type: 'exclusion',
@@ -500,7 +513,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
     }
 
     // Entry zones
-    for (let i = 1; i <= (limits.maxEntryZones ?? 2); i++) {
+    for (let i = 1; i <= limits.maxEntryZones; i++) {
       zones.push({
         id: `Entry ${i}`,
         type: 'entry',
@@ -513,7 +526,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
     }
 
     return zones;
-  }, [currentProfile]);
+  }, [currentProfile, zoneLimits]);
 
   // Merge device zones with all possible zones
   const displayZones = useMemo(() => {
@@ -3018,6 +3031,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
                         <ZoneEditor
                           key={zone.id}
                           zone={zone}
+                          allowedTypes={allowedZoneTypes}
                           onChange={(updated) => {
                             const newDisplayZones = displayZones.map((z) =>
                               z.id === updated.id ? { ...updated, enabled: true } : z
@@ -4184,14 +4198,18 @@ export const WizardPage: React.FC<WizardPageProps> = ({
 
           {/* Action Buttons */}
           <div className="flex flex-col sm:flex-row gap-3">
-            <button
-              className="flex-1 rounded-xl border border-slate-700/50 bg-slate-900/90 backdrop-blur px-6 py-3 text-sm font-semibold text-slate-100 shadow-lg transition-all hover:border-slate-600 hover:bg-slate-800 hover:shadow-xl active:scale-95"
-              onClick={() => {
-                onGoZoneEditor(selectedRoom?.id ?? null, selectedRoom?.profileId ?? profileId ?? null);
-              }}
-            >
-              Continue to Zone Editor
-            </button>
+            {/* A distance-only device (EP1) has no zones to edit, so it is never
+                offered the Zone Editor as a next step. */}
+            {zoneEditingSupported && onGoZoneEditor && (
+              <button
+                className="flex-1 rounded-xl border border-slate-700/50 bg-slate-900/90 backdrop-blur px-6 py-3 text-sm font-semibold text-slate-100 shadow-lg transition-all hover:border-slate-600 hover:bg-slate-800 hover:shadow-xl active:scale-95"
+                onClick={() => {
+                  onGoZoneEditor(selectedRoom?.id ?? null, selectedRoom?.profileId ?? profileId ?? null);
+                }}
+              >
+                Continue to Zone Editor
+              </button>
+            )}
             <button
               className="flex-1 rounded-xl bg-gradient-to-r from-emerald-600 to-emerald-500 px-6 py-3 text-sm font-bold text-white shadow-lg shadow-emerald-500/30 transition-all hover:shadow-xl hover:shadow-emerald-500/40 active:scale-95"
               onClick={() => {

--- a/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
@@ -43,6 +43,7 @@ import { useIsMobileCanvas } from '../hooks/useMediaQuery';
 import { useDeviceMapping, useDeviceMappings } from '../contexts/DeviceMappingsContext';
 import { getDeviceIconUrl } from '../utils/deviceIcon';
 import { resolveCoverageFov, resolveTrackingCoverageFov } from '../utils/coverage';
+import { resolveZoneLimits, roomSupportsZoneEditing } from '../utils/zoneCapabilities';
 import { usesPolygonOnlyZones } from '../utils/firmware';
 import { resolveEntityPrefix } from '../utils/entityUtils';
 import { MIN_POLYGON_VERTICES, canDeleteVertex, deleteVertex } from '../utils/polygonVertices';
@@ -258,14 +259,25 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
   const installationAngle =
     typeof liveState?.config?.installationAngle === 'number' ? liveState.config.installationAngle : 0;
 
+  // Zone slot counts for the selected device. A profile that declares a zone
+  // type unsupported resolves to zero slots, so an EP1 offers none at all.
+  const zoneLimits = useMemo(() => resolveZoneLimits(selectedProfile), [selectedProfile]);
+
+  // Only rooms whose sensor can actually hold zones may be edited here; an EP1
+  // room must not be reachable through the room selector either.
+  const zoneCapableRooms = useMemo(
+    () => rooms.filter((room) => roomSupportsZoneEditing(room, profiles)),
+    [rooms, profiles],
+  );
+
   // Generate all possible zone slots based on profile limits
   const allPossibleZones = useMemo(() => {
     if (!selectedProfile) return [];
-    const limits = selectedProfile.limits;
+    const limits = zoneLimits;
     const zones: ZoneRect[] = [];
 
     // Regular zones
-    for (let i = 1; i <= (limits.maxZones ?? 4); i++) {
+    for (let i = 1; i <= limits.maxZones; i++) {
       zones.push({
         id: `Zone ${i}`,
         type: 'regular',
@@ -278,7 +290,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
     }
 
     // Exclusion zones
-    for (let i = 1; i <= (limits.maxExclusionZones ?? 2); i++) {
+    for (let i = 1; i <= limits.maxExclusionZones; i++) {
       zones.push({
         id: `Exclusion ${i}`,
         type: 'exclusion',
@@ -291,7 +303,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
     }
 
     // Entry zones
-    for (let i = 1; i <= (limits.maxEntryZones ?? 2); i++) {
+    for (let i = 1; i <= limits.maxEntryZones; i++) {
       zones.push({
         id: `Entry ${i}`,
         type: 'entry',
@@ -304,7 +316,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
     }
 
     return zones;
-  }, [selectedProfile]);
+  }, [selectedProfile, zoneLimits]);
 
   // Merge device zones with all possible zones, applying labels from device mapping
   const displayZones = useMemo(() => {
@@ -432,17 +444,20 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
         setProfiles(profileRes.profiles);
         setRooms(roomRes.rooms);
 
-        const initialRoom =
-          (initialRoomId && roomRes.rooms.find((r) => r.id === initialRoomId)) || roomRes.rooms[0] || null;
+        // Never open on a room whose device has no zones (EP1): the editor has
+        // nothing to show for it, and it must not be reachable by defaulting.
+        const editableRooms = roomRes.rooms.filter((room) =>
+          roomSupportsZoneEditing(room, profileRes.profiles),
+        );
+
+        const requestedRoom = initialRoomId
+          ? editableRooms.find((r) => r.id === initialRoomId) ?? null
+          : null;
+        const initialRoom = requestedRoom || editableRooms[0] || null;
         if (initialRoom) {
           setSelectedRoomId(initialRoom.id);
           setSelectedZoneId(initialRoom.zones?.[0]?.id ?? null);
           if (initialRoom.profileId) setSelectedProfileId(initialRoom.profileId);
-        }
-
-        if (!initialRoom && !selectedRoomId && roomRes.rooms.length > 0) {
-          setSelectedRoomId(roomRes.rooms[0].id);
-          setSelectedZoneId(roomRes.rooms[0].zones?.[0]?.id ?? null);
         }
 
         if (!initialRoom?.profileId && !selectedProfileId && profileRes.profiles.length > 0) {
@@ -776,7 +791,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
         lateralMaxMm: Math.max(...lateralRangesMm.map((range) => range.max)),
         lateralBreakpointsMm: undefined,
         lateralRangesMm,
-        exclusionRangesMm: exclusionRangesMm.slice(0, selectedProfile?.limits.maxExclusionZones ?? 2),
+        exclusionRangesMm: exclusionRangesMm.slice(0, zoneLimits.maxExclusionZones),
       }, { persist: false });
       return;
     }
@@ -1459,12 +1474,15 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
   }, [isMobileCanvas]);
 
   const handleRoomSelection = useCallback((roomId: string | null) => {
-    setSelectedRoomId(roomId);
     const room = rooms.find((candidate) => candidate.id === roomId);
+    // Switching sideways onto a zone-less device (EP1) is not an edit this page
+    // can make sense of, so the selection is refused outright.
+    if (room && !roomSupportsZoneEditing(room, profiles)) return;
+    setSelectedRoomId(roomId);
     setSelectedZoneId(room?.zones?.[0]?.id ?? null);
     if (room?.profileId) setSelectedProfileId(room.profileId);
     onRoomChange?.(roomId, room?.profileId ?? selectedProfileId);
-  }, [onRoomChange, rooms, selectedProfileId]);
+  }, [onRoomChange, profiles, rooms, selectedProfileId]);
 
   const toggleMobileZoneList = () => {
     setShowSettings(false);
@@ -1616,13 +1634,13 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
               Menu
             </button>
           ) : null}
-          title={rooms.length > 0 ? (
+          title={zoneCapableRooms.length > 0 ? (
             <select
               className="w-full rounded-lg border border-slate-700 bg-slate-900 px-2 py-1.5 text-sm font-semibold text-slate-100 focus:border-aqua-500 focus:outline-none focus:ring-1 focus:ring-aqua-500/50"
               value={selectedRoomId ?? ''}
               onChange={(event) => handleRoomSelection(event.target.value || null)}
             >
-              {rooms.map((room) => (
+              {zoneCapableRooms.map((room) => (
                 <option key={room.id} value={room.id}>
                   {room.name}
                 </option>
@@ -1980,7 +1998,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
                 handleRoomSelection(e.target.value || null);
               }}
             >
-              {rooms.map((r) => (
+              {zoneCapableRooms.map((r) => (
                 <option key={r.id} value={r.id}>
                   {r.name}
                 </option>
@@ -2242,7 +2260,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
                         type="button"
                         onClick={() => {
                           const existing = ceilingSliceConfig.exclusionRangesMm ?? [];
-                          const maxExclusions = selectedProfile?.limits.maxExclusionZones ?? 2;
+                          const maxExclusions = zoneLimits.maxExclusionZones;
                           if (existing.length >= maxExclusions) return;
                           const width = Math.max(300, (ceilingSliceConfig.lateralMaxMm - ceilingSliceConfig.lateralMinMm) / 8);
                           const center = 0;
@@ -2253,10 +2271,10 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
                             ],
                           });
                         }}
-                        disabled={(ceilingSliceConfig.exclusionRangesMm?.length ?? 0) >= (selectedProfile?.limits.maxExclusionZones ?? 2)}
+                        disabled={(ceilingSliceConfig.exclusionRangesMm?.length ?? 0) >= zoneLimits.maxExclusionZones}
                         className="mt-3 w-full rounded-md border border-rose-500/50 bg-rose-600/20 px-3 py-2 text-xs font-semibold text-rose-100 transition-all hover:bg-rose-600/30 disabled:opacity-40 disabled:cursor-not-allowed"
                       >
-                        + Exclusion ({ceilingSliceConfig.exclusionRangesMm?.length ?? 0}/{selectedProfile?.limits.maxExclusionZones ?? 2})
+                        + Exclusion ({ceilingSliceConfig.exclusionRangesMm?.length ?? 0}/{zoneLimits.maxExclusionZones})
                       </button>
                     </div>
                   )}
@@ -2265,7 +2283,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
                     <button
                       onClick={() => {
                         const regularCount = polygonZones.filter(z => z.type === 'regular').length;
-                        if (regularCount >= (selectedProfile?.limits.maxZones ?? 4)) return;
+                        if (regularCount >= zoneLimits.maxZones) return;
                         const newZone: ZonePolygon = {
                           id: `Zone ${regularCount + 1}`,
                           type: 'regular',
@@ -2275,15 +2293,15 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
                         setPolygonZones([...polygonZones, newZone]);
                         setSelectedZoneId(newZone.id);
                       }}
-                      disabled={polygonZones.filter(z => z.type === 'regular').length >= (selectedProfile?.limits.maxZones ?? 4)}
+                      disabled={polygonZones.filter(z => z.type === 'regular').length >= zoneLimits.maxZones}
                       className="flex-1 rounded-lg border border-blue-500/50 bg-blue-600/20 px-3 py-2 text-xs font-semibold text-blue-100 transition-all hover:bg-blue-600/30 disabled:opacity-40 disabled:cursor-not-allowed"
                     >
-                      + Zone ({polygonZones.filter(z => z.type === 'regular').length}/{selectedProfile?.limits.maxZones ?? 4})
+                      + Zone ({polygonZones.filter(z => z.type === 'regular').length}/{zoneLimits.maxZones})
                     </button>
                     <button
                       onClick={() => {
                         const exclusionCount = polygonZones.filter(z => z.type === 'exclusion').length;
-                        if (exclusionCount >= (selectedProfile?.limits.maxExclusionZones ?? 2)) return;
+                        if (exclusionCount >= zoneLimits.maxExclusionZones) return;
                         const newZone: ZonePolygon = {
                           id: `Exclusion ${exclusionCount + 1}`,
                           type: 'exclusion',
@@ -2293,15 +2311,15 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
                         setPolygonZones([...polygonZones, newZone]);
                         setSelectedZoneId(newZone.id);
                       }}
-                      disabled={polygonZones.filter(z => z.type === 'exclusion').length >= (selectedProfile?.limits.maxExclusionZones ?? 2)}
+                      disabled={polygonZones.filter(z => z.type === 'exclusion').length >= zoneLimits.maxExclusionZones}
                       className="flex-1 rounded-lg border border-rose-500/50 bg-rose-600/20 px-3 py-2 text-xs font-semibold text-rose-100 transition-all hover:bg-rose-600/30 disabled:opacity-40 disabled:cursor-not-allowed"
                     >
-                      + Exclusion ({polygonZones.filter(z => z.type === 'exclusion').length}/{selectedProfile?.limits.maxExclusionZones ?? 2})
+                      + Exclusion ({polygonZones.filter(z => z.type === 'exclusion').length}/{zoneLimits.maxExclusionZones})
                     </button>
                     <button
                       onClick={() => {
                         const entryCount = polygonZones.filter(z => z.type === 'entry').length;
-                        if (entryCount >= (selectedProfile?.limits.maxEntryZones ?? 2)) return;
+                        if (entryCount >= zoneLimits.maxEntryZones) return;
                         const newZone: ZonePolygon = {
                           id: `Entry ${entryCount + 1}`,
                           type: 'entry',
@@ -2311,10 +2329,10 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
                         setPolygonZones([...polygonZones, newZone]);
                         setSelectedZoneId(newZone.id);
                       }}
-                      disabled={polygonZones.filter(z => z.type === 'entry').length >= (selectedProfile?.limits.maxEntryZones ?? 2)}
+                      disabled={polygonZones.filter(z => z.type === 'entry').length >= zoneLimits.maxEntryZones}
                       className="flex-1 rounded-lg border border-emerald-500/50 bg-emerald-600/20 px-3 py-2 text-xs font-semibold text-emerald-100 transition-all hover:bg-emerald-600/30 disabled:opacity-40 disabled:cursor-not-allowed"
                     >
-                      + Entry ({polygonZones.filter(z => z.type === 'entry').length}/{selectedProfile?.limits.maxEntryZones ?? 2})
+                      + Entry ({polygonZones.filter(z => z.type === 'entry').length}/{zoneLimits.maxEntryZones})
                     </button>
                   </div>}
 

--- a/everything-presence-mmwave-configurator/frontend/src/utils/zoneCapabilities.test.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/zoneCapabilities.test.ts
@@ -1,0 +1,120 @@
+// @ts-nocheck -- Node's built-in runner supplies these modules; frontend production types stay dependency-free.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  DEFAULT_ZONE_LIMITS,
+  getZoneCapabilities,
+  resolveZoneLimits,
+  roomSupportsZoneEditing,
+  supportsZoneEditing,
+} from './zoneCapabilities.ts';
+
+// Mirrors config/device-profiles/*.json
+const ep1 = {
+  id: 'everything_presence_one',
+  capabilities: { tracking: false, zones: false, exclusionZones: false, entryZones: false },
+  limits: { maxZones: 0, maxExclusionZones: 0, maxEntryZones: 0, maxRangeMeters: 25 },
+};
+
+const epLite = {
+  id: 'everything_presence_lite',
+  capabilities: { tracking: true, zones: true, exclusionZones: true, entryZones: true },
+  limits: { maxZones: 4, maxExclusionZones: 2, maxEntryZones: 2 },
+};
+
+const epPro = {
+  id: 'everything_presence_pro',
+  capabilities: { tracking: true, zones: true, exclusionZones: true, entryZones: false },
+  limits: { maxZones: 4, maxExclusionZones: 2, maxEntryZones: 0 },
+};
+
+test('EP1 has no zone slots of any kind', () => {
+  assert.deepEqual(resolveZoneLimits(ep1), {
+    maxZones: 0,
+    maxExclusionZones: 0,
+    maxEntryZones: 0,
+  });
+  assert.equal(supportsZoneEditing(ep1), false);
+});
+
+test('a profile that declares no zone support gets no slots even if its limits are missing', () => {
+  // The EP1 profile shipped without maxExclusionZones/maxEntryZones; the
+  // capability flags alone must be enough to keep both at zero.
+  const withoutLimits = { ...ep1, limits: { maxZones: 0, maxRangeMeters: 25 } };
+  assert.deepEqual(resolveZoneLimits(withoutLimits), {
+    maxZones: 0,
+    maxExclusionZones: 0,
+    maxEntryZones: 0,
+  });
+  assert.equal(supportsZoneEditing(withoutLimits), false);
+});
+
+test('zones: false also rules out exclusion and entry zones', () => {
+  const onlyZonesFlag = { id: 'x', capabilities: { zones: false }, limits: {} };
+  assert.deepEqual(resolveZoneLimits(onlyZonesFlag), {
+    maxZones: 0,
+    maxExclusionZones: 0,
+    maxEntryZones: 0,
+  });
+  assert.equal(supportsZoneEditing(onlyZonesFlag), false);
+});
+
+test('EP Lite keeps all four regular and two of each special zone', () => {
+  assert.deepEqual(resolveZoneLimits(epLite), {
+    maxZones: 4,
+    maxExclusionZones: 2,
+    maxEntryZones: 2,
+  });
+  assert.equal(supportsZoneEditing(epLite), true);
+});
+
+test('EP Pro supports zones and exclusions but no entry zones', () => {
+  assert.deepEqual(resolveZoneLimits(epPro), {
+    maxZones: 4,
+    maxExclusionZones: 2,
+    maxEntryZones: 0,
+  });
+  assert.equal(supportsZoneEditing(epPro), true);
+});
+
+test('a capability of false beats a non-zero limit', () => {
+  const contradictory = {
+    id: 'x',
+    capabilities: { zones: true, entryZones: false },
+    limits: { maxZones: 4, maxEntryZones: 2 },
+  };
+  assert.equal(resolveZoneLimits(contradictory).maxEntryZones, 0);
+});
+
+test('a profile that says nothing falls back to the legacy defaults', () => {
+  assert.deepEqual(resolveZoneLimits({ id: 'x' }), DEFAULT_ZONE_LIMITS);
+  assert.equal(supportsZoneEditing({ id: 'x' }), true);
+});
+
+test('an unknown profile is not blocked', () => {
+  assert.equal(supportsZoneEditing(null), true);
+  assert.equal(supportsZoneEditing(undefined), true);
+});
+
+test('a malformed capabilities block is ignored rather than trusted', () => {
+  assert.deepEqual(getZoneCapabilities({ capabilities: 'nonsense' }), {});
+  assert.deepEqual(resolveZoneLimits({ capabilities: 'nonsense' }), DEFAULT_ZONE_LIMITS);
+});
+
+test('negative and fractional limits are normalised', () => {
+  const odd = { id: 'x', capabilities: { zones: true }, limits: { maxZones: 2.7, maxExclusionZones: -3 } };
+  const limits = resolveZoneLimits(odd);
+  assert.equal(limits.maxZones, 2);
+  // A negative value is not a usable count, so the default applies.
+  assert.equal(limits.maxExclusionZones, DEFAULT_ZONE_LIMITS.maxExclusionZones);
+});
+
+test('a room is judged by the profile it points at', () => {
+  const profiles = [ep1, epLite];
+  assert.equal(roomSupportsZoneEditing({ profileId: 'everything_presence_one' }, profiles), false);
+  assert.equal(roomSupportsZoneEditing({ profileId: 'everything_presence_lite' }, profiles), true);
+  // A room with no profile, or one whose profile has not loaded, stays allowed.
+  assert.equal(roomSupportsZoneEditing({ profileId: null }, profiles), true);
+  assert.equal(roomSupportsZoneEditing({ profileId: 'not_loaded_yet' }, profiles), true);
+  assert.equal(roomSupportsZoneEditing(null, profiles), true);
+});

--- a/everything-presence-mmwave-configurator/frontend/src/utils/zoneCapabilities.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/zoneCapabilities.ts
@@ -1,0 +1,110 @@
+import type { DeviceProfileLimits } from '../api/types';
+
+/**
+ * Zone capabilities, resolved from a device profile.
+ *
+ * A profile describes what a device can do twice over: `capabilities` says
+ * whether a feature exists at all, `limits` says how many slots it has. The two
+ * must agree, and where they disagree the capability wins - a device that
+ * cannot detect zones has no zone slots, whatever the limits block happens to
+ * say.
+ *
+ * The defaults below only apply when a profile says *nothing* about a zone
+ * type: neither a capability flag nor a limit. That is the legacy
+ * EP Lite shape (4 zones / 2 exclusion / 2 entry). A profile that declares
+ * `zones: false` - the Everything Presence One - resolves to zero slots of
+ * every kind, so the Zone Editor has nothing to offer and every "+ Zone"
+ * button is disabled.
+ */
+
+export interface ZoneCapabilityFlags {
+  tracking?: boolean;
+  zones?: boolean;
+  exclusionZones?: boolean;
+  entryZones?: boolean;
+  polygonZones?: boolean;
+  distanceOnlyTracking?: boolean;
+}
+
+export interface ResolvedZoneLimits {
+  maxZones: number;
+  maxExclusionZones: number;
+  maxEntryZones: number;
+}
+
+/** Slot counts assumed when a profile declares neither capability nor limit. */
+export const DEFAULT_ZONE_LIMITS: ResolvedZoneLimits = {
+  maxZones: 4,
+  maxExclusionZones: 2,
+  maxEntryZones: 2,
+};
+
+/** The part of a `DeviceProfile` these helpers need; keeps them usable on partial data. */
+type ProfileLike = { id?: string; capabilities?: unknown; limits?: DeviceProfileLimits } | null | undefined;
+
+/** Read the capability block off a profile without trusting its shape. */
+export const getZoneCapabilities = (profile: ProfileLike): ZoneCapabilityFlags => {
+  const capabilities = profile?.capabilities;
+  if (!capabilities || typeof capabilities !== 'object') return {};
+  return capabilities as ZoneCapabilityFlags;
+};
+
+const resolveLimit = (value: unknown, supported: boolean | undefined, fallback: number): number => {
+  // An unsupported feature has no slots, even if the limits block says otherwise.
+  if (supported === false) return 0;
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+    return Math.floor(value);
+  }
+  return fallback;
+};
+
+/**
+ * How many zones of each type this profile allows.
+ *
+ * Missing limits fall back to the defaults *unless* the matching capability is
+ * `false`, in which case the answer is zero. Exclusion and entry zones also
+ * inherit a `zones: false` capability: a device with no zone detection cannot
+ * have exclusion or entry zones either.
+ */
+export const resolveZoneLimits = (profile: ProfileLike): ResolvedZoneLimits => {
+  const capabilities = getZoneCapabilities(profile);
+  const limits = profile?.limits ?? {};
+  return {
+    maxZones: resolveLimit(limits.maxZones, capabilities.zones, DEFAULT_ZONE_LIMITS.maxZones),
+    maxExclusionZones: resolveLimit(
+      limits.maxExclusionZones,
+      capabilities.exclusionZones ?? capabilities.zones,
+      DEFAULT_ZONE_LIMITS.maxExclusionZones,
+    ),
+    maxEntryZones: resolveLimit(
+      limits.maxEntryZones,
+      capabilities.entryZones ?? capabilities.zones,
+      DEFAULT_ZONE_LIMITS.maxEntryZones,
+    ),
+  };
+};
+
+/**
+ * True when the Zone Editor has anything to offer for this profile.
+ *
+ * An unknown profile (still loading, or a room with no profile yet) is treated
+ * as capable so the editor is never hidden by a slow request; the concrete
+ * checks above still block every individual zone type.
+ */
+export const supportsZoneEditing = (profile: ProfileLike): boolean => {
+  if (!profile) return true;
+  if (getZoneCapabilities(profile).zones === false) return false;
+  const limits = resolveZoneLimits(profile);
+  return limits.maxZones > 0 || limits.maxExclusionZones > 0 || limits.maxEntryZones > 0;
+};
+
+/** Resolve a room's profile and ask whether its device supports zone editing. */
+export const roomSupportsZoneEditing = (
+  room: { profileId?: string | null } | null | undefined,
+  profiles: ProfileLike[],
+): boolean => {
+  if (!room?.profileId) return true;
+  const profile = profiles.find((candidate) => candidate?.id === room.profileId) ?? null;
+  // An unknown profile id cannot be shown to be incapable, so allow it.
+  return supportsZoneEditing(profile);
+};


### PR DESCRIPTION
## Summary
Fixed both defects from issue #404, plus the latent wizard crash they exposed.
**1. EP1 profile data.** `config/device-profiles/everything_presence_one.json` set `maxZones: 0` but omitted `maxExclusionZones`/`maxEntryZones`, and every consumer defaulted a missing limit to `2` via `?? 2`, so EP1 was treated as having 2 exclusion + 2 entry slots. Added both keys as `0`, matching the explicit-zero convention already used by `everything_presence_pro.json`.
**2. Made capabilities authoritative instead of defaulting to 2.** Added `frontend/src/utils/zoneCapabilities.ts` and a matching `resolveZoneLimits` in `backend/src/domain/deviceProfiles.ts`. A limit is resolved from the capability flag first: `zones: false` (or `exclusionZones`/`entryZones: false`) yields `0`, and a missing limit only falls back to the legacy 4/2/2 when the profile says nothing at all. Exclusion and entry zones inherit `zones: false`, so the data fix and the code fix are independently sufficient. `DeviceProfileLoader.listProfiles()` now normalises limits at load and logs any profile whose limits contradict its capabilities. Every `?? 4` / `?? 2` call site now goes through the helper (`ZoneEditorPage`, `WizardPage`, `FirmwareUpdateSection`, `devices.ts`, `zoneBackups.ts`).
**3. Gated the Zone Editor route, not each button.** `App.tsx` now refuses to render `ZoneEditorPage` for a room whose profile lacks zone support and falls back to the dashboard, which closes all four unguarded entry points at once.

## Verification
Run from `everything-presence-mmwave-configurator/`.
1. `npm install` (workspaces), then `npm test --prefix frontend` - the `zoneCapabilities` suite should pass alongside the existing util suites; it asserts EP1 resolves to 0/0/0 both with and without the JSON limits, EPL to 4/2/2 and Pro to 4/2/0.
2. `npm test --prefix backend` - `deviceProfiles.test.ts` should pass, covering the same resolution rules plus load-time normalisation.
3. `npm run build --workspaces` - both the frontend (`vite build`) and the backend (`tsc`) should build cleanly.
4. `npm run lint --workspaces` - should report no new findings.
5. `curl -s localhost:<port>/api/devices/profiles | jq '.profiles[] | {id, limits}'` against a running backend - `everything_presence_one` should show `maxZones: 0`, `maxExclusionZones: 0`, `maxEntryZones: 0`; `everything_presence_pro` should show `4/2/0`; `everything_presence_lite` `4/2/2`.
Against a deployed preview with at least one EP1 room and one EPL/Pro room:
6. Select the EP1 room on the live dashboard and open the menu - Zone Editor reads "(Not Available)", is greyed out and does nothing when clicked (unchanged behaviour).
7. From that EP1 room open Room Builder and open its menu (both the desktop menu and the mobile Menu sheet) - Zone Editor is greyed out and labelled "(Not Available)"; clicking it stays in Room Builder. This is the first reported bug.
8. Switch the selected room to an EPL/Pro room and reopen the Room Builder menu - Zone Editor is enabled again and opens the editor.
9. In the Zone Editor on an EPL room, open the room selector - EP1 rooms are absent from the list, so there is no way to switch onto one.
10. In the Zone Editor on an EPL room, open Zone Slots - the counter shows the full complement and "+ Zone", "+ Exclusion" and "+ Entry" all work up to 4/2/2. On a Pro room, "+ Entry" reads "(0/0)" and is disabled while zones and exclusions still work.

Fixes #404