### PR TITLE
Feature Request: Reduce Device Icon to Node

### DIFF
--- a/everything-presence-mmwave-configurator/frontend/package.json
+++ b/everything-presence-mmwave-configurator/frontend/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",
-		"test": "node --experimental-strip-types --test src/utils/roomShapes.test.ts src/utils/polygonVertices.test.ts src/utils/roomHistory.test.ts src/utils/roomSelection.test.ts src/utils/roomBuilderSelection.test.ts src/utils/lockState.test.ts src/utils/roomRotation.test.ts src/utils/doorGeometry.test.ts src/utils/canvasLayers.test.ts",
+		"test": "node --experimental-strip-types --test src/hooks/useDisplaySettings.test.ts src/utils/roomShapes.test.ts src/utils/polygonVertices.test.ts src/utils/roomHistory.test.ts src/utils/roomSelection.test.ts src/utils/roomBuilderSelection.test.ts src/utils/lockState.test.ts src/utils/roomRotation.test.ts src/utils/doorGeometry.test.ts src/utils/canvasLayers.test.ts",
 		"preview": "vite preview",
 		"format": "npx @biomejs/biome format",
 		"format:fix": "npx @biomejs/biome format --write",

--- a/everything-presence-mmwave-configurator/frontend/src/components/DisplayAppearanceControls.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/DisplayAppearanceControls.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
+import { MARKER_SCALE_MAX, MARKER_SCALE_MIN } from '../utils/deviceMarkerSettings';
 
 interface DisplayAppearanceControlsProps {
+  showDeviceMarker: boolean;
+  deviceMarkerStyle: 'icon' | 'node';
+  setDeviceMarkerStyle: (value: 'icon' | 'node') => void;
+  deviceMarkerScale: number;
+  setDeviceMarkerScale: (value: number) => void;
+  deviceMarkerOpacity: number;
+  setDeviceMarkerOpacity: (value: number) => void;
   targetMarkerScale: number;
   setTargetMarkerScale: (value: number) => void;
   showZoneLabels: boolean;
@@ -10,6 +18,13 @@ interface DisplayAppearanceControlsProps {
 }
 
 export const DisplayAppearanceControls: React.FC<DisplayAppearanceControlsProps> = ({
+  showDeviceMarker,
+  deviceMarkerStyle,
+  setDeviceMarkerStyle,
+  deviceMarkerScale,
+  setDeviceMarkerScale,
+  deviceMarkerOpacity,
+  setDeviceMarkerOpacity,
   targetMarkerScale,
   setTargetMarkerScale,
   showZoneLabels,
@@ -20,6 +35,24 @@ export const DisplayAppearanceControls: React.FC<DisplayAppearanceControlsProps>
   <div className="space-y-3">
     <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">Appearance</div>
 
+    <label className={`block text-sm ${showDeviceMarker ? 'text-slate-200' : 'text-slate-500'}`}>
+      <span className="mb-1 block">Device marker style</span>
+      <select value={deviceMarkerStyle} onChange={(event) => setDeviceMarkerStyle(event.target.value as 'icon' | 'node')} disabled={!showDeviceMarker} className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 disabled:opacity-40">
+        <option value="icon">Product icon</option>
+        <option value="node">Translucent node</option>
+      </select>
+    </label>
+
+    <label className={`block text-sm ${showDeviceMarker ? 'text-slate-200' : 'text-slate-500'}`}>
+      <span className="mb-1 flex items-center justify-between gap-3"><span>Device marker size</span><span className="text-xs text-slate-400">{Math.round(deviceMarkerScale * 100)}%</span></span>
+      <input type="range" min={MARKER_SCALE_MIN} max={MARKER_SCALE_MAX} step={0.05} value={deviceMarkerScale} onChange={(event) => setDeviceMarkerScale(Number(event.target.value))} disabled={!showDeviceMarker} className="w-full disabled:opacity-40" />
+    </label>
+
+    <label className={`block text-sm ${showDeviceMarker ? 'text-slate-200' : 'text-slate-500'}`}>
+      <span className="mb-1 flex items-center justify-between gap-3"><span>Device marker opacity</span><span className="text-xs text-slate-400">{Math.round(deviceMarkerOpacity * 100)}%</span></span>
+      <input type="range" min={0.1} max={1} step={0.1} value={deviceMarkerOpacity} onChange={(event) => setDeviceMarkerOpacity(Number(event.target.value))} disabled={!showDeviceMarker} className="w-full disabled:opacity-40" />
+    </label>
+
     <label className="block text-sm text-slate-200">
       <span className="mb-1 flex items-center justify-between gap-3">
         <span>Tracking marker size</span>
@@ -27,8 +60,8 @@ export const DisplayAppearanceControls: React.FC<DisplayAppearanceControlsProps>
       </span>
       <input
         type="range"
-        min={0.5}
-        max={1.75}
+        min={MARKER_SCALE_MIN}
+        max={MARKER_SCALE_MAX}
         step={0.05}
         value={targetMarkerScale}
         onChange={(event) => setTargetMarkerScale(Number(event.target.value))}
@@ -53,8 +86,8 @@ export const DisplayAppearanceControls: React.FC<DisplayAppearanceControlsProps>
       </span>
       <input
         type="range"
-        min={0.5}
-        max={1.75}
+        min={MARKER_SCALE_MIN}
+        max={MARKER_SCALE_MAX}
         step={0.05}
         value={zoneLabelScale}
         onChange={(event) => setZoneLabelScale(Number(event.target.value))}

--- a/everything-presence-mmwave-configurator/frontend/src/components/DisplaySettingsControls.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/DisplaySettingsControls.tsx
@@ -13,6 +13,13 @@ interface DisplaySettingsControlsProps {
   overlayOptions?: DisplayToggleOption[];
   roomOptions?: DisplayToggleOption[];
   appearance: {
+    showDeviceMarker: boolean;
+    deviceMarkerStyle: 'icon' | 'node';
+    setDeviceMarkerStyle: (value: 'icon' | 'node') => void;
+    deviceMarkerScale: number;
+    setDeviceMarkerScale: (value: number) => void;
+    deviceMarkerOpacity: number;
+    setDeviceMarkerOpacity: (value: number) => void;
     targetMarkerScale: number;
     setTargetMarkerScale: (value: number) => void;
     showZoneLabels: boolean;

--- a/everything-presence-mmwave-configurator/frontend/src/components/RoomCanvas.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/RoomCanvas.tsx
@@ -8,6 +8,7 @@ import { useCustomAssets } from '../hooks/useCustomAssets';
 import { formatLengthLabel } from '../utils/lengthLabels';
 import { getDoorGeometry } from '../utils/doorGeometry';
 import { canvasLayerProps } from '../utils/canvasLayers';
+import { MARKER_SCALE_MAX, MARKER_SCALE_MIN } from '../utils/deviceMarkerSettings';
 
 export interface Point {
   x: number;
@@ -121,6 +122,9 @@ interface RoomCanvasProps {
   showFurniture?: boolean;
   showDoors?: boolean;
   showDevice?: boolean;
+  deviceMarkerStyle?: 'icon' | 'node';
+  deviceMarkerScale?: number;
+  deviceMarkerOpacity?: number;
   // When false, device icon won't capture mouse events (allows interacting with zones behind it)
   deviceInteractive?: boolean;
 }
@@ -615,8 +619,13 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
   showFurniture = true,
   showDoors = true,
   showDevice = true,
+  deviceMarkerStyle = 'icon',
+  deviceMarkerScale = 0.5,
+  deviceMarkerOpacity = 1,
   deviceInteractive = true,
 }) => {
+  const markerSize = 36 * Math.min(MARKER_SCALE_MAX, Math.max(MARKER_SCALE_MIN, Number.isFinite(deviceMarkerScale) ? deviceMarkerScale : 0.5));
+  const markerOpacity = Math.min(1, Math.max(0.1, Number.isFinite(deviceMarkerOpacity) ? deviceMarkerOpacity : 1));
   const safePoints = Array.isArray(points) ? points : [];
   // Locked walls are dropped from every hit-test below, so a click near one
   // falls through to whatever is behind it rather than grabbing the locked wall.
@@ -1863,7 +1872,7 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
           fieldOfViewDeg: effectiveFov,
           onCanvasPointerMove: handlePointerMove,
           onCanvasPointerRelease: handlePointerUp,
-          deviceElement: (!deviceInteractive && showDevice && devicePlacement && safePlacement) ? (() => {
+          deviceElement: (!deviceInteractive && (showDevice || showRadar) && devicePlacement && safePlacement) ? (() => {
             const { x: px, y: py } = toCanvasCoord(safePlacement);
             // Add 90 degrees so that 0 degrees points down (Y+) instead of right (X+)
             const rotationRad = (((safePlacement.rotationDeg ?? 0) + 90) * Math.PI) / 180;
@@ -1980,7 +1989,7 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
             const radarPath = radarPoints.map(toCanvasCoord);
             const pathData = radarPath.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ') + ' Z';
 
-            const iconSize = 36;
+            const iconSize = markerSize;
             const iconRotationDeg = safePlacement.mountType === 'ceiling' ? (safePlacement.rotationDeg ?? 0) : 0;
 
             return (
@@ -2007,9 +2016,11 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                   />
                 )}
 
-                {/* Device icon or fallback */}
-                {deviceIconUrl ? (
-                  <g transform={`translate(${px}, ${py}) rotate(${iconRotationDeg})`}>
+                {/* Device marker is independent from coverage. */}
+                {showDevice && (deviceMarkerStyle === 'node' ? (
+                  <circle cx={px} cy={py} r={Math.max(4, iconSize / 3)} fill="#38bdf880" stroke="#e0f2fe" strokeWidth={1.5} opacity={markerOpacity} />
+                ) : deviceIconUrl ? (
+                  <g transform={`translate(${px}, ${py}) rotate(${iconRotationDeg})`} opacity={markerOpacity}>
                     <image
                       href={deviceIconUrl}
                       x={-iconSize / 2}
@@ -2020,12 +2031,12 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                     />
                   </g>
                 ) : (
-                  <>
+                  <g opacity={markerOpacity}>
                     {/* Fallback: circle with direction indicator */}
                     <circle
                       cx={px}
                       cy={py}
-                      r={12}
+                      r={iconSize / 3}
                       fill="#3b82f6"
                       stroke="#1d4ed8"
                       strokeWidth={2}
@@ -2034,22 +2045,22 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                     <line
                       x1={px}
                       y1={py}
-                      x2={px + Math.cos(rotationRad) * 18}
-                      y2={py + Math.sin(rotationRad) * 18}
+                      x2={px + Math.cos(rotationRad) * iconSize / 2}
+                      y2={py + Math.sin(rotationRad) * iconSize / 2}
                       stroke="#ffffff"
                       strokeWidth={3}
                       strokeLinecap="round"
                       style={{ pointerEvents: 'none' }}
                     />
-                  </>
-                )}
+                  </g>
+                ))}
               </g>
             );
           })() : undefined,
         })}
 
         {/* Device rendering - when interactive (Room Builder), render AFTER overlay so device can be dragged */}
-        {deviceInteractive && showDevice && devicePlacement && safePlacement && (
+        {deviceInteractive && (showDevice || showRadar) && devicePlacement && safePlacement && (
           (() => {
             const { x: px, y: py } = toCanvasCoord(safePlacement);
             // Add 90 degrees so that 0 degrees points down (Y+) instead of right (X+)
@@ -2157,7 +2168,7 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
             const radarPath = radarPoints.map(toCanvasCoord);
             const pathData = radarPath.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ') + ' Z';
 
-            const iconSize = 36;
+            const iconSize = markerSize;
             const iconRotationDeg = safePlacement.mountType === 'ceiling' ? (safePlacement.rotationDeg ?? 0) : 0;
 
             return (
@@ -2183,7 +2194,10 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                   />
                 )}
 
-                {deviceIconUrl ? (
+                {showDevice && <g opacity={markerOpacity} style={{ pointerEvents: 'none' }}>
+                {deviceMarkerStyle === 'node' ? (
+                  <circle cx={px} cy={py} r={Math.max(4, iconSize / 3)} fill="#38bdf880" stroke="#e0f2fe" strokeWidth={1.5} />
+                ) : deviceIconUrl ? (
                   <g transform={`translate(${px}, ${py}) rotate(${iconRotationDeg})`}>
                     <image
                       href={deviceIconUrl}
@@ -2193,10 +2207,8 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                       height={iconSize}
                       style={{
                         cursor: devicePositionLocked ? (onDeviceClick ? 'pointer' : 'not-allowed') : 'grab',
-                        pointerEvents: 'all',
+                        pointerEvents: 'none',
                       }}
-                      onPointerDown={handleDevicePointerDown}
-                      onPointerUp={handleDevicePointerUp}
                     />
                   </g>
                 ) : (
@@ -2204,12 +2216,10 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                     <circle
                       cx={px}
                       cy={py}
-                      r={12}
+                      r={iconSize / 3}
                       fill="#3b82f6"
                       stroke="#1d4ed8"
                       strokeWidth={2}
-                      onPointerDown={handleDevicePointerDown}
-                      onPointerUp={handleDevicePointerUp}
                       style={{
                         cursor: devicePositionLocked ? (onDeviceClick ? 'pointer' : 'not-allowed') : 'grab',
                       }}
@@ -2217,8 +2227,8 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                     <line
                       x1={px}
                       y1={py}
-                      x2={px + Math.cos(rotationRad) * 18}
-                      y2={py + Math.sin(rotationRad) * 18}
+                      x2={px + Math.cos(rotationRad) * iconSize / 2}
+                      y2={py + Math.sin(rotationRad) * iconSize / 2}
                       stroke="#ffffff"
                       strokeWidth={3}
                       strokeLinecap="round"
@@ -2227,7 +2237,11 @@ export const RoomCanvas: React.FC<RoomCanvasProps> = ({
                     />
                   </>
                 )}
-                {devicePositionLocked && showLockIndicators && (
+                </g>}
+                {showDevice && (
+                  <circle cx={px} cy={py} r={Math.max(22, iconSize / 2)} fill="transparent" onPointerDown={handleDevicePointerDown} onPointerUp={handleDevicePointerUp} style={{ cursor: devicePositionLocked ? (onDeviceClick ? 'pointer' : 'not-allowed') : 'grab' }} aria-label="Device marker" />
+                )}
+                {showDevice && devicePositionLocked && showLockIndicators && (
                   <LockBadge
                     x={px + iconSize / 2}
                     y={py - iconSize / 2}

--- a/everything-presence-mmwave-configurator/frontend/src/components/ZoneCanvas.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/components/ZoneCanvas.tsx
@@ -69,6 +69,9 @@ interface ZoneCanvasProps {
   showZoneLabels?: boolean;
   zoneLabelScale?: number;
   showDevice?: boolean;
+  deviceMarkerStyle?: 'icon' | 'node';
+  deviceMarkerScale?: number;
+  deviceMarkerOpacity?: number;
   renderOverlay?: (params: {
     toCanvas: (point: { x: number; y: number }) => { x: number; y: number };
     fromCanvas: (point: { x: number; y: number }) => { x: number; y: number };
@@ -124,6 +127,9 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
   showZoneLabels = true,
   zoneLabelScale = 1,
   showDevice = true,
+  deviceMarkerStyle = 'icon',
+  deviceMarkerScale = 0.5,
+  deviceMarkerOpacity = 1,
   renderOverlay,
 }) => {
   // Rectangle zone dragging state
@@ -530,6 +536,9 @@ export const ZoneCanvas: React.FC<ZoneCanvasProps> = ({
       showFurniture={false}
       showDoors={showDoors}
       showDevice={showDevice}
+      deviceMarkerStyle={deviceMarkerStyle}
+      deviceMarkerScale={deviceMarkerScale}
+      deviceMarkerOpacity={deviceMarkerOpacity}
       deviceInteractive={false}
       lockShell
       renderOverlay={(params) => {

--- a/everything-presence-mmwave-configurator/frontend/src/hooks/useDisplaySettings.test.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/hooks/useDisplaySettings.test.ts
@@ -1,0 +1,21 @@
+// @ts-nocheck -- Node's built-in runner supplies these modules.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { normalizeDeviceMarkerSettings as normalizeDisplaySettings } from '../utils/deviceMarkerSettings.ts';
+
+test('legacy settings receive marker appearance defaults', () => {
+  const settings = normalizeDisplaySettings({ showWalls: false });
+  assert.deepEqual([settings.deviceMarkerStyle, settings.deviceMarkerScale, settings.deviceMarkerOpacity], ['icon', 0.5, 1]);
+});
+
+test('valid marker appearance settings survive normalization', () => {
+  const settings = normalizeDisplaySettings({ deviceMarkerStyle: 'node', deviceMarkerScale: 0.75, deviceMarkerOpacity: 0.4 });
+  assert.deepEqual([settings.deviceMarkerStyle, settings.deviceMarkerScale, settings.deviceMarkerOpacity], ['node', 0.75, 0.4]);
+});
+
+test('marker values are finite, bounded, and opacity is quantized', () => {
+  assert.equal(normalizeDisplaySettings({ deviceMarkerScale: Number.NaN }).deviceMarkerScale, 0.5);
+  assert.equal(normalizeDisplaySettings({ deviceMarkerScale: 10 }).deviceMarkerScale, 2);
+  assert.equal(normalizeDisplaySettings({ deviceMarkerOpacity: 0.66 }).deviceMarkerOpacity, 0.7);
+  assert.equal(normalizeDisplaySettings({ deviceMarkerOpacity: -1 }).deviceMarkerOpacity, 0.1);
+});

--- a/everything-presence-mmwave-configurator/frontend/src/hooks/useDisplaySettings.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/hooks/useDisplaySettings.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { MARKER_SCALE_MAX, MARKER_SCALE_MIN, normalizeDeviceMarkerSettings } from '../utils/deviceMarkerSettings';
 
 export interface DisplaySettings {
   showWalls: boolean;
@@ -7,6 +8,9 @@ export interface DisplaySettings {
   showZones: boolean;
   showDeviceIcon: boolean;
   showDeviceRadar: boolean;
+  deviceMarkerStyle: 'icon' | 'node';
+  deviceMarkerScale: number;
+  deviceMarkerOpacity: number;
   showMaxDistanceOverlay: boolean;
   showTriggerDistanceOverlay: boolean;
   showTargets: boolean;
@@ -31,6 +35,9 @@ const defaultSettings: DisplaySettings = {
   showZones: true,
   showDeviceIcon: true,
   showDeviceRadar: false,
+  deviceMarkerStyle: 'icon',
+  deviceMarkerScale: 0.5,
+  deviceMarkerOpacity: 1,
   showMaxDistanceOverlay: true,
   showTriggerDistanceOverlay: false,
   showTargets: true,
@@ -46,13 +53,22 @@ const defaultSettings: DisplaySettings = {
   heatmapThreshold: 0.15,
 };
 
+export const normalizeDisplaySettings = (value: unknown): DisplaySettings => {
+  const parsed = value && typeof value === 'object' ? value as Partial<DisplaySettings> : {};
+  return {
+    ...defaultSettings,
+    ...parsed,
+    ...normalizeDeviceMarkerSettings(parsed),
+  };
+};
+
 const loadSettings = (): DisplaySettings => {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) {
       const parsed = JSON.parse(stored);
       // Merge with defaults to handle any new settings added in future
-      return { ...defaultSettings, ...parsed };
+      return normalizeDisplaySettings(parsed);
     }
   } catch (e) {
     console.warn('Failed to load display settings from localStorage:', e);
@@ -101,6 +117,21 @@ export const useDisplaySettings = () => {
     setSettings((prev) => ({ ...prev, showDeviceRadar: value }));
   }, []);
 
+  const setDeviceMarkerStyle = useCallback((value: 'icon' | 'node') => {
+    if (value !== 'icon' && value !== 'node') return;
+    setSettings((prev) => ({ ...prev, deviceMarkerStyle: value }));
+  }, []);
+
+  const setDeviceMarkerScale = useCallback((value: number) => {
+    if (!Number.isFinite(value)) return;
+    setSettings((prev) => ({ ...prev, deviceMarkerScale: Math.min(MARKER_SCALE_MAX, Math.max(MARKER_SCALE_MIN, value)) }));
+  }, []);
+
+  const setDeviceMarkerOpacity = useCallback((value: number) => {
+    if (!Number.isFinite(value)) return;
+    setSettings((prev) => ({ ...prev, deviceMarkerOpacity: Math.round(Math.min(1, Math.max(0.1, value)) * 10) / 10 }));
+  }, []);
+
   const setShowMaxDistanceOverlay = useCallback((value: boolean) => {
     setSettings((prev) => ({ ...prev, showMaxDistanceOverlay: value }));
   }, []);
@@ -114,7 +145,7 @@ export const useDisplaySettings = () => {
   }, []);
 
   const setTargetMarkerScale = useCallback((value: number) => {
-    setSettings((prev) => ({ ...prev, targetMarkerScale: Math.min(1.75, Math.max(0.5, value)) }));
+    setSettings((prev) => ({ ...prev, targetMarkerScale: Math.min(MARKER_SCALE_MAX, Math.max(MARKER_SCALE_MIN, value)) }));
   }, []);
 
   const setShowZoneLabels = useCallback((value: boolean) => {
@@ -122,7 +153,7 @@ export const useDisplaySettings = () => {
   }, []);
 
   const setZoneLabelScale = useCallback((value: number) => {
-    setSettings((prev) => ({ ...prev, zoneLabelScale: Math.min(1.75, Math.max(0.5, value)) }));
+    setSettings((prev) => ({ ...prev, zoneLabelScale: Math.min(MARKER_SCALE_MAX, Math.max(MARKER_SCALE_MIN, value)) }));
   }, []);
 
   const setShowAlignedDirection = useCallback((value: boolean) => {
@@ -157,6 +188,9 @@ export const useDisplaySettings = () => {
     showZones: settings.showZones,
     showDeviceIcon: settings.showDeviceIcon,
     showDeviceRadar: settings.showDeviceRadar,
+    deviceMarkerStyle: settings.deviceMarkerStyle,
+    deviceMarkerScale: settings.deviceMarkerScale,
+    deviceMarkerOpacity: settings.deviceMarkerOpacity,
     showMaxDistanceOverlay: settings.showMaxDistanceOverlay,
     showTriggerDistanceOverlay: settings.showTriggerDistanceOverlay,
     showTargets: settings.showTargets,
@@ -176,6 +210,9 @@ export const useDisplaySettings = () => {
     setShowZones,
     setShowDeviceIcon,
     setShowDeviceRadar,
+    setDeviceMarkerStyle,
+    setDeviceMarkerScale,
+    setDeviceMarkerOpacity,
     setShowMaxDistanceOverlay,
     setShowTriggerDistanceOverlay,
     setShowTargets,

--- a/everything-presence-mmwave-configurator/frontend/src/pages/LiveTrackingPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/LiveTrackingPage.tsx
@@ -122,6 +122,9 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
     showZones, setShowZones,
     showDeviceIcon, setShowDeviceIcon,
     showDeviceRadar, setShowDeviceRadar,
+    deviceMarkerStyle, setDeviceMarkerStyle,
+    deviceMarkerScale, setDeviceMarkerScale,
+    deviceMarkerOpacity, setDeviceMarkerOpacity,
     showMaxDistanceOverlay, setShowMaxDistanceOverlay,
     showTriggerDistanceOverlay, setShowTriggerDistanceOverlay,
     showTargets, setShowTargets,
@@ -1115,6 +1118,7 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
           }}
         >
           <ZoneCanvas
+            deviceMarkerStyle={deviceMarkerStyle} deviceMarkerScale={deviceMarkerScale} deviceMarkerOpacity={deviceMarkerOpacity}
             zones={displayedRectZones}
             onZonesChange={() => {}}
             // Polygon zones support - show polygon zones when polygon mode is enabled
@@ -2304,7 +2308,7 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
                         />
                         <span className="flex items-center gap-1.5">
                           <span className="w-3 h-3 rounded-full bg-green-500"></span>
-                          Device Icon
+                          Device marker
                         </span>
                       </label>
                       <label className="flex items-center gap-2 cursor-pointer text-sm text-slate-200 hover:text-white transition-colors">
@@ -2325,6 +2329,10 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
                   <div className="mt-3 border-t border-slate-700/50 pt-3">
                     <DisplaySettingsControls
                       appearance={{
+                        showDeviceMarker: showDeviceIcon,
+                        deviceMarkerStyle, setDeviceMarkerStyle,
+                        deviceMarkerScale, setDeviceMarkerScale,
+                        deviceMarkerOpacity, setDeviceMarkerOpacity,
                         targetMarkerScale,
                         setTargetMarkerScale,
                         showZoneLabels,
@@ -2838,10 +2846,14 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
             { label: 'Furniture', checked: showFurniture, onChange: setShowFurniture },
             { label: 'Doors', checked: showDoors, onChange: setShowDoors },
             ...(!isEP1 ? [{ label: 'Zones', checked: showZones, onChange: setShowZones }] : []),
-            { label: 'Device icon', checked: showDeviceIcon, onChange: setShowDeviceIcon },
+            { label: 'Device marker', checked: showDeviceIcon, onChange: setShowDeviceIcon },
             { label: 'Targets', checked: showTargets, onChange: setShowTargets },
           ]}
           appearance={{
+            showDeviceMarker: showDeviceIcon,
+            deviceMarkerStyle, setDeviceMarkerStyle,
+            deviceMarkerScale, setDeviceMarkerScale,
+            deviceMarkerOpacity, setDeviceMarkerOpacity,
             targetMarkerScale,
             setTargetMarkerScale,
             showZoneLabels,
@@ -2916,4 +2928,3 @@ export const LiveTrackingPage: React.FC<LiveTrackingPageProps> = ({
     </div>
   );
 };
-

--- a/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/RoomBuilderPage.tsx
@@ -210,6 +210,9 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
     showDoors, setShowDoors,
     showDeviceIcon, setShowDeviceIcon,
     showDeviceRadar, setShowDeviceRadar,
+    deviceMarkerStyle, setDeviceMarkerStyle,
+    deviceMarkerScale, setDeviceMarkerScale,
+    deviceMarkerOpacity, setDeviceMarkerOpacity,
     showTargets, setShowTargets,
     targetMarkerScale, setTargetMarkerScale,
     showZoneLabels, setShowZoneLabels,
@@ -2282,6 +2285,7 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                   }}
                 >
                 <RoomCanvas
+                  deviceMarkerStyle={deviceMarkerStyle} deviceMarkerScale={deviceMarkerScale} deviceMarkerOpacity={deviceMarkerOpacity}
                   points={selectedRoom.roomShell?.points ?? []}
                   // The canvas emits this while a corner point is being dragged.
                   onChange={(nextPoints) => handlePointsChange(nextPoints, { coalesceKey: 'points:vertex-drag' })}
@@ -3251,10 +3255,14 @@ export const RoomBuilderPage: React.FC<RoomBuilderPageProps> = ({
                           { label: 'Walls', checked: showWalls, onChange: setShowWalls },
                           { label: 'Furniture', checked: showFurniture, onChange: setShowFurniture },
                           { label: 'Doors', checked: showDoors, onChange: setShowDoors },
-                          { label: 'Device icon', checked: showDeviceIcon, onChange: setShowDeviceIcon },
+                          { label: 'Device marker', checked: showDeviceIcon, onChange: setShowDeviceIcon },
                           { label: 'Targets', checked: showTargets, onChange: setShowTargets, note: !liveState?.deviceId ? 'No device' : undefined },
                         ]}
                         appearance={{
+                          showDeviceMarker: showDeviceIcon,
+                          deviceMarkerStyle, setDeviceMarkerStyle,
+                          deviceMarkerScale, setDeviceMarkerScale,
+                          deviceMarkerOpacity, setDeviceMarkerOpacity,
                           targetMarkerScale,
                           setTargetMarkerScale,
                           showZoneLabels,

--- a/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/WizardPage.tsx
@@ -176,6 +176,9 @@ export const WizardPage: React.FC<WizardPageProps> = ({
     showTargets, setShowTargets,
     showDeviceIcon, setShowDeviceIcon,
     showDeviceRadar, setShowDeviceRadar,
+    deviceMarkerStyle, setDeviceMarkerStyle,
+    deviceMarkerScale, setDeviceMarkerScale,
+    deviceMarkerOpacity, setDeviceMarkerOpacity,
     targetMarkerScale, setTargetMarkerScale,
     showZoneLabels, setShowZoneLabels,
     zoneLabelScale, setZoneLabelScale,
@@ -1765,6 +1768,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
           {currentStep === 'outline' && (
             <>
             <RoomCanvas
+              deviceMarkerStyle={deviceMarkerStyle} deviceMarkerScale={deviceMarkerScale} deviceMarkerOpacity={deviceMarkerOpacity}
               points={selectedRoom?.roomShell?.points ?? []}
               onChange={handleRoomOutlineChange}
               onCanvasClick={wallDrawingClick}
@@ -1806,6 +1810,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
 
           {currentStep === 'doors' && (
             <RoomCanvas
+              deviceMarkerStyle={deviceMarkerStyle} deviceMarkerScale={deviceMarkerScale} deviceMarkerOpacity={deviceMarkerOpacity}
               points={selectedRoom?.roomShell?.points ?? []}
               onChange={() => {}}
               lockShell={true}
@@ -1830,7 +1835,8 @@ export const WizardPage: React.FC<WizardPageProps> = ({
               onDoorDragEnd={handleDoorDragEnd}
               showWalls={showWalls}
               showDoors={showDoors}
-              devicePlacement={showDeviceIcon ? selectedRoom?.devicePlacement : undefined}
+              devicePlacement={selectedRoom?.devicePlacement}
+              showDevice={showDeviceIcon}
               fieldOfViewDeg={trackingFieldOfViewDeg}
               maxRangeMeters={trackingMaxRangeMeters}
               deviceIconUrl={deviceIconUrl}
@@ -1864,6 +1870,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
 
           {currentStep === 'furniture' && (
             <RoomCanvas
+              deviceMarkerStyle={deviceMarkerStyle} deviceMarkerScale={deviceMarkerScale} deviceMarkerOpacity={deviceMarkerOpacity}
               points={selectedRoom?.roomShell?.points ?? []}
               onChange={() => {}}
               lockShell={true}
@@ -1888,7 +1895,8 @@ export const WizardPage: React.FC<WizardPageProps> = ({
               }}
               onFurnitureChange={handleFurnitureChange}
               showFurniture={showFurniture}
-              devicePlacement={showDeviceIcon ? selectedRoom?.devicePlacement : undefined}
+              devicePlacement={selectedRoom?.devicePlacement}
+              showDevice={showDeviceIcon}
               fieldOfViewDeg={trackingFieldOfViewDeg}
               maxRangeMeters={trackingMaxRangeMeters}
               deviceIconUrl={deviceIconUrl}
@@ -1922,6 +1930,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
 
           {currentStep === 'placement' && (
             <RoomCanvas
+              deviceMarkerStyle={deviceMarkerStyle} deviceMarkerScale={deviceMarkerScale} deviceMarkerOpacity={deviceMarkerOpacity}
               points={selectedRoom?.roomShell?.points ?? []}
               onChange={() => {}}
               lockShell={true}
@@ -2004,6 +2013,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
               }}
             >
               <ZoneCanvas
+                deviceMarkerStyle={deviceMarkerStyle} deviceMarkerScale={deviceMarkerScale} deviceMarkerOpacity={deviceMarkerOpacity}
                 zones={enabledZones}
                 onZonesChange={(updatedZones) => {
                   // When zones change on canvas, update only the enabled ones
@@ -2788,10 +2798,14 @@ export const WizardPage: React.FC<WizardPageProps> = ({
                   { label: 'Furniture', checked: showFurniture, onChange: setShowFurniture },
                   { label: 'Doors', checked: showDoors, onChange: setShowDoors },
                   { label: 'Zones', checked: showZones, onChange: setShowZones },
-                  { label: 'Device icon', checked: showDeviceIcon, onChange: setShowDeviceIcon },
+                  { label: 'Device marker', checked: showDeviceIcon, onChange: setShowDeviceIcon },
                   { label: 'Targets', checked: showTargets, onChange: setShowTargets, note: !liveState?.deviceId ? 'No device' : undefined },
                 ]}
                 appearance={{
+                  showDeviceMarker: showDeviceIcon,
+                  deviceMarkerStyle, setDeviceMarkerStyle,
+                  deviceMarkerScale, setDeviceMarkerScale,
+                  deviceMarkerOpacity, setDeviceMarkerOpacity,
                   targetMarkerScale,
                   setTargetMarkerScale,
                   showZoneLabels,
@@ -3542,6 +3556,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
             }}
           >
             <RoomCanvas
+              deviceMarkerStyle={deviceMarkerStyle} deviceMarkerScale={deviceMarkerScale} deviceMarkerOpacity={deviceMarkerOpacity}
               points={selectedRoom?.roomShell?.points ?? []}
               onChange={handleRoomOutlineChange}
               onCanvasClick={wallDrawingClick}
@@ -3638,6 +3653,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
             }}
           >
             <RoomCanvas
+              deviceMarkerStyle={deviceMarkerStyle} deviceMarkerScale={deviceMarkerScale} deviceMarkerOpacity={deviceMarkerOpacity}
               points={selectedRoom?.roomShell?.points ?? []}
               onChange={() => {}}
               lockShell={true}
@@ -3958,6 +3974,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
             }}
           >
             <ZoneCanvas
+              deviceMarkerStyle={deviceMarkerStyle} deviceMarkerScale={deviceMarkerScale} deviceMarkerOpacity={deviceMarkerOpacity}
               zones={enabledZones}
               onZonesChange={(updatedZones) => {
                 // When zones change on canvas, update only the enabled ones

--- a/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
+++ b/everything-presence-mmwave-configurator/frontend/src/pages/ZoneEditorPage.tsx
@@ -133,6 +133,9 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
     showZones, setShowZones,
     showDeviceIcon, setShowDeviceIcon,
     showDeviceRadar, setShowDeviceRadar,
+    deviceMarkerStyle, setDeviceMarkerStyle,
+    deviceMarkerScale, setDeviceMarkerScale,
+    deviceMarkerOpacity, setDeviceMarkerOpacity,
     showTargets, setShowTargets,
     targetMarkerScale, setTargetMarkerScale,
     showZoneLabels, setShowZoneLabels,
@@ -1778,6 +1781,7 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
           }}
         >
           <ZoneCanvas
+            deviceMarkerStyle={deviceMarkerStyle} deviceMarkerScale={deviceMarkerScale} deviceMarkerOpacity={deviceMarkerOpacity}
             zones={enabledZones}
             onZonesChange={(updatedZones) => {
               // When zones change on canvas, update only the enabled ones
@@ -2097,10 +2101,14 @@ export const ZoneEditorPage: React.FC<ZoneEditorPageProps> = ({
                     { label: 'Furniture', checked: showFurniture, onChange: setShowFurniture },
                     { label: 'Doors', checked: showDoors, onChange: setShowDoors },
                     { label: 'Zones', checked: showZones, onChange: setShowZones },
-                    { label: 'Device icon', checked: showDeviceIcon, onChange: setShowDeviceIcon },
+                    { label: 'Device marker', checked: showDeviceIcon, onChange: setShowDeviceIcon },
                     { label: 'Targets', checked: showTargets, onChange: setShowTargets },
                   ]}
                   appearance={{
+                    showDeviceMarker: showDeviceIcon,
+                    deviceMarkerStyle, setDeviceMarkerStyle,
+                    deviceMarkerScale, setDeviceMarkerScale,
+                    deviceMarkerOpacity, setDeviceMarkerOpacity,
                     targetMarkerScale,
                     setTargetMarkerScale,
                     showZoneLabels,

--- a/everything-presence-mmwave-configurator/frontend/src/utils/canvasLayers.test.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/canvasLayers.test.ts
@@ -40,3 +40,10 @@ test('RoomCanvas emits its layers in paint order, handles last', () => {
     assert.ok(ranks[i] >= ranks[i - 1], `layer "${layers[i]}" is drawn after "${layers[i - 1]}"`);
   }
 });
+
+test('device coverage is independent from marker appearance and the marker keeps a hit target', () => {
+  const source = readFileSync(new URL('../components/RoomCanvas.tsx', import.meta.url), 'utf8');
+  assert.match(source, /\(showDevice \|\| showRadar\)/, 'coverage should render while the marker is hidden');
+  assert.match(source, /r=\{Math\.max\(22, iconSize \/ 2\)\}/, 'marker should retain a stable hit target');
+  assert.match(source, /<g opacity=\{markerOpacity\}/, 'opacity should be scoped to marker visuals');
+});

--- a/everything-presence-mmwave-configurator/frontend/src/utils/deviceMarkerSettings.ts
+++ b/everything-presence-mmwave-configurator/frontend/src/utils/deviceMarkerSettings.ts
@@ -1,0 +1,20 @@
+export interface DeviceMarkerSettings {
+  deviceMarkerStyle: 'icon' | 'node';
+  deviceMarkerScale: number;
+  deviceMarkerOpacity: number;
+}
+
+export const MARKER_SCALE_MIN = 0.25;
+export const MARKER_SCALE_MAX = 2;
+
+const clampFinite = (value: unknown, fallback: number, min: number, max: number) =>
+  typeof value === 'number' && Number.isFinite(value) ? Math.min(max, Math.max(min, value)) : fallback;
+
+export const normalizeDeviceMarkerSettings = (value: unknown): DeviceMarkerSettings => {
+  const settings = value && typeof value === 'object' ? value as Partial<DeviceMarkerSettings> : {};
+  return {
+    deviceMarkerStyle: settings.deviceMarkerStyle === 'node' ? 'node' : 'icon',
+    deviceMarkerScale: clampFinite(settings.deviceMarkerScale, 0.5, MARKER_SCALE_MIN, MARKER_SCALE_MAX),
+    deviceMarkerOpacity: Math.round(clampFinite(settings.deviceMarkerOpacity, 1, 0.1, 1) * 10) / 10,
+  };
+};


### PR DESCRIPTION
## Summary
Adds independent, locally persisted controls for device coverage and marker visibility, style, size, and opacity. Device markers default to a 50% product icon, can switch to a translucent node, and retain a stable invisible interaction target at small sizes or low opacity. Radar rendering remains independent of marker appearance.
Applies the settings consistently across Room Builder, Zone Editor, Live Tracking, and Wizard canvases. Device, tracking-marker, and zone-label size sliders now share a consistent 25%–200% range; opacity retains its meaningful 10%–100% range and 10% increments. Persisted marker values are validated, bounded, and migrated with defaults.

## Verification
1. Run `cd everything-presence-mmwave-configurator/frontend && npm install && npm test`; confirm all display-settings, canvas-layer, and existing regression tests pass.
2. Run `npm run build`; confirm the production frontend compiles successfully.
3. Open Room Builder, Zone Editor, Live Tracking, and each Wizard canvas in a deployed preview. Change the device marker between Product icon and Translucent node; expect the selected style to appear consistently on every canvas.
4. Move the device, tracking-marker, and zone-label size sliders to both endpoints; expect each size control to span 25%–200%, with the device defaulting to 50%.
5. Move marker opacity through its range; expect 10% increments from 10% to 100% while radar coverage and lock indicators remain unchanged.
6. Hide the device marker while leaving coverage enabled; expect the marker to disappear and radar coverage to remain visible. Disable coverage while leaving the marker enabled; expect only the marker to remain.
7. In Room Builder, set a small or low-opacity marker and drag it from around its visible center; expect the device to remain easy to select and move.
8. Reload the preview; expect marker style, size, opacity, visibility, and coverage preferences to persist.

Fixes #377