### PR TITLE
Add "org.opencontainers.image.version" label to docker container

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -61,6 +61,9 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: false
           load: false
+          build-args: |
+            BUILD_VERSION=${{ env.VERSION }}
+            BUILD_REF=${{ github.sha }}
           tags: |
             ${{ env.STANDALONE_IMAGE_TAG }}
 
@@ -74,6 +77,8 @@ jobs:
           load: false
           build-args: |
             BUILD_FROM=${{ matrix.build_from }}
+            BUILD_VERSION=${{ env.VERSION }}
+            BUILD_REF=${{ github.sha }}
           tags: |
             ${{ env.ADDON_IMAGE_TAG }}
 
@@ -147,6 +152,9 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           load: false
+          build-args: |
+            BUILD_VERSION=${{ env.VERSION }}
+            BUILD_REF=${{ github.sha }}
           tags: |
             ${{ env.IMAGE_TAG }}-${{ matrix.arch }}
             ${{ env.LATEST_TAG }}-${{ matrix.arch }}
@@ -155,6 +163,17 @@ jobs:
       - name: Test Docker image
         run: |
           docker run --rm --platform ${{ matrix.platform }} --entrypoint /bin/echo ${{ env.IMAGE_TAG }}-${{ matrix.arch }} "Image built successfully"
+
+      - name: Verify image version label
+        run: |
+          LABEL_VERSION=$(docker inspect \
+            --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' \
+            ${{ env.IMAGE_TAG }}-${{ matrix.arch }})
+          echo "org.opencontainers.image.version = '$LABEL_VERSION'"
+          if [ "$LABEL_VERSION" != "${{ env.VERSION }}" ]; then
+            echo "::error::Expected label 'org.opencontainers.image.version' to be '${{ env.VERSION }}' but got '$LABEL_VERSION'"
+            exit 1
+          fi
 
   build-push-addon:
     name: Build and Push Add-on Image
@@ -217,6 +236,8 @@ jobs:
           load: false
           build-args: |
             BUILD_FROM=${{ matrix.build_from }}
+            BUILD_VERSION=${{ env.VERSION }}
+            BUILD_REF=${{ github.sha }}
           tags: |
             ${{ env.ADDON_IMAGE_TAG }}-${{ matrix.arch }}
             ${{ env.ADDON_LATEST_TAG }}-${{ matrix.arch }}
@@ -225,6 +246,17 @@ jobs:
       - name: Test Docker image
         run: |
           docker run --rm --platform ${{ matrix.platform }} --entrypoint /bin/echo ${{ env.ADDON_IMAGE_TAG }}-${{ matrix.arch }} "Image built successfully"
+
+      - name: Verify image version label
+        run: |
+          LABEL_VERSION=$(docker inspect \
+            --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' \
+            ${{ env.ADDON_IMAGE_TAG }}-${{ matrix.arch }})
+          echo "org.opencontainers.image.version = '$LABEL_VERSION'"
+          if [ "$LABEL_VERSION" != "${{ env.VERSION }}" ]; then
+            echo "::error::Expected label 'org.opencontainers.image.version' to be '${{ env.VERSION }}' but got '$LABEL_VERSION'"
+            exit 1
+          fi
 
   manifest-standalone:
     name: Create Standalone Multi-Arch Manifest
@@ -261,17 +293,28 @@ jobs:
 
       - name: Create multi-arch manifests
         run: |
-          docker buildx imagetools create \
+          # Per-arch LABELs live in each image config and are not lifted onto the
+          # index that `imagetools create` builds, so mirror them as index
+          # annotations to keep `imagetools inspect` and registry UIs in step.
+          ANNOTATIONS=(
+            --annotation "index:org.opencontainers.image.version=${{ env.VERSION }}"
+            --annotation "index:org.opencontainers.image.revision=${{ github.sha }}"
+            --annotation "index:org.opencontainers.image.title=Everything Presence Zone Configurator"
+            --annotation "index:org.opencontainers.image.source=https://github.com/EverythingSmartHome/everything-presence-addons"
+            --annotation "index:org.opencontainers.image.url=https://github.com/EverythingSmartHome/everything-presence-addons"
+            --annotation "index:org.opencontainers.image.vendor=Everything Smart Home"
+          )
+          docker buildx imagetools create "${ANNOTATIONS[@]}" \
             -t ${{ env.IMAGE_TAG }} \
             ${{ env.IMAGE_TAG }}-amd64 \
             ${{ env.IMAGE_TAG }}-arm64 \
             ${{ env.IMAGE_TAG }}-armv7
-          docker buildx imagetools create \
+          docker buildx imagetools create "${ANNOTATIONS[@]}" \
             -t ${{ env.LATEST_TAG }} \
             ${{ env.LATEST_TAG }}-amd64 \
             ${{ env.LATEST_TAG }}-arm64 \
             ${{ env.LATEST_TAG }}-armv7
-          docker buildx imagetools create \
+          docker buildx imagetools create "${ANNOTATIONS[@]}" \
             -t ${{ env.MAJOR_TAG }} \
             ${{ env.MAJOR_TAG }}-amd64 \
             ${{ env.MAJOR_TAG }}-arm64 \
@@ -312,17 +355,28 @@ jobs:
 
       - name: Create multi-arch manifests
         run: |
-          docker buildx imagetools create \
+          # Per-arch LABELs live in each image config and are not lifted onto the
+          # index that `imagetools create` builds, so mirror them as index
+          # annotations to keep `imagetools inspect` and registry UIs in step.
+          ANNOTATIONS=(
+            --annotation "index:org.opencontainers.image.version=${{ env.VERSION }}"
+            --annotation "index:org.opencontainers.image.revision=${{ github.sha }}"
+            --annotation "index:org.opencontainers.image.title=Everything Presence Zone Configurator (add-on)"
+            --annotation "index:org.opencontainers.image.source=https://github.com/EverythingSmartHome/everything-presence-addons"
+            --annotation "index:org.opencontainers.image.url=https://github.com/EverythingSmartHome/everything-presence-addons"
+            --annotation "index:org.opencontainers.image.vendor=Everything Smart Home"
+          )
+          docker buildx imagetools create "${ANNOTATIONS[@]}" \
             -t ${{ env.ADDON_IMAGE_TAG }} \
             ${{ env.ADDON_IMAGE_TAG }}-amd64 \
             ${{ env.ADDON_IMAGE_TAG }}-arm64 \
             ${{ env.ADDON_IMAGE_TAG }}-armv7
-          docker buildx imagetools create \
+          docker buildx imagetools create "${ANNOTATIONS[@]}" \
             -t ${{ env.ADDON_LATEST_TAG }} \
             ${{ env.ADDON_LATEST_TAG }}-amd64 \
             ${{ env.ADDON_LATEST_TAG }}-arm64 \
             ${{ env.ADDON_LATEST_TAG }}-armv7
-          docker buildx imagetools create \
+          docker buildx imagetools create "${ANNOTATIONS[@]}" \
             -t ${{ env.ADDON_MAJOR_TAG }} \
             ${{ env.ADDON_MAJOR_TAG }}-amd64 \
             ${{ env.ADDON_MAJOR_TAG }}-arm64 \

--- a/everything-presence-mmwave-configurator/Dockerfile
+++ b/everything-presence-mmwave-configurator/Dockerfile
@@ -1,5 +1,12 @@
 ARG BUILD_FROM=ghcr.io/hassio-addons/base:19.0.0
 
+# Image identity, stamped into OCI labels on every runnable stage.
+# BUILD_VERSION mirrors `version:` in config.yaml and is supplied by CI (and by
+# the Home Assistant Supervisor, which injects it automatically) — the "dev"
+# default only applies to a plain local `docker build`.
+ARG BUILD_VERSION=dev
+ARG BUILD_REF=unknown
+
 FROM node:20-alpine AS build
 WORKDIR /app
 ENV NODE_ENV=development
@@ -38,6 +45,19 @@ RUN rm -rf /etc/services.d/zone-configurator && \
 
 EXPOSE 42069/tcp 38080/tcp
 
+# Last instruction in the stage so a version-only change rebuilds one tiny layer.
+# These explicitly override the org.opencontainers.image.* values inherited from
+# BUILD_FROM, which otherwise describe the base image rather than this add-on.
+ARG BUILD_VERSION
+ARG BUILD_REF
+LABEL org.opencontainers.image.version="${BUILD_VERSION}" \
+      org.opencontainers.image.revision="${BUILD_REF}" \
+      org.opencontainers.image.title="Everything Presence Zone Configurator (add-on)" \
+      org.opencontainers.image.description="Visualise and configure Everything Presence Lite, One and Pro mmWave presence sensors for Home Assistant." \
+      org.opencontainers.image.source="https://github.com/EverythingSmartHome/everything-presence-addons" \
+      org.opencontainers.image.url="https://github.com/EverythingSmartHome/everything-presence-addons" \
+      org.opencontainers.image.vendor="Everything Smart Home"
+
 FROM node:20-alpine AS standalone
 WORKDIR /app
 ENV NODE_ENV=production \
@@ -56,6 +76,17 @@ COPY config ./config
 
 EXPOSE 42069/tcp 38080/tcp
 CMD ["node", "backend/dist/index.js"]
+
+# Last instruction in the stage so a version-only change rebuilds one tiny layer.
+ARG BUILD_VERSION
+ARG BUILD_REF
+LABEL org.opencontainers.image.version="${BUILD_VERSION}" \
+      org.opencontainers.image.revision="${BUILD_REF}" \
+      org.opencontainers.image.title="Everything Presence Zone Configurator" \
+      org.opencontainers.image.description="Visualise and configure Everything Presence Lite, One and Pro mmWave presence sensors for Home Assistant." \
+      org.opencontainers.image.source="https://github.com/EverythingSmartHome/everything-presence-addons" \
+      org.opencontainers.image.url="https://github.com/EverythingSmartHome/everything-presence-addons" \
+      org.opencontainers.image.vendor="Everything Smart Home"
 
 # Default build target for Home Assistant add-on builds.
 FROM addon AS final


### PR DESCRIPTION
## Summary
Every image this repo produces now carries `org.opencontainers.image.version` (plus a companion OCI set), sourced from the same `version:` field in `everything-presence-mmwave-configurator/config.yaml` that the workflow already extracts into `env.VERSION` and that the backend serves as `appVersion`.
The labels are declared in the `Dockerfile` rather than on the CI steps, so images built locally with `docker build` and add-on images built by the Home Assistant Supervisor are labelled too — the Supervisor injects `BUILD_VERSION` as a build arg automatically. A global `ARG BUILD_VERSION=dev` / `ARG BUILD_REF=unknown` sits alongside the existing `ARG BUILD_FROM`, is re-declared inside the `addon` and `standalone` stages, and feeds a `LABEL` block placed as the last instruction of each stage so a version-only change rebuilds one tiny layer. `FROM addon AS final` inherits the add-on labels.
The label set explicitly overrides `version`, `revision`, `title`, `description`, `source`, `url` and `vendor`, because `ghcr.io/hassio-addons/base` and `ghcr.io/home-assistant/armv7-base` set their own `org.opencontainers.image.*` values that would otherwise be inherited and describe the base image instead of this product. `title` distinguishes the add-on variant.

Fixes #406